### PR TITLE
Fix logging environment in Sentry

### DIFF
--- a/config/cms/docker_run_development.py
+++ b/config/cms/docker_run_development.py
@@ -7,7 +7,8 @@ from lms.envs.fun.utils import Configuration
 # Load custom configuration parameters from yaml files
 config = Configuration(os.path.dirname(__file__))
 
-ENVIRONMENT = "development"
+LOGGING["handlers"]["sentry"]["environment"] = "development"
+
 DEBUG = True
 REQUIRE_DEBUG = True
 

--- a/config/cms/docker_run_feature.py
+++ b/config/cms/docker_run_feature.py
@@ -7,7 +7,7 @@ from lms.envs.fun.utils import Configuration
 # Load custom configuration parameters from yaml files
 config = Configuration(os.path.dirname(__file__))
 
-ENVIRONMENT = "feature"
+LOGGING["handlers"]["sentry"]["environment"] = "feature"
 
 EMAIL_BACKEND = config(
     "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"

--- a/config/cms/docker_run_preprod.py
+++ b/config/cms/docker_run_preprod.py
@@ -7,7 +7,7 @@ from lms.envs.fun.utils import Configuration
 # Load custom configuration parameters from yaml files
 config = Configuration(os.path.dirname(__file__))
 
-ENVIRONMENT = "preprod"
+LOGGING["handlers"]["sentry"]["environment"] = "preprod"
 
 EMAIL_BACKEND = config(
     "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"

--- a/config/cms/docker_run_production.py
+++ b/config/cms/docker_run_production.py
@@ -26,7 +26,6 @@ AUTH_TOKENS = config
 
 ############### ALWAYS THE SAME ################################
 
-ENVIRONMENT = "production"
 RELEASE = config("RELEASE", default=None)
 DEBUG = False
 
@@ -321,7 +320,7 @@ if SENTRY_DSN:
         "class": "raven.handlers.logging.SentryHandler",
         "dsn": SENTRY_DSN,
         "level": "ERROR",
-        "environment": ENVIRONMENT,
+        "environment": "production",
         "release": RELEASE,
     }
 

--- a/config/cms/docker_run_staging.py
+++ b/config/cms/docker_run_staging.py
@@ -7,7 +7,7 @@ from lms.envs.fun.utils import Configuration
 # Load custom configuration parameters from yaml files
 config = Configuration(os.path.dirname(__file__))
 
-ENVIRONMENT = "staging"
+LOGGING["handlers"]["sentry"]["environment"] = "staging"
 
 EMAIL_BACKEND = config(
     "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"

--- a/config/lms/docker_run_development.py
+++ b/config/lms/docker_run_development.py
@@ -7,7 +7,8 @@ from .utils import Configuration
 # Load custom configuration parameters from yaml files
 config = Configuration(os.path.dirname(__file__))
 
-ENVIRONMENT = "development"
+LOGGING["handlers"]["sentry"]["environment"] = "development"
+
 DEBUG = True
 REQUIRE_DEBUG = True
 

--- a/config/lms/docker_run_feature.py
+++ b/config/lms/docker_run_feature.py
@@ -7,7 +7,7 @@ from .utils import Configuration
 # Load custom configuration parameters from yaml files
 config = Configuration(os.path.dirname(__file__))
 
-ENVIRONMENT = "feature"
+LOGGING["handlers"]["sentry"]["environment"] = "feature"
 
 EMAIL_BACKEND = config(
     "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"

--- a/config/lms/docker_run_preprod.py
+++ b/config/lms/docker_run_preprod.py
@@ -7,7 +7,7 @@ from .utils import Configuration
 # Load custom configuration parameters from yaml files
 config = Configuration(os.path.dirname(__file__))
 
-ENVIRONMENT = "preprod"
+LOGGING["handlers"]["sentry"]["environment"] = "preprod"
 
 EMAIL_BACKEND = config(
     "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"

--- a/config/lms/docker_run_production.py
+++ b/config/lms/docker_run_production.py
@@ -29,7 +29,6 @@ AUTH_TOKENS = config
 
 ################################ ALWAYS THE SAME ##############################
 
-ENVIRONMENT = "production"
 RELEASE = config("RELEASE", default=None)
 DEBUG = False
 DEFAULT_TEMPLATE_ENGINE["OPTIONS"]["debug"] = False
@@ -432,7 +431,7 @@ if SENTRY_DSN:
         "class": "raven.handlers.logging.SentryHandler",
         "dsn": SENTRY_DSN,
         "level": "ERROR",
-        "environment": ENVIRONMENT,
+        "environment": "production",
         "release": RELEASE,
     }
 

--- a/config/lms/docker_run_staging.py
+++ b/config/lms/docker_run_staging.py
@@ -7,7 +7,7 @@ from .utils import Configuration
 # Load custom configuration parameters from yaml files
 config = Configuration(os.path.dirname(__file__))
 
-ENVIRONMENT = "staging"
+LOGGING["handlers"]["sentry"]["environment"] = "staging"
 
 EMAIL_BACKEND = config(
     "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"


### PR DESCRIPTION
## Purpose

The previous implementation was not working because the ENVIRONMENT setting was redefined after the LOGGING setting had already been set with the Sentry environment equal to "production". 

## Proposal

I propose to directly override the value of the environment in the LOGGING setting.
