### PR TITLE
♻️(hawthorn/1/oee) use celery-redis-sentinel to connect to sentinel

### DIFF
--- a/env.d/redis-sentinel
+++ b/env.d/redis-sentinel
@@ -1,8 +1,8 @@
 # Celery settings
-CELERY_BROKER_TRANSPORT=sentinel
+CELERY_BROKER_TRANSPORT=redis-sentinel
 CELERY_BROKER_HOST=redis-sentinel
 CELERY_BROKER_PORT=26379
-BROKER_TRANSPORT_OPTIONS: {"master_name": "mymaster"}
+BROKER_TRANSPORT_OPTIONS={"sentinel":[["redis-sentinel",26379]],"service_name":"mymaster"}
 
 # Session in redis
 SESSION_REDIS_SENTINEL_LIST=[["redis-sentinel", 26379]]

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [hawthorn.1-oee-2.12.2] - 2019-12-05
+
 ### Fixed
 
 - Use the plugin celery-redis-sentinel to introduce the support of
@@ -210,7 +212,8 @@ First release of OpenEdx extended.
 
 - Add a configurable LTI consumer xblock
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-2.12.1...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-2.12.2...HEAD
+[hawthorn.1-oee-2.12.2]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-2.12.1...hawthorn.1-oee-2.12.2
 [hawthorn.1-oee-2.12.1]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-2.12.0...hawthorn.1-oee-2.12.1
 [hawthorn.1-oee-2.12.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-2.11.0...hawthorn.1-oee-2.12.0
 [hawthorn.1-oee-2.11.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-2.10.1...hawthorn.1-oee-2.11.0

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -9,6 +9,11 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Use the plugin celery-redis-sentinel to introduce the support of
+  redis sentinel in celery instead of upgrading celery itself.
+
 ## [hawthorn.1-oee-2.12.1] - 2019-12-04
 
 ### Fixed

--- a/releases/hawthorn/1/oee/config/cms/docker_run_production.py
+++ b/releases/hawthorn/1/oee/config/cms/docker_run_production.py
@@ -6,6 +6,7 @@ import json
 import os
 import platform
 
+from celery_redis_sentinel import register
 from lms.envs.fun.utils import Configuration
 from openedx.core.lib.derived import derive_settings
 from path import Path as path
@@ -524,12 +525,17 @@ DATADOG = config("DATADOG", default={}, formatter=json.loads)
 DATADOG["api_key"] = config("DATADOG_API", default=None)
 
 # Celery Broker
+# For redis sentinel use the `redis-sentinel` transport
 CELERY_BROKER_TRANSPORT = config("CELERY_BROKER_TRANSPORT", default="redis")
 CELERY_BROKER_USER = config("CELERY_BROKER_USER", default="")
 CELERY_BROKER_PASSWORD = config("CELERY_BROKER_PASSWORD", default="")
 CELERY_BROKER_HOST = config("CELERY_BROKER_HOST", default="redis")
 CELERY_BROKER_PORT = config("CELERY_BROKER_PORT", default=6379, formatter=int)
 CELERY_BROKER_VHOST = config("CELERY_BROKER_VHOST", default=0, formatter=int)
+
+if CELERY_BROKER_TRANSPORT == "redis-sentinel":
+    # register redis sentinel schema in celery
+    register()
 
 BROKER_URL = "{transport}://{user}:{password}@{host}:{port}/{vhost}".format(
     transport=CELERY_BROKER_TRANSPORT,
@@ -540,6 +546,8 @@ BROKER_URL = "{transport}://{user}:{password}@{host}:{port}/{vhost}".format(
     vhost=CELERY_BROKER_VHOST,
 )
 BROKER_USE_SSL = config("CELERY_BROKER_USE_SSL", default=False, formatter=bool)
+# To use redis-sentinel, refer to the documentation here 
+# https://celery-redis-sentinel.readthedocs.io/en/latest/
 BROKER_TRANSPORT_OPTIONS = config("BROKER_TRANSPORT_OPTIONS", default={}, formatter=json.loads)
 
 # Message expiry time in seconds

--- a/releases/hawthorn/1/oee/config/lms/docker_run_production.py
+++ b/releases/hawthorn/1/oee/config/lms/docker_run_production.py
@@ -10,6 +10,7 @@ import json
 import os
 import platform
 
+from celery_redis_sentinel import register
 from openedx.core.lib.derived import derive_settings
 from path import Path as path
 from xmodule.modulestore.modulestore_settings import (
@@ -773,12 +774,17 @@ ZENDESK_CUSTOM_FIELDS = config(
 EDX_API_KEY = config("EDX_API_KEY", default="ThisIsAnExampleKeyForDevPurposeOnly")
 
 # Celery Broker
+# For redis sentinel use the `redis-sentinel` transport
 CELERY_BROKER_TRANSPORT = config("CELERY_BROKER_TRANSPORT", default="redis")
 CELERY_BROKER_USER = config("CELERY_BROKER_USER", default="")
 CELERY_BROKER_PASSWORD = config("CELERY_BROKER_PASSWORD", default="")
 CELERY_BROKER_HOST = config("CELERY_BROKER_HOST", default="redis")
 CELERY_BROKER_PORT = config("CELERY_BROKER_PORT", default=6379, formatter=int)
 CELERY_BROKER_VHOST = config("CELERY_BROKER_VHOST", default=0, formatter=int)
+
+if CELERY_BROKER_TRANSPORT == "redis-sentinel":
+    # register redis sentinel schema in celery
+    register()
 
 BROKER_URL = "{transport}://{user}:{password}@{host}:{port}/{vhost}".format(
     transport=CELERY_BROKER_TRANSPORT,
@@ -789,6 +795,8 @@ BROKER_URL = "{transport}://{user}:{password}@{host}:{port}/{vhost}".format(
     vhost=CELERY_BROKER_VHOST,
 )
 BROKER_USE_SSL = config("CELERY_BROKER_USE_SSL", default=False, formatter=bool)
+# To use redis-sentinel, refer to the documentation here 
+# https://celery-redis-sentinel.readthedocs.io/en/latest/
 BROKER_TRANSPORT_OPTIONS = config("BROKER_TRANSPORT_OPTIONS", default={}, formatter=json.loads)
 
 # Block Structures

--- a/releases/hawthorn/1/oee/requirements.txt
+++ b/releases/hawthorn/1/oee/requirements.txt
@@ -9,4 +9,4 @@ configurable_lti_consumer-xblock==1.2.3
 # ==== third-party apps ====
 raven==6.9.0
 django-redis-sessions==0.6.1
-celery==4.3.0
+celery-redis-sentinel==0.3.0


### PR DESCRIPTION
## Purpose

In a first we choose to upgrade celery to the last version to be able to
connect to a redis sentinel. But in the meantime we installer the lib
celery-redis-sentinel in the others flavors and to be consistent we
choose to do the same in hawtorn.

## Proposal

- [x] use celery-redis-sentinel instead of upgrading to celery 4
