### PR TITLE
⬆️ (hawthorn/1/oee) upgrade xblock-poll to it's latest version

### DIFF
--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -10,7 +10,8 @@ release.
 ## [Unreleased]
 
 ### Changed
-
+- Upgrade [xblock-poll](https://github.com/open-craft/xblock-poll)
+  to version [`v1.8.7`](https://github.com/open-craft/xblock-poll/tree/v1.8.7)
 - Remove useless timezone configuration
 - Remove useless development dependencies
 

--- a/releases/hawthorn/1/oee/requirements.txt
+++ b/releases/hawthorn/1/oee/requirements.txt
@@ -9,3 +9,6 @@ configurable_lti_consumer-xblock==1.2.3
 # ==== third-party apps ====
 raven==6.9.0
 django-redis-sessions==0.6.1
+
+# upgrade xblock-poll
+git+https://github.com/open-craft/xblock-poll.git@v1.8.7#egg=xblock-poll==1.8.7


### PR DESCRIPTION
`xblock-poll` version 1.5.1 still used by latest versions of `edx-platform`
has a bug preventing instructor to download CSV files of user's
responses. Version 1.8.7 should fix that issue
