### PR TITLE
🔧(development) set Django session persistence to database

### DIFF
--- a/config/cms/docker_run_development.py
+++ b/config/cms/docker_run_development.py
@@ -14,6 +14,7 @@ EMAIL_BACKEND = config(
     "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"
 )
 
+SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
 
 PIPELINE_ENABLED = False
 STATICFILES_STORAGE = "openedx.core.storage.DevelopmentStorage"

--- a/config/lms/docker_run_development.py
+++ b/config/lms/docker_run_development.py
@@ -14,6 +14,8 @@ EMAIL_BACKEND = config(
     "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"
 )
 
+SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
+
 PIPELINE_ENABLED = False
 STATICFILES_STORAGE = "openedx.core.storage.DevelopmentStorage"
 


### PR DESCRIPTION
Default value is memory which is incompatible with frequent server restarts
