### PR TITLE
🐛(circle) fix bin/ci checkpoint

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -77,7 +77,7 @@ function checkpoint(){
 # Get a list of changed files in the current branch
 function get_changes() {
 
-    git whatchanged --name-only --pretty="" "master..HEAD" | sort -u
+    git whatchanged --name-only --pretty="" "origin/master..HEAD" | sort -u
 }
 
 


### PR DESCRIPTION
## Purpose

The `master` Git reference does not exist after a job checkout in CircleCI. Hence, we don't properly detect current branch changes.

## Proposal

- [x] use `origin/master` reference to compare to `HEAD`
