### PR TITLE
🔧(cache) configure Django cache

### DIFF
--- a/config/cms/docker_run_production.py
+++ b/config/cms/docker_run_production.py
@@ -148,9 +148,13 @@ LOG_DIR = config("LOG_DIR", default="/edx/var/logs/edx")
 CACHES = config(
     "CACHES",
     default={
-        "default": {
+        "loc_cache": {
             "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-            "LOCATION": "unique-snowflake",
+            "LOCATION": "edx_location_mem_cache",
+        },
+        "default": {
+            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "LOCATION": "memcached:11211",
         }
     },
     formatter=json.loads,

--- a/config/lms/docker_run_production.py
+++ b/config/lms/docker_run_production.py
@@ -215,21 +215,17 @@ if config("SESSION_COOKIE_NAME", default=None):
 CACHES = config(
     "CACHES",
     default={
-        "default": {
+        "loc_cache": {
             "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-            "LOCATION": "unique-snowflake",
+            "LOCATION": "edx_location_mem_cache",
+        },
+        "default": {
+            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "LOCATION": "memcached:11211",
         }
     },
     formatter=json.loads,
 )
-
-# Cache used for location mapping -- called many times with the same key/value
-# in a given request.
-if "loc_cache" not in CACHES:
-    CACHES["loc_cache"] = {
-        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-        "LOCATION": "edx_location_mem_cache",
-    }
 
 # Email overrides
 DEFAULT_FROM_EMAIL = config("DEFAULT_FROM_EMAIL", default=DEFAULT_FROM_EMAIL)


### PR DESCRIPTION
Default configuration was using LocMemCache backend preventing
cache to be shared between containers.
By example, lms course plan was not invalidated when modifications
were made in studio.
We now use Memcached as default cache and LocMemcach for 'location mapping'
as recommended by edX
https://github.com/edx/edx-platform/blob/master/lms/envs/aws.py#L199

