### PR TITLE
👷(project) fix jobs filtering for tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,25 +184,37 @@ workflows:
             branches:
               ignore: master
             tags:
-              only: /.*/
+              ignore: /.*/
       - check-changelog:
           filters:
             branches:
               ignore: master
             tags:
-              only: /.*/
+              ignore: /.*/
       - lint-changelog:
           filters:
             branches:
               ignore: master
             tags:
-              only: /.*/
+              ignore: /.*/
 
       # Build jobs
-      - master/bare
-      - dogwood/3/bare
-      - hawthorn/1/oee
-      - hawthorn/1/bare
+      - master/bare:
+          filters:
+            tags:
+              only: /.*/
+      - dogwood/3/bare:
+          filters:
+            tags:
+              only: /.*/
+      - hawthorn/1/oee:
+          filters:
+            tags:
+              only: /.*/
+      - hawthorn/1/bare:
+          filters:
+            tags:
+              only: /.*/
 
       # We are pushing to Docker only images that are the result of a tag respecting the pattern:
       #    **{branch-name}-x.y.z**
@@ -217,9 +229,6 @@ workflows:
       #   - eucalyptus-funwb-2.3.19
       - hub:
           requires:
-            - lint-git
-            - check-changelog
-            - lint-changelog
             - master/bare
             - dogwood/3/bare
             - hawthorn/1/bare


### PR DESCRIPTION
## Purpose

The CI `hub` job seems broken and it is not triggered upon new git tag event.

## Proposal

From CircleCI's documentation:

> CircleCI does not run workflows for tags unless you explicitly specify tag filters. Additionally, if a job requires any other jobs (directly or indirectly), you must specify tag filters for those jobs.

- [x] activate tags filtering for each release job
- [x] ignore quality checks for tags as they must have been checked primarily while proposing changes in a branch (PR)
