### PR TITLE
👷(project) add checkout step to the hub job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,6 +142,8 @@ jobs:
     <<: *defaults
 
     steps:
+      - checkout
+
       # Thanks to docker layer caching, rebuilding the image should be blazing
       # fast!
       - run:


### PR DESCRIPTION
## Purpose

The hub job is broken as project sources are not available during execution.

## Proposal

- [x] checkout project sources
