### PR TITLE
➕(edxapp) add lynx dependency for html to text conversion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -176,6 +176,7 @@ RUN apt-get update && \
     libmysqlclient20 \
     libxml2 \
     libxmlsec1-dev \
+    lynx \
     nodejs \
     nodejs-legacy \
     tzdata && \


### PR DESCRIPTION
## Purpose

It appears that lynx (an old headless web browser) is required to run html to text conversions in the platform backend:

https://github.com/edx/edx-platform/blob/master/openedx/core/lib/html_to_text.py#L15

## Proposal

- [x] add lynx system dependency
