### PR TITLE
🔧(lti consumer) sample configuration for our configurable LTI consumer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 # EDX-PLATFORM multi-stage docker build
 
-# Change release to build, by providing the EDXAPP_RELEASE build argument to
+# Change release to build, by providing the EDXAPP_RELEASE_ARCHIVE_URL build argument to
 # your build command:
 #
 # $ docker build \
-#     --build-arg EDXAPP_RELEASE="open-release/hawthorn.1" \
-#     -t edxapp:hawthorn.1 \
+#     --build-arg EDXAPP_RELEASE_ARCHIVE_URL="https://github.com/edx/edx-platform/archive/master.tar.gz" \
+#     -t edxapp:latest \
 #     .
-ARG EDXAPP_RELEASE=open-release/hawthorn.1
+ARG EDXAPP_RELEASE_ARCHIVE_URL=https://github.com/edx/edx-platform/archive/master.tar.gz
 
 # === BASE ===
 FROM ubuntu:16.04 as base
@@ -26,9 +26,9 @@ RUN apt-get update && \
 RUN curl -sLo get-pip.py https://bootstrap.pypa.io/get-pip.py
 
 # Download edxapp release
-# Get default EDXAPP_RELEASE value (defined on top)
-ARG EDXAPP_RELEASE
-RUN curl -sLo edxapp.tgz https://github.com/edx/edx-platform/archive/$EDXAPP_RELEASE.tar.gz && \
+# Get default EDXAPP_RELEASE_ARCHIVE_URL value (defined on top)
+ARG EDXAPP_RELEASE_ARCHIVE_URL
+RUN curl -sLo edxapp.tgz $EDXAPP_RELEASE_ARCHIVE_URL && \
     tar xzf edxapp.tgz
 
 
@@ -43,8 +43,8 @@ RUN apt-get update && \
 
 WORKDIR /edx/app/edxapp/edx-platform
 
-# Get default EDXAPP_RELEASE value (defined on top)
-ARG EDXAPP_RELEASE
+# Get default EDXAPP_RELEASE_ARCHIVE_URL value (defined on top)
+ARG EDXAPP_RELEASE_ARCHIVE_URL
 COPY --from=downloads /downloads/edx-platform-* .
 
 # We copy default configuration files to "/config" and we point to them via
@@ -108,7 +108,7 @@ FROM builder as development
 
 ARG UID=1000
 ARG GID=1000
-ARG EDXAPP_RELEASE
+ARG EDXAPP_RELEASE_ARCHIVE_URL
 
 # Install system dependencies
 RUN apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,8 @@ RUN python get-pip.py
 WORKDIR /edx/app/edxapp/edx-platform
 
 # Install python dependencies
-RUN pip install --src /usr/local/src -r requirements/edx/base.txt
+RUN pip install --src /usr/local/src -r requirements/edx/base.txt && \
+    pip install -r requirements/edx/extend.txt
 
 # Install Javascript requirements
 RUN npm install

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ dev-build:  ## build the edxapp production image
 .PHONY: dev-build
 
 clone:  ## clone source repositories
-	@./bin/clone_repositories;
+	./bin/clone_repositories "openfun" "oee/hawthorn.1"
 .PHONY: clone
 
 collectstatic: tree  ## copy static assets to static root directory

--- a/bin/clone_repositories
+++ b/bin/clone_repositories
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-RELEASE="${1:-open-release/hawthorn.1}"
+REMOTE="${1:-edx}"
+RELEASE="${2:-open-release/hawthorn.1}"
 
 echo -e "📦 Cloning edx-platform (release: ${RELEASE})..."
 # Clone it from here to get a better message in command line
@@ -13,7 +14,7 @@ git remote add openfun https://github.com/openfun/edx-platform.git
 # Better do the checkout separately from the clone so that if the repository
 # already exists, the checkout is still done to the branch we want.
 echo -e "🔖 Fetching tags..."
-git fetch edx "${RELEASE}"
+git fetch "${REMOTE}" "${RELEASE}"
 echo -e "✅ Checking out release: ${RELEASE}"
 git checkout -f "${RELEASE}"
 echo -e "🛀 Cleaning local clone..."

--- a/config/cms/docker_run_development.py
+++ b/config/cms/docker_run_development.py
@@ -14,7 +14,6 @@ EMAIL_BACKEND = config(
     "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"
 )
 
-
 PIPELINE_ENABLED = False
 STATICFILES_STORAGE = "openedx.core.storage.DevelopmentStorage"
 

--- a/config/cms/docker_run_production.py
+++ b/config/cms/docker_run_production.py
@@ -13,6 +13,8 @@ from xmodule.modulestore.modulestore_settings import (
     convert_module_store_setting_if_needed
 )
 
+from configurable_lti_consumer import filter_configurable_lti_consumer
+
 from ..common import *
 
 
@@ -596,6 +598,16 @@ if FEATURES["ENABLE_COURSEWARE_INDEX"] or FEATURES["ENABLE_LIBRARY_INDEX"]:
 ELASTIC_SEARCH_CONFIG = config(
     "ELASTIC_SEARCH_CONFIG", default=[{}], formatter=json.loads
 )
+
+################ CONFIGURABLE LTI CONSUMER ###############
+
+CONFIGURABLE_LTI_CONSUMER_SETTINGS = config(
+    "CONFIGURABLE_LTI_CONSUMER_SETTINGS", default={}, formatter=json.loads
+)
+
+# helper function that will be passed to XBock.load_class
+# method to filter multiple Python endpoints for the same xblock (lti_consumer)
+XBLOCK_SELECT_FUNCTION = filter_configurable_lti_consumer
 
 XBLOCK_SETTINGS = config("XBLOCK_SETTINGS", default={}, formatter=json.loads)
 XBLOCK_SETTINGS.setdefault("VideoDescriptor", {})["licensing_enabled"] = FEATURES.get(

--- a/config/lms/docker_run_production.py
+++ b/config/lms/docker_run_production.py
@@ -16,6 +16,8 @@ from xmodule.modulestore.modulestore_settings import (
     convert_module_store_setting_if_needed
 )
 
+from configurable_lti_consumer import filter_configurable_lti_consumer
+
 from ..common import *
 from .utils import Configuration
 
@@ -1172,6 +1174,12 @@ LTI_AGGREGATE_SCORE_PASSBACK_DELAY = config(
     default=LTI_AGGREGATE_SCORE_PASSBACK_DELAY,
     formatter=int,
 )
+
+################ CONFIGURABLE LTI CONSUMER ###############
+
+# helper function that will be passed to XBock.load_class
+# method to filter multiple Python endpoints for the same xblock (lti_consumer)
+XBLOCK_SELECT_FUNCTION = filter_configurable_lti_consumer
 
 ##################### Credit Provider help link ####################
 CREDIT_HELP_LINK_URL = config("CREDIT_HELP_LINK_URL", default=CREDIT_HELP_LINK_URL)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
     build:
       context: .
       target: production
+      args:
+        EDXAPP_RELEASE_ARCHIVE_URL: https://github.com/openfun/edx-platform/archive/oee/hawthorn.1-0.1.1.tar.gz
     image: edxapp:latest
     env_file: env.d/development
     environment:
@@ -51,6 +53,7 @@ services:
       args:
         UID: ${UID}
         GID: ${GID}
+        EDXAPP_RELEASE_ARCHIVE_URL: https://github.com/openfun/edx-platform/archive/oee/hawthorn.1-0.1.1.tar.gz
     image: edxapp:dev
     env_file: env.d/development
     ports:


### PR DESCRIPTION
# Purpose
This PR is a part of a group of changes to `edx-platform`, `fun-platform` and a new repository
`configurable-lti-consumer` which aims to allow CMS to propose several preconfigured instances
of `lti-consumer` block

# Proposal
This PR propose a working demonstration configuration