### PR TITLE
✨(session) add redis as session backend

### DIFF
--- a/config/cms/docker_run_production.py
+++ b/config/cms/docker_run_production.py
@@ -107,6 +107,7 @@ DEFAULT_MOBILE_AVAILABLE = config(
 GITHUB_REPO_ROOT = config("GITHUB_REPO_ROOT", default=GITHUB_REPO_ROOT)
 
 STATIC_URL = "/static/studio/"
+STATIC_ROOT_BASE = path("/edx/app/edxapp/staticfiles")
 STATIC_ROOT = path("/edx/app/edxapp/staticfiles/studio")
 
 WEBPACK_LOADER["DEFAULT"]["STATS_FILE"] = STATIC_ROOT / "webpack-stats.json"

--- a/config/cms/docker_run_production.py
+++ b/config/cms/docker_run_production.py
@@ -157,14 +157,27 @@ SESSION_COOKIE_DOMAIN = config("SESSION_COOKIE_DOMAIN", default=None)
 SESSION_COOKIE_HTTPONLY = config(
     "SESSION_COOKIE_HTTPONLY", default=True, formatter=bool
 )
-SESSION_ENGINE = config(
-    "SESSION_ENGINE", default="django.contrib.sessions.backends.cache"
-)
+SESSION_ENGINE = config("SESSION_ENGINE", default="redis_sessions.session")
+
 SESSION_COOKIE_SECURE = config(
     "SESSION_COOKIE_SECURE", default=SESSION_COOKIE_SECURE, formatter=bool
 )
 SESSION_SAVE_EVERY_REQUEST = config(
     "SESSION_SAVE_EVERY_REQUEST", default=SESSION_SAVE_EVERY_REQUEST, formatter=bool
+)
+
+SESSION_REDIS = config(
+    "SESSION_REDIS",
+    default={
+        "host": "redis",
+        "port": 6379,
+        "db": 1,  # db 0 is used for Celery Broker
+        "password": "",
+        "prefix": "session",
+        "socket_timeout": 1,
+        "retry_on_timeout": False,
+    },
+    formatter=json.loads,
 )
 
 # social sharing settings

--- a/config/lms/docker_run_production.py
+++ b/config/lms/docker_run_production.py
@@ -33,8 +33,20 @@ RELEASE = config("RELEASE", default=None)
 DEBUG = False
 DEFAULT_TEMPLATE_ENGINE["OPTIONS"]["debug"] = False
 
-SESSION_ENGINE = config(
-    "SESSION_ENGINE", default="django.contrib.sessions.backends.cache"
+SESSION_ENGINE = config("SESSION_ENGINE", default="redis_sessions.session")
+
+SESSION_REDIS = config(
+    "SESSION_REDIS",
+    default={
+        "host": "redis",
+        "port": 6379,
+        "db": 1,  # db 0 is used for Celery Broker
+        "password": "",
+        "prefix": "session",
+        "socket_timeout": 1,
+        "retry_on_timeout": False,
+    },
+    formatter=json.loads,
 )
 
 # IMPORTANT: With this enabled, the server must always be behind a proxy that

--- a/config/lms/docker_run_production.py
+++ b/config/lms/docker_run_production.py
@@ -112,7 +112,8 @@ CELERYBEAT_SCHEDULE = {}  # For scheduling tasks, entries can be added to this d
 ########################## NON-SECURE ENV CONFIG ##############################
 # Things like server locations, ports, etc.
 
-STATIC_ROOT = path("/edx/app/edxapp/staticfiles")
+STATIC_ROOT_BASE = path("/edx/app/edxapp/staticfiles")
+STATIC_ROOT = STATIC_ROOT_BASE
 STATIC_URL = "/static/"
 
 WEBPACK_LOADER["DEFAULT"]["STATS_FILE"] = STATIC_ROOT / "webpack-stats.json"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,9 @@ services:
   memcached:
     image: memcached:1.4
 
+  redis:
+      image: redis:4.0
+
   mailcatcher:
     image: sj26/mailcatcher:latest
     ports:
@@ -44,6 +47,7 @@ services:
       - mysql
       - mongodb
       - memcached
+      - redis
     user: ${UID}:${GID}
 
   lms-dev:
@@ -72,6 +76,7 @@ services:
       - mysql
       - mongodb
       - memcached
+      - redis
 
   cms:
     image: edxapp:latest

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ configurable_lti_consumer-xblock==1.0.0-rc.1
 # ==== third-party apps ====
 
 raven==6.9.0
+django-redis-sessions==0.6.1


### PR DESCRIPTION
## Purpose

Redis is in our opinion the best practice to record sessions as it combines the speed of memory with a persistence layer.

## Proposal

- [x] add dependency to the `redis-session-backend` Django third-party app,
- [x] declare Redis as default session backend in lms and cms settings.