### PR TITLE
👷(project) add docker-compose upgrade to the hub job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,6 +144,14 @@ jobs:
     steps:
       - checkout
 
+      # Install a recent docker-compose release
+      - run:
+        name: Upgrade docker-compose
+        command: |
+          curl -L "https://github.com/docker/compose/releases/download/1.24.1/docker-compose-$(uname -s)-$(uname -m)" -o ~/docker-compose
+          chmod +x ~/docker-compose
+          sudo mv ~/docker-compose /usr/local/bin/docker-compose
+
       # Thanks to docker layer caching, rebuilding the image should be blazing
       # fast!
       - run:


### PR DESCRIPTION
## Purpose

We cannot build target images with the default docker-compose release.

## Proposal

- [x] add docker-compose upgrade to the `hub` job
