### PR TITLE
Fix SESSION_REDIS_PORT setting definition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ EDX_RELEASE_REF           ?= release-2018-08-29-14.14
 EDX_DEMO_RELEASE_REF      ?= master
 EDX_DEMO_ARCHIVE_URL      ?= https://github.com/edx/edx-demo-course/archive/$(EDX_DEMO_RELEASE_REF).tar.gz
 
+# Redis service used
+REDIS_SERVICE             ?= redis
+
 # Get local user ids
 DOCKER_UID              = $(shell id -u)
 DOCKER_GID              = $(shell id -g)
@@ -18,8 +21,6 @@ COMPOSE          = \
   DOCKER_UID=$(DOCKER_UID) \
   DOCKER_GID=$(DOCKER_GID) \
   FLAVORED_EDX_RELEASE_PATH="$(FLAVORED_EDX_RELEASE_PATH)" \
-  EDX_RELEASE_REF="$(EDX_RELEASE_REF)" \
-  EDX_ARCHIVE_URL="$(EDX_ARCHIVE_URL)" \
   docker-compose
 COMPOSE_RUN      = $(COMPOSE) run --rm -e HOME="/tmp"
 COMPOSE_EXEC     = $(COMPOSE) exec
@@ -252,6 +253,7 @@ info:  ## get activated release info
 	@echo -e "* EDX_ARCHIVE_URL            : $(COLOR_INFO)$(EDX_ARCHIVE_URL)$(COLOR_RESET)"
 	@echo -e "* EDX_DEMO_RELEASE_REF       : $(COLOR_INFO)$(EDX_DEMO_RELEASE_REF)$(COLOR_RESET)"
 	@echo -e "* EDX_DEMO_ARCHIVE_URL       : $(COLOR_INFO)$(EDX_DEMO_ARCHIVE_URL)$(COLOR_RESET)"
+	@echo -e "* REDIS_SERVICE              : $(COLOR_INFO)$(REDIS_SERVICE)$(COLOR_RESET)"
 	@echo -e ""
 .PHONY: info
 

--- a/README.md
+++ b/README.md
@@ -49,17 +49,17 @@ including database services which in production are not run on Docker. See the
 
 Concerning Redis, it is possible to run a single redis instance (the default choice)
 or to run redis with sentinel to simulate a HA instance. 
-To use Redis sentinel you have to set the `REDIS_TARGET_INSTANCE` environment variable
+To use Redis sentinel you have to set the `REDIS_SERVICE` environment variable
 to `redis-sentinel`:
 
 ```bash
-$ export REDIS_TARGET_INSTANCE=redis-sentinel
+$ export REDIS_SERVICE=redis-sentinel
 ```
 
 To switch back to the single redis instance, unset this environment variable:
 
 ```bash
-$ unset REDIS_TARGET_INSTANCE
+$ unset REDIS_SERVICE
 ```
 
 ## Prerequisite

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,12 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-1.3.1] - 2019-12-04
+
+### Fixed
+
+- Fix SESSION_REDIS_PORT setting definition
+
 ## [dogwood.3-fun-1.3.0] - 2019-12-02
 
 ### Added
@@ -39,7 +45,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.1...HEAD
+[dogwood.3-fun-1.3.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.0...dogwood.3-fun-1.3.1
 [dogwood.3-fun-1.3.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.2.1...dogwood.3-fun-1.3.0
 [dogwood.3-fun-1.2.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.2.0...dogwood.3-fun-1.2.1
 [dogwood.3-fun-1.2.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.1.0...dogwood.3-fun-1.2.0

--- a/releases/dogwood/3/fun/config/cms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/cms/docker_run_production.py
@@ -174,7 +174,7 @@ SESSION_SAVE_EVERY_REQUEST = config(
 # Configuration to use session with redis
 # To use redis, change SESSION_ENGINE to "redis_sessions.session"
 SESSION_REDIS_HOST = config("SESSION_REDIS_HOST", default="redis")
-SESSION_REDIS_PORT = config("SESSION_REDIS_HOST", default=6379, formatter=int)
+SESSION_REDIS_PORT = config("SESSION_REDIS_PORT", default=6379, formatter=int)
 SESSION_REDIS_DB = config("SESSION_REDIS_DB", default=1, formatter=int)
 SESSION_REDIS_PASSWORD = config("SESSION_REDIS_PASSWORD", default=None)
 SESSION_REDIS_PREFIX = config("SESSION_REDIS_PREFIX", default="session")

--- a/releases/dogwood/3/fun/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/lms/docker_run_production.py
@@ -185,7 +185,7 @@ SESSION_SAVE_EVERY_REQUEST = config(
 # Configuration to use session with redis
 # To use redis, change SESSION_ENGINE to "redis_sessions.session"
 SESSION_REDIS_HOST = config("SESSION_REDIS_HOST", default="redis")
-SESSION_REDIS_PORT = config("SESSION_REDIS_HOST", default=6379, formatter=int)
+SESSION_REDIS_PORT = config("SESSION_REDIS_PORT", default=6379, formatter=int)
 SESSION_REDIS_DB = config("SESSION_REDIS_DB", default=1, formatter=int)
 SESSION_REDIS_PASSWORD = config("SESSION_REDIS_PASSWORD", default=None)
 SESSION_REDIS_PREFIX = config("SESSION_REDIS_PREFIX", default="session")

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,12 @@ release.
 
 ## [Unreleased]
 
+## [eucalyptus.3-1.0.1-wb] - 2019-12-04
+
+### Fixed
+
+- Fix SESSION_REDIS_PORT setting definition
+
 ## [eucalyptus.3-1.0.0-wb] - 2019-11-14
 
 ### Added
@@ -17,5 +23,6 @@ release.
 - Set replicaSet and read_preference in mongodb connection
 - Add missing support for redis sentinel
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.0-wb...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.1-wb...HEAD
+[eucalyptus.3-1.0.1-wb]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.0-wb...eucalyptus.3-1.0.1-wb
 [eucalyptus.3-1.0.0-wb]: https://github.com/openfun/openedx-docker/releases/tag/eucalyptus.3-1.0.0-wb

--- a/releases/eucalyptus/3/wb/config/cms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/cms/docker_run_production.py
@@ -193,7 +193,7 @@ SESSION_SAVE_EVERY_REQUEST = config(
 # Configuration to use session with redis
 # To use redis, change SESSION_ENGINE with value redis_sessions.session
 SESSION_REDIS_HOST = config("SESSION_REDIS_HOST", default="redis")
-SESSION_REDIS_PORT = config("SESSION_REDIS_HOST", default=6379, formatter=int)
+SESSION_REDIS_PORT = config("SESSION_REDIS_PORT", default=6379, formatter=int)
 SESSION_REDIS_DB = config("SESSION_REDIS_DB", default=1, formatter=int)
 SESSION_REDIS_PASSWORD = config("SESSION_REDIS_PASSWORD", default=None)
 SESSION_REDIS_PREFIX = config("SESSION_REDIS_PREFIX", default="session")

--- a/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
@@ -199,7 +199,7 @@ SESSION_SAVE_EVERY_REQUEST = config(
 # Configuration to use session with redis
 # To use redis, change SESSION_ENGINE with value redis_sessions.session
 SESSION_REDIS_HOST = config("SESSION_REDIS_HOST", default="redis")
-SESSION_REDIS_PORT = config("SESSION_REDIS_HOST", default=6379, formatter=int)
+SESSION_REDIS_PORT = config("SESSION_REDIS_PORT", default=6379, formatter=int)
 SESSION_REDIS_DB = config("SESSION_REDIS_DB", default=1, formatter=int)
 SESSION_REDIS_PASSWORD = config("SESSION_REDIS_PASSWORD", default=None)
 SESSION_REDIS_PREFIX = config("SESSION_REDIS_PREFIX", default="session")

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -9,6 +9,12 @@ release.
 
 ## [Unreleased]
 
+## [hawthorn.1-oee-2.12.1] - 2019-12-04
+
+### Fixed
+
+- Fix SESSION_REDIS_PORT setting definition
+
 ## [hawthorn.1-oee-2.12.0] - 2019-12-02
 
 ### Added
@@ -199,7 +205,8 @@ First release of OpenEdx extended.
 
 - Add a configurable LTI consumer xblock
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-2.12.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-2.12.1...HEAD
+[hawthorn.1-oee-2.12.1]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-2.12.0...hawthorn.1-oee-2.12.1
 [hawthorn.1-oee-2.12.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-2.11.0...hawthorn.1-oee-2.12.0
 [hawthorn.1-oee-2.11.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-2.10.1...hawthorn.1-oee-2.11.0
 [hawthorn.1-oee-2.10.1]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-2.10.0...hawthorn.1-oee-2.10.1

--- a/releases/hawthorn/1/oee/config/cms/docker_run_production.py
+++ b/releases/hawthorn/1/oee/config/cms/docker_run_production.py
@@ -175,7 +175,7 @@ SESSION_SAVE_EVERY_REQUEST = config(
 )
 
 SESSION_REDIS_HOST = config("SESSION_REDIS_HOST", default="redis")
-SESSION_REDIS_PORT = config("SESSION_REDIS_HOST", default=6379, formatter=int)
+SESSION_REDIS_PORT = config("SESSION_REDIS_PORT", default=6379, formatter=int)
 SESSION_REDIS_DB = config("SESSION_REDIS_DB", default=1, formatter=int)
 SESSION_REDIS_PASSWORD = config("SESSION_REDIS_PASSWORD", default=None)
 SESSION_REDIS_PREFIX = config("SESSION_REDIS_PREFIX", default="session")

--- a/releases/hawthorn/1/oee/config/lms/docker_run_production.py
+++ b/releases/hawthorn/1/oee/config/lms/docker_run_production.py
@@ -36,7 +36,7 @@ DEFAULT_TEMPLATE_ENGINE["OPTIONS"]["debug"] = False
 SESSION_ENGINE = config("SESSION_ENGINE", default="redis_sessions.session")
 
 SESSION_REDIS_HOST = config("SESSION_REDIS_HOST", default="redis")
-SESSION_REDIS_PORT = config("SESSION_REDIS_HOST", default=6379, formatter=int)
+SESSION_REDIS_PORT = config("SESSION_REDIS_PORT", default=6379, formatter=int)
 SESSION_REDIS_DB = config("SESSION_REDIS_DB", default=1, formatter=int)
 SESSION_REDIS_PASSWORD = config("SESSION_REDIS_PASSWORD", default=None)
 SESSION_REDIS_PREFIX = config("SESSION_REDIS_PREFIX", default="session")


### PR DESCRIPTION
## Purpose

In PR fixing support for redis sentinel, a copy/pasta typo was nade in the SESSION_REDIS_PORT setting definition for all flavors supporting redis sentinel.
Also, a typo was made in the Readme file, the old variable name used to select redis service was kept instead of using the new one, `REDIS_SERVICE`.

## Proposal

- [x] fix SESSION_REDIS_PORT setting definition in all flavors using it
- [x] fix readme
- [x] display redis service info in `make info` task