### PR TITLE
🐛(docker) fix typo in redis-sentinel env file

### DIFF
--- a/env.d/redis-sentinel
+++ b/env.d/redis-sentinel
@@ -2,7 +2,7 @@
 CELERY_BROKER_TRANSPORT=redis-sentinel
 CELERY_BROKER_HOST=redis-sentinel
 CELERY_BROKER_PORT=26379
-BROKER_TRANSPORT_OPTIONS={"sentinel":[["redis-sentinel",26379]],"service_name":"mymaster"}
+BROKER_TRANSPORT_OPTIONS={"sentinels":[["redis-sentinel",26379]],"service_name":"mymaster"}
 
 # Session in redis
 SESSION_REDIS_SENTINEL_LIST=[["redis-sentinel", 26379]]


### PR DESCRIPTION
## Purpose

There is a typo in the redis-sentinel env file. The sentinels key in the
BROKER_TRANSPORT_OPTIONS was mispelled, sentinel key was used instead of
sentinels.

## Proposal

- [x] fix typo in `BROKER_TRANSPORT_OPTIONS` setting
- [x] I think my reviewers deserve a drink with all the typo I made this week...
