### PR TITLE
🐛(logging) fix wrong settings for tracking logs

### DIFF
--- a/config/cms/docker_run_production.py
+++ b/config/cms/docker_run_production.py
@@ -352,7 +352,7 @@ STUDIO_SHORT_NAME = config("STUDIO_SHORT_NAME", default=STUDIO_SHORT_NAME)
 
 # Event Tracking
 TRACKING_IGNORE_URL_PATTERNS = config(
-    "TRACKING_IGNORE_URL_PATTERNS", default=None, formatter=json.loads
+    "TRACKING_IGNORE_URL_PATTERNS", default=TRACKING_IGNORE_URL_PATTERNS, formatter=json.loads
 )
 
 # Heartbeat

--- a/config/lms/docker_run_production.py
+++ b/config/lms/docker_run_production.py
@@ -483,7 +483,7 @@ ASSET_IGNORE_REGEX = config("ASSET_IGNORE_REGEX", default=ASSET_IGNORE_REGEX)
 
 # Event Tracking
 TRACKING_IGNORE_URL_PATTERNS = config(
-    "TRACKING_IGNORE_URL_PATTERNS", default=None, formatter=json.loads
+    "TRACKING_IGNORE_URL_PATTERNS", default=TRACKING_IGNORE_URL_PATTERNS, formatter=json.loads
 )
 
 # SSL external authentication settings


### PR DESCRIPTION
We were initializing TRACKING_IGNORE_URL_PATTERNS to None instead of a list
of url to ignore when writing tracking logs, making each requests track a
TypeError.
