### PR TITLE
🔧(config) add LOCALE_PATHS to configurable settings

### DIFF
--- a/releases/dogwood/3/bare/CHANGELOG.md
+++ b/releases/dogwood/3/bare/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Changed
+
+- Add LOCALE_PATHS to configurable settings
+
 ## [dogwood.3-1.0.0] - 2019-09-24
 
 ### Added

--- a/releases/dogwood/3/bare/config/cms/docker_run_production.py
+++ b/releases/dogwood/3/bare/config/cms/docker_run_production.py
@@ -210,6 +210,10 @@ COURSES_WITH_UNSAFE_CODE = config(
     "COURSES_WITH_UNSAFE_CODE", default=[], formatter=json.loads
 )
 
+LOCALE_PATHS = config(
+    "LOCALE_PATHS", default=LOCALE_PATHS, formatter=json.loads
+)
+
 ASSET_IGNORE_REGEX = config("ASSET_IGNORE_REGEX", default=ASSET_IGNORE_REGEX)
 
 # Theme overrides

--- a/releases/dogwood/3/bare/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/bare/config/lms/docker_run_production.py
@@ -415,6 +415,10 @@ COURSES_WITH_UNSAFE_CODE = config(
     "COURSES_WITH_UNSAFE_CODE", default=[], formatter=json.loads
 )
 
+LOCALE_PATHS = config(
+    "LOCALE_PATHS", default=LOCALE_PATHS, formatter=json.loads
+)
+
 ASSET_IGNORE_REGEX = config("ASSET_IGNORE_REGEX", default=ASSET_IGNORE_REGEX)
 
 # Event Tracking

--- a/releases/hawthorn/1/bare/CHANGELOG.md
+++ b/releases/hawthorn/1/bare/CHANGELOG.md
@@ -11,6 +11,7 @@ release.
 
 ### Changed
 
+- Add LOCALE_PATHS to configurable settings
 - Remove useless timezone configuration
 - Remove useless development dependencies
 

--- a/releases/hawthorn/1/bare/config/cms/docker_run_production.py
+++ b/releases/hawthorn/1/bare/config/cms/docker_run_production.py
@@ -241,6 +241,10 @@ COMPREHENSIVE_THEME_DIRS = (
     or []
 )
 
+LOCALE_PATHS = config(
+    "LOCALE_PATHS", default=LOCALE_PATHS, formatter=json.loads
+)
+
 # COMPREHENSIVE_THEME_LOCALE_PATHS contain the paths to themes locale directories e.g.
 # "COMPREHENSIVE_THEME_LOCALE_PATHS" : [
 #        "/edx/src/edx-themes/conf/locale"

--- a/releases/hawthorn/1/bare/config/lms/docker_run_production.py
+++ b/releases/hawthorn/1/bare/config/lms/docker_run_production.py
@@ -322,6 +322,10 @@ COMPREHENSIVE_THEME_DIRS = (
     or []
 )
 
+LOCALE_PATHS = config(
+    "LOCALE_PATHS", default=LOCALE_PATHS, formatter=json.loads
+)
+
 # COMPREHENSIVE_THEME_LOCALE_PATHS contain the paths to themes locale directories e.g.
 # "COMPREHENSIVE_THEME_LOCALE_PATHS" : [
 #        "/edx/src/edx-themes/conf/locale"

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -11,6 +11,7 @@ release.
 
 ### Changed
 
+- Add LOCALE_PATHS to configurable settings
 - Remove useless timezone configuration
 - Remove useless development dependencies
 

--- a/releases/hawthorn/1/oee/config/cms/docker_run_production.py
+++ b/releases/hawthorn/1/oee/config/cms/docker_run_production.py
@@ -254,6 +254,10 @@ COMPREHENSIVE_THEME_DIRS = (
     or []
 )
 
+LOCALE_PATHS = config(
+    "LOCALE_PATHS", default=LOCALE_PATHS, formatter=json.loads
+)
+
 # COMPREHENSIVE_THEME_LOCALE_PATHS contain the paths to themes locale directories e.g.
 # "COMPREHENSIVE_THEME_LOCALE_PATHS" : [
 #        "/edx/src/edx-themes/conf/locale"

--- a/releases/hawthorn/1/oee/config/lms/docker_run_production.py
+++ b/releases/hawthorn/1/oee/config/lms/docker_run_production.py
@@ -337,6 +337,10 @@ COMPREHENSIVE_THEME_DIRS = (
     or []
 )
 
+LOCALE_PATHS = config(
+    "LOCALE_PATHS", default=LOCALE_PATHS, formatter=json.loads
+)
+
 # COMPREHENSIVE_THEME_LOCALE_PATHS contain the paths to themes locale directories e.g.
 # "COMPREHENSIVE_THEME_LOCALE_PATHS" : [
 #        "/edx/src/edx-themes/conf/locale"

--- a/releases/master/bare/config/cms/docker_run_production.py
+++ b/releases/master/bare/config/cms/docker_run_production.py
@@ -232,6 +232,10 @@ COURSES_WITH_UNSAFE_CODE = config(
 
 ASSET_IGNORE_REGEX = config("ASSET_IGNORE_REGEX", default=ASSET_IGNORE_REGEX)
 
+LOCALE_PATHS = config(
+    "LOCALE_PATHS", default=LOCALE_PATHS, formatter=json.loads
+)
+
 COMPREHENSIVE_THEME_DIRS = (
     config(
         "COMPREHENSIVE_THEME_DIRS",

--- a/releases/master/bare/config/lms/docker_run_production.py
+++ b/releases/master/bare/config/lms/docker_run_production.py
@@ -322,6 +322,10 @@ COMPREHENSIVE_THEME_DIRS = (
     or []
 )
 
+LOCALE_PATHS = config(
+    "LOCALE_PATHS", default=LOCALE_PATHS, formatter=json.loads
+)
+
 # COMPREHENSIVE_THEME_LOCALE_PATHS contain the paths to themes locale directories e.g.
 # "COMPREHENSIVE_THEME_LOCALE_PATHS" : [
 #        "/edx/src/edx-themes/conf/locale"


### PR DESCRIPTION
## Purpose

This sets and order paths when edx finds i18n files. Overriding
this settings allow us to override edx-platform i18n strings by
redefining them in theme.
