### PR TITLE
Add missing support to redis sentinel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,8 +133,8 @@ clean:  ## remove downloaded sources
 
 clean-db: \
   stop
-clean-db:  ## Remove mongo & mysql databases
-	$(COMPOSE) rm mongodb mysql redis
+clean-db:  ## Remove mongo, mysql & redis databases
+	$(COMPOSE) rm mongodb mysql redis redis-sentinel redis-master redis-slave
 .PHONY: clean-db
 
 collectstatic: \

--- a/README.md
+++ b/README.md
@@ -47,6 +47,21 @@ including database services which in production are not run on Docker. See the
   proxy other requests to Django.
 - **mailcatcher** the email backend
 
+Concerning Redis, it is possible to run a single redis instance (the default choice)
+or to run redis with sentinel to simulate a HA instance. 
+To use Redis sentinel you have to set the `REDIS_TARGET_INSTANCE` environment variable
+to `redis-sentinel`:
+
+```bash
+$ export REDIS_TARGET_INSTANCE=redis-sentinel
+```
+
+To switch back to the single redis instance, unset this environment variable:
+
+```bash
+$ unset REDIS_TARGET_INSTANCE
+```
+
 ## Prerequisite
 
 Make sure you have a recent version of [Docker](https://docs.docker.com/install)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,7 @@
 # OpenEdx docker-compose stack used for development/test purpose
 #
+#
+#
 # Nota bene: this docker-compose file requires that you have set the DOCKER_UID
 # and DOCKER_GID variables with relevant values (i.e. matching the current
 # system user ids). If you use the project's Makefile or the bin/compose
@@ -21,11 +23,30 @@ services:
     # See https://docs.mongodb.com/v3.0/reference/program/mongod/#options for complete details.
     command: mongod --smallfiles --nojournal --storageEngine wiredTiger
 
+  memcached:
+    image: memcached:1.4
+
   redis:
     image: redis:4
 
-  memcached:
-    image: memcached:1.4
+  redis-master:
+    image: redis:4.0.10-alpine
+
+  redis-slave:
+    image: redis:4.0.10-alpine
+    command: redis-server --slaveof redis-master 6379
+    depends_on:
+      - redis-master
+
+  redis-sentinel:
+    image: s7anley/redis-sentinel-docker
+    environment:
+      - MASTER_NAME=mymaster
+      - QUORUM=1
+      - MASTER=redis-master
+    depends_on:
+        - redis-master
+        - redis-slave
 
   mailcatcher:
     image: sj26/mailcatcher:latest
@@ -40,7 +61,9 @@ services:
         EDX_RELEASE_REF: ${EDX_RELEASE_REF:-release-2018-08-29-14.14}
         EDX_ARCHIVE_URL: ${EDX_ARCHIVE_URL:-https://github.com/edx/edx-platform/archive/release-2018-08-29-14.14.tar.gz}
     image: edxapp:${EDX_RELEASE:-master}-${FLAVOR:-bare}
-    env_file: env.d/development
+    env_file: 
+      - env.d/development
+      - env.d/${REDIS_SERVICE:-redis}
     environment:
       SERVICE_VARIANT: lms
       DJANGO_SETTINGS_MODULE: lms.envs.fun.docker_run
@@ -50,13 +73,13 @@ services:
       - ./${FLAVORED_EDX_RELEASE_PATH:-releases/master/bare}/data/store:/edx/app/edxapp/data
       - ./${FLAVORED_EDX_RELEASE_PATH:-releases/master/bare}/data/export:/edx/var/edxapp/export
       - ./${FLAVORED_EDX_RELEASE_PATH:-releases/master/bare}/config:/config
+    user: ${DOCKER_UID}:${DOCKER_GID}
     depends_on:
       - mailcatcher
       - mysql
       - mongodb
       - memcached
-      - redis
-    user: ${DOCKER_UID}:${DOCKER_GID}
+      - ${REDIS_SERVICE:-redis}
 
   lms-dev:
     build:
@@ -68,7 +91,12 @@ services:
         EDX_RELEASE_REF: ${EDX_RELEASE_REF:-release-2018-08-29-14.14}
         EDX_ARCHIVE_URL: ${EDX_ARCHIVE_URL:-https://github.com/edx/edx-platform/archive/release-2018-08-29-14.14.tar.gz}
     image: edxapp:${EDX_RELEASE:-master}-${FLAVOR:-bare}-dev
-    env_file: env.d/development
+    env_file: 
+      - env.d/development
+      - env.d/${REDIS_SERVICE:-redis}
+    environment:
+      SERVICE_VARIANT: lms
+      DJANGO_SETTINGS_MODULE: lms.envs.fun.docker_run
     ports:
       - "8072:8000"
     volumes:
@@ -85,11 +113,13 @@ services:
       - mysql
       - mongodb
       - memcached
-      - redis
+      - ${REDIS_SERVICE:-redis}
 
   cms:
     image: edxapp:${EDX_RELEASE:-master}-${FLAVOR:-bare}
-    env_file: env.d/development
+    env_file: 
+      - env.d/development
+      - env.d/${REDIS_SERVICE:-redis}
     environment:
       SERVICE_VARIANT: cms
       DJANGO_SETTINGS_MODULE: cms.envs.fun.docker_run
@@ -104,7 +134,9 @@ services:
 
   cms-dev:
     image: edxapp:${EDX_RELEASE:-master}-${FLAVOR:-bare}-dev
-    env_file: env.d/development
+    env_file: 
+      - env.d/development
+      - env.d/${REDIS_SERVICE:-redis}
     ports:
       - "8082:8000"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     image: memcached:1.4
 
   redis:
-    image: redis:4
+      image: redis:4.0.10-alpine
 
   redis-master:
     image: redis:4.0.10-alpine

--- a/env.d/redis
+++ b/env.d/redis
@@ -1,0 +1,4 @@
+# Add Redis service environment variables in this file
+# 
+# PLEASE DO NOT REMOVE THIS FILE
+# It is required for docker-compose environment description

--- a/env.d/redis-sentinel
+++ b/env.d/redis-sentinel
@@ -1,0 +1,9 @@
+# Celery settings
+CELERY_BROKER_TRANSPORT=sentinel
+CELERY_BROKER_HOST=redis-sentinel
+CELERY_BROKER_PORT=26379
+BROKER_TRANSPORT_OPTIONS: {"master_name": "mymaster"}
+
+# Session in redis
+SESSION_REDIS_SENTINEL_LIST=[["redis-sentinel", 26379]]
+SESSION_REDIS_SENTINEL_MASTER_ALIAS=mymaster

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-1.3.0] - 2019-12-02
+
 ### Added
 
 - Add missing support for redis sentinel
@@ -37,7 +39,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.2.1...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.0...HEAD
+[dogwood.3-fun-1.3.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.2.1...dogwood.3-fun-1.3.0
 [dogwood.3-fun-1.2.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.2.0...dogwood.3-fun-1.2.1
 [dogwood.3-fun-1.2.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.1.0...dogwood.3-fun-1.2.0
 [dogwood.3-fun-1.1.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.0.0...dogwood.3-fun-1.1.0

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Added
+
+- Add missing support for redis sentinel
+
 ## [dogwood.3-fun-1.2.1] - 2019-11-29
 
 ### Fixed

--- a/releases/dogwood/3/fun/config/cms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/cms/docker_run_production.py
@@ -14,6 +14,7 @@ import json
 import os
 import platform
 
+from celery_redis_sentinel import register
 from lms.envs.fun.utils import Configuration
 from openedx.core.lib.logsettings import get_logger_config
 from path import Path as path
@@ -169,6 +170,32 @@ SESSION_COOKIE_SECURE = config(
 SESSION_SAVE_EVERY_REQUEST = config(
     "SESSION_SAVE_EVERY_REQUEST", default=SESSION_SAVE_EVERY_REQUEST, formatter=bool
 )
+
+# Configuration to use session with redis
+# To use redis, change SESSION_ENGINE to "redis_sessions.session"
+SESSION_REDIS_HOST = config("SESSION_REDIS_HOST", default="redis")
+SESSION_REDIS_PORT = config("SESSION_REDIS_HOST", default=6379, formatter=int)
+SESSION_REDIS_DB = config("SESSION_REDIS_DB", default=1, formatter=int)
+SESSION_REDIS_PASSWORD = config("SESSION_REDIS_PASSWORD", default=None)
+SESSION_REDIS_PREFIX = config("SESSION_REDIS_PREFIX", default="session")
+SESSION_REDIS_SOCKET_TIMEOUT = config("SESSION_REDIS_SOCKET_TIMEOUT", default=1, formatter=int)
+SESSION_REDIS_RETRY_ON_TIMEOUT = config("SESSION_REDIS_RETRY_ON_TIMEOUT", default=False, formatter=bool)
+
+SESSION_REDIS = config(
+    "SESSION_REDIS",
+    default={
+        "host": SESSION_REDIS_HOST,
+        "port": SESSION_REDIS_PORT,
+        "db": SESSION_REDIS_DB,  # db 0 is used for Celery Broker
+        "password": SESSION_REDIS_PASSWORD,
+        "prefix": SESSION_REDIS_PREFIX,
+        "socket_timeout": SESSION_REDIS_SOCKET_TIMEOUT,
+        "retry_on_timeout": SESSION_REDIS_RETRY_ON_TIMEOUT,
+    },
+    formatter=json.loads,
+)
+SESSION_REDIS_SENTINEL_LIST = config("SESSION_REDIS_SENTINEL_LIST", default=None, formatter=json.loads)
+SESSION_REDIS_SENTINEL_MASTER_ALIAS = config("SESSION_REDIS_SENTINEL_MASTER_ALIAS", default=None)
 
 # social sharing settings
 SOCIAL_SHARING_SETTINGS = config(
@@ -442,12 +469,17 @@ DATADOG = config("DATADOG", default={}, formatter=json.loads)
 DATADOG["api_key"] = config("DATADOG_API", default=None)
 
 # Celery Broker
+# For redis sentinel use the transport redis-sentinel
 CELERY_BROKER_TRANSPORT = config("CELERY_BROKER_TRANSPORT", default="redis")
 CELERY_BROKER_USER = config("CELERY_BROKER_USER", default="")
 CELERY_BROKER_PASSWORD = config("CELERY_BROKER_PASSWORD", default="")
 CELERY_BROKER_HOST = config("CELERY_BROKER_HOST", default="redis")
 CELERY_BROKER_PORT = config("CELERY_BROKER_PORT", default=6379, formatter=int)
 CELERY_BROKER_VHOST = config("CELERY_BROKER_VHOST", default=0, formatter=int)
+
+if CELERY_BROKER_TRANSPORT == "redis-sentinel":
+    # register redis sentinel schema in celery
+    register()
 
 BROKER_URL = "{transport}://{user}:{password}@{host}:{port}/{vhost}".format(
     transport=CELERY_BROKER_TRANSPORT,
@@ -457,6 +489,9 @@ BROKER_URL = "{transport}://{user}:{password}@{host}:{port}/{vhost}".format(
     port=CELERY_BROKER_PORT,
     vhost=CELERY_BROKER_VHOST,
 )
+# To use redis-sentinel, refer to the documenation here 
+# https://celery-redis-sentinel.readthedocs.io/en/latest/
+BROKER_TRANSPORT_OPTIONS = config("BROKER_TRANSPORT_OPTIONS", default={}, formatter=json.loads)
 
 # Event tracking
 TRACKING_BACKENDS.update(config("TRACKING_BACKENDS", default={}, formatter=json.loads))

--- a/releases/dogwood/3/fun/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/lms/docker_run_production.py
@@ -22,6 +22,7 @@ import json
 import os
 import platform
 
+from celery_redis_sentinel import register
 from openedx.core.lib.logsettings import get_logger_config
 from path import Path as path
 from xmodule.modulestore.modulestore_settings import (
@@ -180,6 +181,32 @@ SESSION_COOKIE_SECURE = config(
 SESSION_SAVE_EVERY_REQUEST = config(
     "SESSION_SAVE_EVERY_REQUEST", default=SESSION_SAVE_EVERY_REQUEST, formatter=bool
 )
+
+# Configuration to use session with redis
+# To use redis, change SESSION_ENGINE to "redis_sessions.session"
+SESSION_REDIS_HOST = config("SESSION_REDIS_HOST", default="redis")
+SESSION_REDIS_PORT = config("SESSION_REDIS_HOST", default=6379, formatter=int)
+SESSION_REDIS_DB = config("SESSION_REDIS_DB", default=1, formatter=int)
+SESSION_REDIS_PASSWORD = config("SESSION_REDIS_PASSWORD", default=None)
+SESSION_REDIS_PREFIX = config("SESSION_REDIS_PREFIX", default="session")
+SESSION_REDIS_SOCKET_TIMEOUT = config("SESSION_REDIS_SOCKET_TIMEOUT", default=1, formatter=int)
+SESSION_REDIS_RETRY_ON_TIMEOUT = config("SESSION_REDIS_RETRY_ON_TIMEOUT", default=False, formatter=bool)
+
+SESSION_REDIS = config(
+    "SESSION_REDIS",
+    default={
+        "host": SESSION_REDIS_HOST,
+        "port": SESSION_REDIS_PORT,
+        "db": SESSION_REDIS_DB,  # db 0 is used for Celery Broker
+        "password": SESSION_REDIS_PASSWORD,
+        "prefix": SESSION_REDIS_PREFIX,
+        "socket_timeout": SESSION_REDIS_SOCKET_TIMEOUT,
+        "retry_on_timeout": SESSION_REDIS_RETRY_ON_TIMEOUT,
+    },
+    formatter=json.loads,
+)
+SESSION_REDIS_SENTINEL_LIST = config("SESSION_REDIS_SENTINEL_LIST", default=None, formatter=json.loads)
+SESSION_REDIS_SENTINEL_MASTER_ALIAS = config("SESSION_REDIS_SENTINEL_MASTER_ALIAS", default=None)
 
 REGISTRATION_EXTRA_FIELDS = config(
     "REGISTRATION_EXTRA_FIELDS", default=REGISTRATION_EXTRA_FIELDS, formatter=json.loads
@@ -694,12 +721,17 @@ ZENDESK_API_KEY = config("ZENDESK_API_KEY", default=None)
 EDX_API_KEY = config("EDX_API_KEY", default=None)
 
 # Celery Broker
+# For redis sentinel use the redis-sentinel transport
 CELERY_BROKER_TRANSPORT = config("CELERY_BROKER_TRANSPORT", default="redis")
 CELERY_BROKER_USER = config("CELERY_BROKER_USER", default="")
 CELERY_BROKER_PASSWORD = config("CELERY_BROKER_PASSWORD", default="")
 CELERY_BROKER_HOST = config("CELERY_BROKER_HOST", default="redis")
 CELERY_BROKER_PORT = config("CELERY_BROKER_PORT", default=6379, formatter=int)
 CELERY_BROKER_VHOST = config("CELERY_BROKER_VHOST", default=0, formatter=int)
+
+if CELERY_BROKER_TRANSPORT == "redis-sentinel":
+    # register redis sentinel schema in celery
+    register()
 
 BROKER_URL = "{transport}://{user}:{password}@{host}:{port}/{vhost}".format(
     transport=CELERY_BROKER_TRANSPORT,
@@ -709,6 +741,9 @@ BROKER_URL = "{transport}://{user}:{password}@{host}:{port}/{vhost}".format(
     port=CELERY_BROKER_PORT,
     vhost=CELERY_BROKER_VHOST,
 )
+# To use redis-sentinel, refer to the documenation here 
+# https://celery-redis-sentinel.readthedocs.io/en/latest/
+BROKER_TRANSPORT_OPTIONS = config("BROKER_TRANSPORT_OPTIONS", default={}, formatter=json.loads)
 
 # upload limits
 STUDENT_FILEUPLOAD_MAX_SIZE = config(

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -19,3 +19,4 @@ xblock-utils2==0.3.0
 # ==== third-party apps ====
 raven==6.9.0
 django-redis-sessions==0.6.1
+celery-redis-sentinel==0.3.0

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Added
+
+- Add missing support for redis sentinel
+
 ## [hawthorn.1-oee-2.11.0] - 2019-11-22
 
 ### Added

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [hawthorn.1-oee-2.12.0] - 2019-12-02
+
 ### Added
 
 - Add missing support for redis sentinel
@@ -197,7 +199,8 @@ First release of OpenEdx extended.
 
 - Add a configurable LTI consumer xblock
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-2.11.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-2.12.0...HEAD
+[hawthorn.1-oee-2.12.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-2.11.0...hawthorn.1-oee-2.12.0
 [hawthorn.1-oee-2.11.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-2.10.1...hawthorn.1-oee-2.11.0
 [hawthorn.1-oee-2.10.1]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-2.10.0...hawthorn.1-oee-2.10.1
 [hawthorn.1-oee-2.10.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-2.9.1...hawthorn.1-oee-2.10.0

--- a/releases/hawthorn/1/oee/config/cms/docker_run_production.py
+++ b/releases/hawthorn/1/oee/config/cms/docker_run_production.py
@@ -174,19 +174,29 @@ SESSION_SAVE_EVERY_REQUEST = config(
     "SESSION_SAVE_EVERY_REQUEST", default=SESSION_SAVE_EVERY_REQUEST, formatter=bool
 )
 
+SESSION_REDIS_HOST = config("SESSION_REDIS_HOST", default="redis")
+SESSION_REDIS_PORT = config("SESSION_REDIS_HOST", default=6379, formatter=int)
+SESSION_REDIS_DB = config("SESSION_REDIS_DB", default=1, formatter=int)
+SESSION_REDIS_PASSWORD = config("SESSION_REDIS_PASSWORD", default=None)
+SESSION_REDIS_PREFIX = config("SESSION_REDIS_PREFIX", default="session")
+SESSION_REDIS_SOCKET_TIMEOUT = config("SESSION_REDIS_SOCKET_TIMEOUT", default=1, formatter=int)
+SESSION_REDIS_RETRY_ON_TIMEOUT = config("SESSION_REDIS_RETRY_ON_TIMEOUT", default=False, formatter=bool)
+
 SESSION_REDIS = config(
     "SESSION_REDIS",
     default={
-        "host": "redis",
-        "port": 6379,
-        "db": 1,  # db 0 is used for Celery Broker
-        "password": "",
-        "prefix": "session",
-        "socket_timeout": 1,
-        "retry_on_timeout": False,
+        "host": SESSION_REDIS_HOST,
+        "port": SESSION_REDIS_PORT,
+        "db": SESSION_REDIS_DB,  # db 0 is used for Celery Broker
+        "password": SESSION_REDIS_PASSWORD,
+        "prefix": SESSION_REDIS_PREFIX,
+        "socket_timeout": SESSION_REDIS_SOCKET_TIMEOUT,
+        "retry_on_timeout": SESSION_REDIS_RETRY_ON_TIMEOUT,
     },
     formatter=json.loads,
 )
+SESSION_REDIS_SENTINEL_LIST = config("SESSION_REDIS_SENTINEL_LIST", default=None, formatter=json.loads)
+SESSION_REDIS_SENTINEL_MASTER_ALIAS = config("SESSION_REDIS_SENTINEL_MASTER_ALIAS", default=None)
 
 # social sharing settings
 SOCIAL_SHARING_SETTINGS = config(
@@ -530,6 +540,7 @@ BROKER_URL = "{transport}://{user}:{password}@{host}:{port}/{vhost}".format(
     vhost=CELERY_BROKER_VHOST,
 )
 BROKER_USE_SSL = config("CELERY_BROKER_USE_SSL", default=False, formatter=bool)
+BROKER_TRANSPORT_OPTIONS = config("BROKER_TRANSPORT_OPTIONS", default={}, formatter=json.loads)
 
 # Message expiry time in seconds
 CELERY_EVENT_QUEUE_TTL = config("CELERY_EVENT_QUEUE_TTL", default=None, formatter=int)

--- a/releases/hawthorn/1/oee/config/lms/docker_run_production.py
+++ b/releases/hawthorn/1/oee/config/lms/docker_run_production.py
@@ -35,19 +35,29 @@ DEFAULT_TEMPLATE_ENGINE["OPTIONS"]["debug"] = False
 
 SESSION_ENGINE = config("SESSION_ENGINE", default="redis_sessions.session")
 
+SESSION_REDIS_HOST = config("SESSION_REDIS_HOST", default="redis")
+SESSION_REDIS_PORT = config("SESSION_REDIS_HOST", default=6379, formatter=int)
+SESSION_REDIS_DB = config("SESSION_REDIS_DB", default=1, formatter=int)
+SESSION_REDIS_PASSWORD = config("SESSION_REDIS_PASSWORD", default=None)
+SESSION_REDIS_PREFIX = config("SESSION_REDIS_PREFIX", default="session")
+SESSION_REDIS_SOCKET_TIMEOUT = config("SESSION_REDIS_SOCKET_TIMEOUT", default=1, formatter=int)
+SESSION_REDIS_RETRY_ON_TIMEOUT = config("SESSION_REDIS_RETRY_ON_TIMEOUT", default=False, formatter=bool)
+
 SESSION_REDIS = config(
     "SESSION_REDIS",
     default={
-        "host": "redis",
-        "port": 6379,
-        "db": 1,  # db 0 is used for Celery Broker
-        "password": "",
-        "prefix": "session",
-        "socket_timeout": 1,
-        "retry_on_timeout": False,
+        "host": SESSION_REDIS_HOST,
+        "port": SESSION_REDIS_PORT,
+        "db": SESSION_REDIS_DB,  # db 0 is used for Celery Broker
+        "password": SESSION_REDIS_PASSWORD,
+        "prefix": SESSION_REDIS_PREFIX,
+        "socket_timeout": SESSION_REDIS_SOCKET_TIMEOUT,
+        "retry_on_timeout": SESSION_REDIS_RETRY_ON_TIMEOUT,
     },
     formatter=json.loads,
 )
+SESSION_REDIS_SENTINEL_LIST = config("SESSION_REDIS_SENTINEL_LIST", default=None, formatter=json.loads)
+SESSION_REDIS_SENTINEL_MASTER_ALIAS = config("SESSION_REDIS_SENTINEL_MASTER_ALIAS", default=None)
 
 # Override edX LMS urls with Fonzie's
 ROOT_URLCONF = "lms.root_urls"
@@ -779,6 +789,7 @@ BROKER_URL = "{transport}://{user}:{password}@{host}:{port}/{vhost}".format(
     vhost=CELERY_BROKER_VHOST,
 )
 BROKER_USE_SSL = config("CELERY_BROKER_USE_SSL", default=False, formatter=bool)
+BROKER_TRANSPORT_OPTIONS = config("BROKER_TRANSPORT_OPTIONS", default={}, formatter=json.loads)
 
 # Block Structures
 BLOCK_STRUCTURES_SETTINGS = config(

--- a/releases/hawthorn/1/oee/requirements.txt
+++ b/releases/hawthorn/1/oee/requirements.txt
@@ -9,3 +9,4 @@ configurable_lti_consumer-xblock==1.2.3
 # ==== third-party apps ====
 raven==6.9.0
 django-redis-sessions==0.6.1
+celery==4.3.0


### PR DESCRIPTION
## Purpose

On our flavors we want to use redis sentinel with celery and to store sessions. The version of celery does not support redis-sentinel. 

## Proposal

- [x] on hawtorn we upgraded the version of celery to version 4.3.0, the support of sentinel was added on this version.
- [x] on dogwood and eucalyptus we added the celery-redis-sentinel on our fork and we added needed settings to use it.
