### PR TITLE
⬆️(lti) upgrade xblock configurable lti consumer to 1.0.0-rc.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 
 # ==== xblocks ====
 
-configurable_lti_consumer-xblock==1.0.0-rc.1
+configurable_lti_consumer-xblock==1.0.0-rc.2
 
 
 # ==== third-party apps ====


### PR DESCRIPTION
## Purpose

We want to take advantage of the new features on the [XBlock configurable LTI consumer](https://github.com/openfun/xblock-configurable-lti-consumer/releases/tag/v1.0.0-rc.2):

This version has automatically resizable iframes depending on the content of the LTI iframe. 
It also removed the header that was useless and interferred with the LTI content.

## Proposal

Bump package version to 1.0.0-rc.2
