### PR TITLE
Fix CI job names and execution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ build_steps: &build_steps
     - run:
         name: Build production image
         command: |
-          source releases/${CIRCLE_JOB}/activate
+          source $(bin/ci activate_path)
           make build
 
     # Development image build. It uses the "development" Dockerfile target
@@ -38,14 +38,14 @@ build_steps: &build_steps
     - run:
         name: Build development image
         command: |
-          source releases/${CIRCLE_JOB}/activate
+          source $(bin/ci activate_path)
           make dev-build
 
     # Bootstrap
     - run:
         name: Bootstrap the CMS & LMS
         command: |
-          source releases/${CIRCLE_JOB}/activate
+          source $(bin/ci activate_path)
           make tree
           make migrate
           make run
@@ -55,7 +55,7 @@ build_steps: &build_steps
     - run:
         name: Check production build
         command: |
-          source releases/${CIRCLE_JOB}/activate
+          source $(bin/ci activate_path)
           make test-cms
           make test-lms
 
@@ -63,7 +63,7 @@ build_steps: &build_steps
     - run:
         name: Import demonstration course
         command: |
-          source releases/${CIRCLE_JOB}/activate
+          source $(bin/ci activate_path)
           make demo-course
 
 # List openedx-docker jobs that will be integrated and executed in a workflow
@@ -125,25 +125,25 @@ jobs:
   # Build jobs
   #
   # Note that the job name should match the EDX_RELEASE value
-  master/bare:
+  master-bare:
     <<: [*defaults, *build_steps]
 
-  dogwood/3/bare:
+  dogwood.3-bare:
     <<: [*defaults, *build_steps]
 
-  dogwood/3/fun:
+  dogwood.3-fun:
     <<: [*defaults, *build_steps]
 
-  eucalyptus/3/bare:
+  eucalyptus.3-bare:
     <<: [*defaults, *build_steps]
 
-  eucalyptus/3/wb:
+  eucalyptus.3-wb:
     <<: [*defaults, *build_steps]
 
-  hawthorn/1/bare:
+  hawthorn.1-bare:
     <<: [*defaults, *build_steps]
 
-  hawthorn/1/oee:
+  hawthorn.1-oee:
     <<: [*defaults, *build_steps]
 
   # Hub job
@@ -218,31 +218,31 @@ workflows:
               ignore: /.*/
 
       # Build jobs
-      - master/bare:
+      - master-bare:
           filters:
             tags:
               ignore: /.*/
-      - dogwood/3/bare:
+      - dogwood.3-bare:
           filters:
             tags:
               ignore: /.*/
-      - dogwood/3/fun:
+      - dogwood.3-fun:
           filters:
             tags:
               ignore: /.*/
-      - eucalyptus/3/bare:
+      - eucalyptus.3-bare:
           filters:
             tags:
               ignore: /.*/
-      - eucalyptus/3/wb:
+      - eucalyptus.3-wb:
           filters:
             tags:
               ignore: /.*/
-      - hawthorn/1/oee:
+      - hawthorn.1-oee:
           filters:
             tags:
               ignore: /.*/
-      - hawthorn/1/bare:
+      - hawthorn.1-bare:
           filters:
             tags:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,11 @@ build_steps: &build_steps
     # Checkout openedx-docker sources
     - checkout
 
+    # Skip release build & testing if changes are not targeting it
+    - run:
+        name: Check if changes are targeting the current release
+        command: bin/ci checkpoint
+
     # Install a recent docker-compose release
     - run:
         name: Upgrade docker-compose

--- a/bin/ci
+++ b/bin/ci
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eo pipefail
+
 # usage: display usage with the appropriate exit code
 #
 # usage: usage [EXIT_CODE]
@@ -14,6 +16,8 @@ function usage(){
 Available commands:
 
   activate_path    display CIRCLE_TAG (or CIRCLE_JOB) release activate script path
+  checkpoint       skip release job if changes are not targeting the current release
+  get_changes      get a list of changed files in the current branch compared to master
 "
 
     # shellcheck disable=SC2086
@@ -50,6 +54,30 @@ function activate_path(){
   )
 
   echo "releases/${release}/activate"
+}
+
+# Skip release job if changes are not targeting the current release
+function checkpoint(){
+
+  changes=$(get_changes)
+
+  if echo "${changes}" | grep -v "releases/" > /dev/null ; then
+    (>&2 echo "Current work scope is global, all releases should build.")
+    exit 0
+  fi
+
+  release_path=$(activate_path | sed -E 's|/activate$||')
+
+  if ! echo "${changes}" | grep "${release_path}" > /dev/null ; then
+    (>&2 echo "Skipping release (out of scope).")
+    circleci-agent step halt
+  fi
+}
+
+# Get a list of changed files in the current branch
+function get_changes() {
+
+    git whatchanged --name-only --pretty="" "master..HEAD" | sort -u
 }
 
 

--- a/bin/ci
+++ b/bin/ci
@@ -13,34 +13,38 @@ function usage(){
 
 Available commands:
 
-  activate_path       display CIRCLE_TAG release activate script path
+  activate_path    display CIRCLE_TAG (or CIRCLE_JOB) release activate script path
 "
 
     # shellcheck disable=SC2086
     exit ${exit_code}
 }
 
-# Get active release activation path given the CIRCLE_TAG environment variable
+# Get active release activation path given the CIRCLE_TAG or CIRCLE_JOB
+# environment variable. If both are defined the CIRCLE_TAG variable will
+# prevail.
 function activate_path(){
 
+  declare reference
   declare release
 
-  if [[ -z ${CIRCLE_TAG} ]]; then
-    (>&2 echo "CIRCLE_TAG environment variable is not defined!")
+  reference=${CIRCLE_TAG:-${CIRCLE_JOB}}
+  if [[ -z ${reference} ]]; then
+    (>&2 echo "CIRCLE_TAG or CIRCLE_JOB environment variable should be defined!")
     exit 20
   fi
 
-  # We need to convert the CIRCLE_TAG (_e.g._ something like hawthorn.1-1.0.3)
-  # to a flavored release path (e.g. something like hawthorn/1/bare for the
-  # later CIRCLE_TAG example). In the following, we have a three-steps pipeline
+  # We need to convert the reference (_e.g._ something like hawthorn.1-1.0.3 or dogwood.3-fun)
+  # to a flavored release path (e.g. something like hawthorn/1/bare or dogwood/3/fun for the
+  # later examples). In the following, we have a three-steps pipeline
   # to do so: i. get the release name, number and optionally a flavor from the
-  # CIRCLE_TAG, ii. in case of empty release number and/or flavor, our sed
+  # reference, ii. in case of empty release number and/or flavor, our sed
   # substitution will generate duplicated slashes that should be fixed, and
   # iii.  the default flavor (empty third group from our regular expression)
   # should be named "bare".
   release=$(\
-    echo "${CIRCLE_TAG}" | \
-    sed -E 's|^([a-z]*)\.?([0-9]*)-?([a-z]*)-?([0-9.]+)$|\1/\2/\3|g' | \
+    echo "${reference}" | \
+    sed -E 's|^([a-z]*)\.?([0-9]*)-?([a-z]*)?(-[0-9.]+)?$|\1/\2/\3|g' | \
     sed -E 's|//|/|g' | \
     sed -E 's|/$|/bare|g'
   )


### PR DESCRIPTION
## Purpose

This project's CI needs a little bit more attention to be more efficient.

## Proposal

- [x] Avoid using slashes in job names so that CircleCI reports jobs properly in GitHub's pull requests
- [x] Avoid running all releases build/bootstrap when a PR only targets a single/few release(s)