### PR TITLE
✨(edxapp) make memcached host & port configurable

### DIFF
--- a/config/cms/docker_run_production.py
+++ b/config/cms/docker_run_production.py
@@ -143,6 +143,9 @@ ALLOWED_HOSTS = config(
 
 LOG_DIR = config("LOG_DIR", default="/edx/var/logs/edx")
 
+MEMCACHED_HOST = config("MEMCACHED_HOST", default="memcached")
+MEMCACHED_PORT = config("MEMCACHED_PORT", default=11211, formatter=int)
+
 CACHES = config(
     "CACHES",
     default={
@@ -152,7 +155,7 @@ CACHES = config(
         },
         "default": {
             "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
-            "LOCATION": "memcached:11211",
+            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
         }
     },
     formatter=json.loads,

--- a/config/lms/docker_run_production.py
+++ b/config/lms/docker_run_production.py
@@ -222,6 +222,9 @@ if config("SESSION_COOKIE_NAME", default=None):
     # being a str()
     SESSION_COOKIE_NAME = str(config("SESSION_COOKIE_NAME"))
 
+MEMCACHED_HOST = config("MEMCACHED_HOST", default="memcached")
+MEMCACHED_PORT = config("MEMCACHED_PORT", default=11211, formatter=int)
+
 CACHES = config(
     "CACHES",
     default={
@@ -231,7 +234,7 @@ CACHES = config(
         },
         "default": {
             "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
-            "LOCATION": "memcached:11211",
+            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
         }
     },
     formatter=json.loads,


### PR DESCRIPTION
## Purpose

`memcached` cache backend should be easily configurable via environment variables or the `settings.yml` file.


## Proposal

- [x] Add the `MEMCACHED_HOST` and `MEMCACHED_PORT` configuration variables

Backport from #95 