### PR TITLE
Upgrade configurable LTI xblock to v1.0.0-rc.1

### DIFF
--- a/config/cms/docker_run_production.py
+++ b/config/cms/docker_run_production.py
@@ -13,8 +13,6 @@ from xmodule.modulestore.modulestore_settings import (
     convert_module_store_setting_if_needed
 )
 
-from configurable_lti_consumer import filter_configurable_lti_consumer
-
 from ..common import *
 
 
@@ -605,13 +603,28 @@ ELASTIC_SEARCH_CONFIG = config(
 
 ################ CONFIGURABLE LTI CONSUMER ###############
 
-CONFIGURABLE_LTI_CONSUMER_SETTINGS = config(
-    "CONFIGURABLE_LTI_CONSUMER_SETTINGS", default={}, formatter=json.loads
+# Add just the standard LTI consumer by default, forcing it to open in a new window and ask
+# the user before sending email and username:
+LTI_XBLOCK_CONFIGURATIONS = config(
+    "LTI_XBLOCK_CONFIGURATIONS",
+    default=[
+        {
+            "display_name": "LTI consumer",
+            "pattern": ".*",
+            "hidden_fields": [
+                "ask_to_send_email",
+                "ask_to_send_username",
+                "new_window",
+            ],
+            "defaults": {
+                "ask_to_send_email": True,
+                "ask_to_send_username": True,
+                "launch_target": "new_window",
+            },
+        },
+    ],
+    formatter=json.loads,
 )
-
-# helper function that will be passed to XBock.load_class
-# method to filter multiple Python endpoints for the same xblock (lti_consumer)
-XBLOCK_SELECT_FUNCTION = filter_configurable_lti_consumer
 
 XBLOCK_SETTINGS = config("XBLOCK_SETTINGS", default={}, formatter=json.loads)
 XBLOCK_SETTINGS.setdefault("VideoDescriptor", {})["licensing_enabled"] = FEATURES.get(

--- a/config/lms/docker_run_production.py
+++ b/config/lms/docker_run_production.py
@@ -16,8 +16,6 @@ from xmodule.modulestore.modulestore_settings import (
     convert_module_store_setting_if_needed
 )
 
-from configurable_lti_consumer import filter_configurable_lti_consumer
-
 from ..common import *
 from .utils import Configuration
 
@@ -1181,9 +1179,28 @@ LTI_AGGREGATE_SCORE_PASSBACK_DELAY = config(
 
 ################ CONFIGURABLE LTI CONSUMER ###############
 
-# helper function that will be passed to XBock.load_class
-# method to filter multiple Python endpoints for the same xblock (lti_consumer)
-XBLOCK_SELECT_FUNCTION = filter_configurable_lti_consumer
+# Add just the standard LTI consumer by default, forcing it to open in a new window and ask
+# the user before sending email and username:
+LTI_XBLOCK_CONFIGURATIONS = config(
+    "LTI_XBLOCK_CONFIGURATIONS",
+    default=[
+        {
+            "display_name": "LTI consumer",
+            "pattern": ".*",
+            "hidden_fields": [
+                "ask_to_send_email",
+                "ask_to_send_username",
+                "new_window",
+            ],
+            "defaults": {
+                "ask_to_send_email": True,
+                "ask_to_send_username": True,
+                "launch_target": "new_window",
+            },
+        },
+    ],
+    formatter=json.loads,
+)
 
 ##################### Credit Provider help link ####################
 CREDIT_HELP_LINK_URL = config("CREDIT_HELP_LINK_URL", default=CREDIT_HELP_LINK_URL)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       context: .
       target: production
       args:
-        EDXAPP_RELEASE_ARCHIVE_URL: https://github.com/openfun/edx-platform/archive/oee/hawthorn.1-0.1.3.tar.gz
+        EDXAPP_RELEASE_ARCHIVE_URL: https://github.com/openfun/edx-platform/archive/oee/hawthorn.1-1.0.0-rc1.tar.gz
     image: edxapp:latest
     env_file: env.d/development
     environment:
@@ -53,7 +53,7 @@ services:
       args:
         UID: ${UID}
         GID: ${GID}
-        EDXAPP_RELEASE_ARCHIVE_URL: https://github.com/openfun/edx-platform/archive/oee/hawthorn.1-0.1.3.tar.gz
+        EDXAPP_RELEASE_ARCHIVE_URL: https://github.com/openfun/edx-platform/archive/oee/hawthorn.1-1.0.0-rc1.tar.gz
     image: edxapp:dev
     env_file: env.d/development
     ports:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 
 # ==== xblocks ====
 
-configurable_lti_consumer-xblock==0.2.1
+configurable_lti_consumer-xblock==1.0.0-rc.1
 
 
 # ==== third-party apps ====


### PR DESCRIPTION
## Purpose

Upgrading oee dependencies to use our configurable LTI XBlock version 1.0.0-rc.1 after a major refactoring.

## Proposal

- [x] upgrade the version of `edx-platform` to [hawthorn.1-1.0.0-rc.1](https://github.com/openfun/edx-platform/releases/tag/oee%2Fhawthorn.1-1.0.0-rc1) (necessary only because the name of the setting has changed),
- [x] update our default lms and cms settings to activate a pre-configured LTI consumer,
- [x] update the dependency to the configurable LTI XBlock to [v1.0.0-rc.1](https://github.com/openfun/xblock-configurable-lti-consumer/releases/tag/v1.0.0-rc.1).
