### PR TITLE
⬆️(lti) upgrade xblock configurable LTI consumer to 1.2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 
 # ==== xblocks ====
 
-configurable_lti_consumer-xblock==1.1.0
+configurable_lti_consumer-xblock==1.2.1
 
 
 # ==== third-party apps ====


### PR DESCRIPTION
## Purpose

We experienced a flickering on page load with Marsha's iframe resizer. It was fixed in v1.21 of the [configurable LTI consumer XBlock](https://github.com/openfun/xblock-configurable-lti-consumer/pull/14/files).

## Proposal

Bump dependency to configurable_lti_consumer-xblock==1.2.1