### PR TITLE
⬆️(lti) upgrade xblock configurable lti consumer to 1.0.0-rc.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 
 # ==== xblocks ====
 
-configurable_lti_consumer-xblock==1.0.0-rc.2
+configurable_lti_consumer-xblock==1.0.0-rc.3
 
 
 # ==== third-party apps ====


### PR DESCRIPTION
## Purpose

The previous release of this package was subject to a packing bug and was therefore not up-to-date.

## Proposal

Bump package version to 1.0.0-rc.3
