### PR TITLE
➕(core) add a requirement file for Open edx Extended

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,8 @@ WORKDIR /edx/app/edxapp/edx-platform
 ARG EDXAPP_RELEASE_ARCHIVE_URL
 COPY --from=downloads /downloads/edx-platform-* .
 
+COPY ./requirements.txt /edx/app/edxapp/edx-platform/requirements/edx/extend.txt
+
 # We copy default configuration files to "/config" and we point to them via
 # symlinks. That allows to easily override default configurations by mounting a
 # docker volume.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+# Open edX extended: dependencies
+
+# ==== xblocks ====
+
+configurable_lti_consumer-xblock==0.2.1
+
+
+# ==== third-party apps ====
+
+raven==6.9.0


### PR DESCRIPTION
## Purpose

This requirement file was originally located in the oee fork of edx-platform in openfun/edx-platform. 
In fact, the small fork in edx-platform works normally if the configurable LTI consumer is not installed.
It means the fork is robust and we can handle dependencies in openedx-docker. It is easier and makes more sense for all the dependencies that we need to add that have nothing to do with the edx-platform fork.

## Proposal

- [x] add a requirements.txt file to openedx-docker on the oee branch,
- [x] add basic requirements we know we need (configurable-lti-consumer and raven),
- [x] modify the Dockerfile to install requirements from this local file (we will then be able to remove the eponym file in edx-platform).