### PR TITLE
⬆️(lti) upgrade xblock configurable LTI consumer to 1.2.2

### DIFF
--- a/config/cms/docker_run_production.py
+++ b/config/cms/docker_run_production.py
@@ -645,6 +645,9 @@ LTI_XBLOCK_CONFIGURATIONS = config(
     ],
     formatter=json.loads,
 )
+LTI_XBLOCK_SECRETS = config(
+    "LTI_XBLOCK_SECRETS", default={}, formatter=json.loads
+)
 
 XBLOCK_SETTINGS = config("XBLOCK_SETTINGS", default={}, formatter=json.loads)
 XBLOCK_SETTINGS.setdefault("VideoDescriptor", {})["licensing_enabled"] = FEATURES.get(

--- a/config/lms/docker_run_production.py
+++ b/config/lms/docker_run_production.py
@@ -1212,6 +1212,9 @@ LTI_XBLOCK_CONFIGURATIONS = config(
     ],
     formatter=json.loads,
 )
+LTI_XBLOCK_SECRETS = config(
+    "LTI_XBLOCK_SECRETS", default={}, formatter=json.loads
+)
 
 ##################### Credit Provider help link ####################
 CREDIT_HELP_LINK_URL = config("CREDIT_HELP_LINK_URL", default=CREDIT_HELP_LINK_URL)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 
 # ==== xblocks ====
 
-configurable_lti_consumer-xblock==1.2.1
+configurable_lti_consumer-xblock==1.2.2
 
 
 # ==== third-party apps ====


### PR DESCRIPTION
## Purpose

We want to upgrade to v1.2.2 of the [configurable LTI consumer XBlock](https://github.com/openfun/xblock-configurable-lti-consumer).

This version fixes a bug for LTI configurations that don't define defaults or hidden fields. It also allows to configure secrets separately so we don't need to encrypt the whole configuration.

## Proposal

- [x] Bump version to 1.2.2 in requirements.txt,
- [x] Add the new setting to config files.
