### PR TITLE
🔥(images) remove timezone configuration step

### DIFF
--- a/releases/hawthorn/1/bare/CHANGELOG.md
+++ b/releases/hawthorn/1/bare/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+- Remove useless timezone configuration
+
 ## [hawthorn.1-2.6.0] - 2019-02-08
 
 https://github.com/openfun/openedx-docker/releases/tag/hawthorn.1-2.6.0

--- a/releases/hawthorn/1/bare/Dockerfile
+++ b/releases/hawthorn/1/bare/Dockerfile
@@ -12,9 +12,12 @@ ARG EDX_RELEASE_REF=open-release/hawthorn.1
 # === BASE ===
 FROM ubuntu:16.04 as base
 
-# Configure locales
+# Configure locales & timezone
 RUN apt-get update && \
-    apt-get install -y gettext locales && \
+    apt-get install -y \
+      gettext \
+      locales \
+      tzdata && \
     rm -rf /var/lib/apt/lists/*
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     locale-gen
@@ -184,14 +187,6 @@ COPY --from=builder /usr/local /usr/local
 
 # Copy modified sources (sic!)
 COPY --from=builder /edx/app/edxapp/edx-platform  /edx/app/edxapp/edx-platform
-
-# Set container timezone and related timezones database and DST rules
-# See https://serverfault.com/a/856593
-ENV TZ 'Etc/UTC'
-RUN echo $TZ > /etc/timezone && \
-    rm /etc/localtime && \
-    ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
-    dpkg-reconfigure -f noninteractive tzdata
 
 # Now that dependencies are installed and configuration has been set, the above
 # statements will run with a un-privileged user.

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+- Remove useless timezone configuration
+
 ## [hawthorn.1-oee-2.9.1] - 2019-06-04
 
 ### Fix

--- a/releases/hawthorn/1/oee/Dockerfile
+++ b/releases/hawthorn/1/oee/Dockerfile
@@ -12,9 +12,12 @@ ARG EDX_RELEASE_REF=open-release/hawthorn.1
 # === BASE ===
 FROM ubuntu:16.04 as base
 
-# Configure locales
+# Configure locales & timezone
 RUN apt-get update && \
-    apt-get install -y gettext locales && \
+    apt-get install -y \
+      gettext \
+      locales \
+      tzdata && \
     rm -rf /var/lib/apt/lists/*
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     locale-gen
@@ -192,14 +195,6 @@ COPY --from=builder /usr/local /usr/local
 
 # Copy modified sources (sic!)
 COPY --from=builder /edx/app/edxapp/edx-platform  /edx/app/edxapp/edx-platform
-
-# Set container timezone and related timezones database and DST rules
-# See https://serverfault.com/a/856593
-ENV TZ 'Etc/UTC'
-RUN echo $TZ > /etc/timezone && \
-    rm /etc/localtime && \
-    ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
-    dpkg-reconfigure -f noninteractive tzdata
 
 # Now that dependencies are installed and configuration has been set, the above
 # statements will run with a un-privileged user.

--- a/releases/master/bare/Dockerfile
+++ b/releases/master/bare/Dockerfile
@@ -12,9 +12,12 @@ ARG EDX_RELEASE_REF=release-2018-08-29-14.14
 # === BASE ===
 FROM ubuntu:16.04 as base
 
-# Configure locales
+# Configure locales & timezone
 RUN apt-get update && \
-    apt-get install -y gettext locales && \
+    apt-get install -y \
+      gettext \
+      locales \
+      tzdata && \
     rm -rf /var/lib/apt/lists/*
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     locale-gen
@@ -183,14 +186,6 @@ COPY --from=builder /usr/local /usr/local
 
 # Copy modified sources (sic!)
 COPY --from=builder /edx/app/edxapp/edx-platform  /edx/app/edxapp/edx-platform
-
-# Set container timezone and related timezones database and DST rules
-# See https://serverfault.com/a/856593
-ENV TZ 'Etc/UTC'
-RUN echo $TZ > /etc/timezone && \
-    rm /etc/localtime && \
-    ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
-    dpkg-reconfigure -f noninteractive tzdata
 
 # Now that dependencies are installed and configuration has been set, the above
 # statements will run with a un-privileged user.


### PR DESCRIPTION
## Purpose

One should not enforce a timezone in a Docker image. Instead, this should be set at the runtime depending on the host configuration or via the `TZ` environment variable for non-alpine images.

More, than that the configuration commands were buggy (or partially useless).

## Proposal

- [x] Remove timezone configuration from our `Dockerfile`s
