### PR TITLE
🐛(hawthorn/1/oee) restore instructor exports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,10 @@ $(FLAVORED_EDX_RELEASE_PATH)/data/store/.keep:
 	mkdir -p $(FLAVORED_EDX_RELEASE_PATH)/data/store
 	touch $(FLAVORED_EDX_RELEASE_PATH)/data/store/.keep
 
+$(FLAVORED_EDX_RELEASE_PATH)/data/export/.keep:
+	mkdir -p $(FLAVORED_EDX_RELEASE_PATH)/data/export
+	touch $(FLAVORED_EDX_RELEASE_PATH)/data/export/.keep
+
 $(FLAVORED_EDX_RELEASE_PATH)/src/edx-demo-course/.keep:
 	mkdir -p $(FLAVORED_EDX_RELEASE_PATH)/src/edx-demo-course
 	touch $(FLAVORED_EDX_RELEASE_PATH)/src/edx-demo-course/.keep
@@ -277,6 +281,7 @@ tree: \
   $(FLAVORED_EDX_RELEASE_PATH)/data/static/development/.keep \
   $(FLAVORED_EDX_RELEASE_PATH)/data/media/.keep \
   $(FLAVORED_EDX_RELEASE_PATH)/data/store/.keep \
+  $(FLAVORED_EDX_RELEASE_PATH)/data/export/.keep \
   $(FLAVORED_EDX_RELEASE_PATH)/src/edx-demo-course/.keep \
   $(FLAVORED_EDX_RELEASE_PATH)/src/edx-platform/.keep
 tree:  ## create data directories mounted as volumes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,7 @@ services:
       - ./${FLAVORED_EDX_RELEASE_PATH:-releases/master/bare}/data/static/production:/edx/app/edxapp/staticfiles
       - ./${FLAVORED_EDX_RELEASE_PATH:-releases/master/bare}/data/media:/edx/var/edxapp/media
       - ./${FLAVORED_EDX_RELEASE_PATH:-releases/master/bare}/data/store:/edx/app/edxapp/data
+      - ./${FLAVORED_EDX_RELEASE_PATH:-releases/master/bare}/data/export:/edx/var/edxapp/export
       - ./${FLAVORED_EDX_RELEASE_PATH:-releases/master/bare}/config:/config
     depends_on:
       - mailcatcher
@@ -73,6 +74,7 @@ services:
       - ./${FLAVORED_EDX_RELEASE_PATH:-releases/master/bare}/data/static/development:/edx/app/edxapp/staticfiles
       - ./${FLAVORED_EDX_RELEASE_PATH:-releases/master/bare}/data/media:/edx/var/edxapp/media
       - ./${FLAVORED_EDX_RELEASE_PATH:-releases/master/bare}/data/store:/edx/app/edxapp/data
+      - ./${FLAVORED_EDX_RELEASE_PATH:-releases/master/bare}/data/export:/edx/var/edxapp/export
       - ./${FLAVORED_EDX_RELEASE_PATH:-releases/master/bare}/config:/config
     command: >
       python manage.py lms runserver 0.0.0.0:8000 --settings=fun.docker_run_development

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -14,6 +14,11 @@ release.
 - Remove useless timezone configuration
 - Remove useless development dependencies
 
+### Fixed
+
+- Restore LMS's instructor exported files support and fonzie's integration in
+  development
+
 ## [hawthorn.1-oee-2.9.1] - 2019-06-04
 
 ### Fix

--- a/releases/hawthorn/1/oee/entrypoint.sh
+++ b/releases/hawthorn/1/oee/entrypoint.sh
@@ -5,4 +5,8 @@
 
 # Activate user's virtualenv
 source /edx/app/edxapp/venv/bin/activate
+
+# Override default lms root_urls
+ln -sf /config/lms/root_urls.py /edx/app/edxapp/edx-platform/lms/
+
 exec "$@"


### PR DESCRIPTION
## Purpose

During the latest project refactoring, we missed the LMS's instructor exported file volume and fonzie's support for development.

## Proposal

- [x] add `export` volume to docker-compose
- [x] override LMS URLs in the development `ENTRYPOINT` to integrate Fonzie
