### PR TITLE
🐳(base) configure locales

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,15 @@ ARG EDXAPP_RELEASE_ARCHIVE_URL=https://github.com/edx/edx-platform/archive/maste
 # === BASE ===
 FROM ubuntu:16.04 as base
 
+# Configure locales
+RUN apt-get update && \
+    apt-get install -y gettext locales && \
+    rm -rf /var/lib/apt/lists/*
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    locale-gen
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
 
 # === DOWNLOAD ===
 FROM base as downloads


### PR DESCRIPTION
## Purpose

Python encoding is based on the system locale, hence to prevent encoding failures, we need to configure the system locale as `en_US.UTF-8`.

## Proposal

- [x] install & configure default locale to `en_US.UTF-8`
- [x] install the `gettext` tool that is required by Django admin commands to collect and compile translations
