### PR TITLE
🔧(edxapp) add missing DRF setting required by Fonzie API

### DIFF
--- a/config/lms/docker_run_production.py
+++ b/config/lms/docker_run_production.py
@@ -847,6 +847,14 @@ GRADES_DOWNLOAD = config(
     formatter=json.loads
 )
 
+# Add Django Rest Framework URL versioning required by Fonzie to edX
+# existing DRF configuration
+REST_FRAMEWORK.update({
+   'ALLOWED_VERSIONS': ('1.0', ),
+   'DEFAULT_VERSION': '1.0',
+   'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.URLPathVersioning',
+})
+
 # Rate limit for regrading tasks that a grading policy change can kick off
 POLICY_CHANGE_TASK_RATE_LIMIT = config(
     "POLICY_CHANGE_TASK_RATE_LIMIT", default=POLICY_CHANGE_TASK_RATE_LIMIT


### PR DESCRIPTION
When tagging 2.9.0 we forgot API versioning related settings.
`rest_framework.versioning.URLPathVersioning` is required by DRF
to successfully route to Fonzie urls of form `api/v1.0/endpoint`
