### PR TITLE
🐛(compose) fix development entrypoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,7 @@ services:
       - ./data/media:/edx/var/edxapp/media
       - ./data/store:/edx/app/edxapp/data
       - ./config:/config
+    entrypoint: /usr/local/bin/entrypoint.sh
     command: >
       python manage.py lms runserver 0.0.0.0:8000 --settings=fun.docker_run_development
     depends_on:
@@ -95,6 +96,7 @@ services:
       - ./data/media:/edx/var/edxapp/media
       - ./data/store:/edx/app/edxapp/data
       - ./config:/config
+    entrypoint: /usr/local/bin/entrypoint.sh
     command: >
       python manage.py cms runserver 0.0.0.0:8000 --settings=fun.docker_run_development
     depends_on:


### PR DESCRIPTION
## Purpose

When working with development images, the defined entrypoint (that wraps commands execution in a python virtual environment), is not properly called and the resulting command is not executed in the virtual environment context.

I have the feeling that the commands is spawn in a new shell that does not inherit from the entrypoint's environment.

## Proposal

Redefining the `entrypoint` in the `docker-compose.yml` file seems to fix the issue.

