### PR TITLE
Port to hawthorn.1: Allow setting an environment and a release in Sentry logs

### DIFF
--- a/config/cms/docker_run_development.py
+++ b/config/cms/docker_run_development.py
@@ -7,6 +7,7 @@ from lms.envs.fun.utils import Configuration
 # Load custom configuration parameters from yaml files
 config = Configuration(os.path.dirname(__file__))
 
+ENVIRONMENT = "development"
 DEBUG = True
 REQUIRE_DEBUG = True
 

--- a/config/cms/docker_run_feature.py
+++ b/config/cms/docker_run_feature.py
@@ -7,6 +7,8 @@ from lms.envs.fun.utils import Configuration
 # Load custom configuration parameters from yaml files
 config = Configuration(os.path.dirname(__file__))
 
+ENVIRONMENT = "feature"
+
 EMAIL_BACKEND = config(
     "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"
 )

--- a/config/cms/docker_run_preprod.py
+++ b/config/cms/docker_run_preprod.py
@@ -7,6 +7,8 @@ from lms.envs.fun.utils import Configuration
 # Load custom configuration parameters from yaml files
 config = Configuration(os.path.dirname(__file__))
 
+ENVIRONMENT = "preprod"
+
 EMAIL_BACKEND = config(
     "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"
 )

--- a/config/cms/docker_run_production.py
+++ b/config/cms/docker_run_production.py
@@ -322,6 +322,7 @@ if SENTRY_DSN:
         "dsn": SENTRY_DSN,
         "level": "ERROR",
         "environment": ENVIRONMENT,
+        "release": RELEASE,
     }
 
 # FIXME: the PLATFORM_NAME and PLATFORM_DESCRIPTION settings should be set to lazy translatable

--- a/config/cms/docker_run_production.py
+++ b/config/cms/docker_run_production.py
@@ -26,6 +26,8 @@ AUTH_TOKENS = config
 
 ############### ALWAYS THE SAME ################################
 
+ENVIRONMENT = "production"
+RELEASE = config("RELEASE", default=None)
 DEBUG = False
 
 # IMPORTANT: With this enabled, the server must always be behind a proxy that
@@ -319,6 +321,7 @@ if SENTRY_DSN:
         "class": "raven.handlers.logging.SentryHandler",
         "dsn": SENTRY_DSN,
         "level": "ERROR",
+        "environment": ENVIRONMENT,
     }
 
 # FIXME: the PLATFORM_NAME and PLATFORM_DESCRIPTION settings should be set to lazy translatable

--- a/config/cms/docker_run_staging.py
+++ b/config/cms/docker_run_staging.py
@@ -7,6 +7,8 @@ from lms.envs.fun.utils import Configuration
 # Load custom configuration parameters from yaml files
 config = Configuration(os.path.dirname(__file__))
 
+ENVIRONMENT = "staging"
+
 EMAIL_BACKEND = config(
     "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"
 )

--- a/config/lms/docker_run_development.py
+++ b/config/lms/docker_run_development.py
@@ -7,6 +7,7 @@ from .utils import Configuration
 # Load custom configuration parameters from yaml files
 config = Configuration(os.path.dirname(__file__))
 
+ENVIRONMENT = "development"
 DEBUG = True
 REQUIRE_DEBUG = True
 

--- a/config/lms/docker_run_feature.py
+++ b/config/lms/docker_run_feature.py
@@ -7,6 +7,8 @@ from .utils import Configuration
 # Load custom configuration parameters from yaml files
 config = Configuration(os.path.dirname(__file__))
 
+ENVIRONMENT = "feature"
+
 EMAIL_BACKEND = config(
     "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"
 )

--- a/config/lms/docker_run_preprod.py
+++ b/config/lms/docker_run_preprod.py
@@ -7,6 +7,8 @@ from .utils import Configuration
 # Load custom configuration parameters from yaml files
 config = Configuration(os.path.dirname(__file__))
 
+ENVIRONMENT = "preprod"
+
 EMAIL_BACKEND = config(
     "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"
 )

--- a/config/lms/docker_run_production.py
+++ b/config/lms/docker_run_production.py
@@ -433,6 +433,7 @@ if SENTRY_DSN:
         "dsn": SENTRY_DSN,
         "level": "ERROR",
         "environment": ENVIRONMENT,
+        "release": RELEASE,
     }
 
 

--- a/config/lms/docker_run_production.py
+++ b/config/lms/docker_run_production.py
@@ -29,6 +29,8 @@ AUTH_TOKENS = config
 
 ################################ ALWAYS THE SAME ##############################
 
+ENVIRONMENT = "production"
+RELEASE = config("RELEASE", default=None)
 DEBUG = False
 DEFAULT_TEMPLATE_ENGINE["OPTIONS"]["debug"] = False
 
@@ -430,6 +432,7 @@ if SENTRY_DSN:
         "class": "raven.handlers.logging.SentryHandler",
         "dsn": SENTRY_DSN,
         "level": "ERROR",
+        "environment": ENVIRONMENT,
     }
 
 

--- a/config/lms/docker_run_staging.py
+++ b/config/lms/docker_run_staging.py
@@ -7,6 +7,8 @@ from .utils import Configuration
 # Load custom configuration parameters from yaml files
 config = Configuration(os.path.dirname(__file__))
 
+ENVIRONMENT = "staging"
+
 EMAIL_BACKEND = config(
     "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"
 )


### PR DESCRIPTION
## Purpose

We must backport to the hawthorn.1 branch our improvements to the Sentry configuration on master.

## Proposal

I just cherry picked the commits from https://github.com/openfun/openedx-docker/pull/72