### PR TITLE
(dogwood|eucalyptus) Fix CMS CELERY_ACCEPT_CONTENT

### DIFF
--- a/releases/dogwood/3/bare/CHANGELOG.md
+++ b/releases/dogwood/3/bare/CHANGELOG.md
@@ -9,6 +9,13 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-1.1.2] - 2019-12-10
+
+### Fixed
+
+- Set CELERY_ACCEPT_CONTENT CMS setting to 'json' to prevent permission issues
+  while running in an OpenShift context
+
 ## [dogwood.3-1.1.1] - 2019-11-29
 
 ### Fixed
@@ -27,7 +34,8 @@ release.
 
 First experimental release of OpenEdx `dogwood.3` (bare flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-1.1.1...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-1.1.2...HEAD
+[dogwood.3-1.1.2]: https://github.com/openfun/openedx-docker/compare/tag/dogwood.3-1.1.1...dogwood.3-1.1.2
 [dogwood.3-1.1.1]: https://github.com/openfun/openedx-docker/compare/tag/dogwood.3-1.1.0...dogwood.3-1.1.1
 [dogwood.3-1.1.0]: https://github.com/openfun/openedx-docker/compare/tag/dogwood.3-1.0.0...dogwood.3-1.1.0
 [dogwood.3-1.0.0]: https://github.com/openfun/openedx-docker/releases/tag/dogwood.3-1.0.0

--- a/releases/dogwood/3/bare/config/cms/docker_run_production.py
+++ b/releases/dogwood/3/bare/config/cms/docker_run_production.py
@@ -107,6 +107,12 @@ CELERY_QUEUES = config(
 
 CELERY_ROUTES = "cms.celery.Router"
 
+# Force accepted content to "json" only. If we also accept pickle-serialized
+# messages, the worker will crash when it's running with a privileged user (even
+# if it's not the root user but a user belonging to the root group, which is our
+# case with OpenShift).
+CELERY_ACCEPT_CONTENT = ["json"]
+
 ############# NON-SECURE ENV CONFIG ##############################
 # Things like server locations, ports, etc.
 

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,13 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-1.3.3] - 2019-12-10
+
+### Fixed
+
+- Set CELERY_ACCEPT_CONTENT CMS setting to 'json' to prevent permission issues
+  while running in an OpenShift context
+
 ## [dogwood.3-fun-1.3.2] - 2019-12-05
 
 ### Changed
@@ -52,7 +59,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.2...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.3...HEAD
+[dogwood.3-fun-1.3.3]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.2...dogwood.3-fun-1.3.3
 [dogwood.3-fun-1.3.2]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.1...dogwood.3-fun-1.3.2
 [dogwood.3-fun-1.3.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.0...dogwood.3-fun-1.3.1
 [dogwood.3-fun-1.3.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.2.1...dogwood.3-fun-1.3.0

--- a/releases/dogwood/3/fun/config/cms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/cms/docker_run_production.py
@@ -111,6 +111,12 @@ CELERY_QUEUES = config(
 
 CELERY_ROUTES = "cms.celery.Router"
 
+# Force accepted content to "json" only. If we also accept pickle-serialized
+# messages, the worker will crash when it's running with a privileged user (even
+# if it's not the root user but a user belonging to the root group, which is our
+# case with OpenShift).
+CELERY_ACCEPT_CONTENT = ["json"]
+
 ############# NON-SECURE ENV CONFIG ##############################
 # Things like server locations, ports, etc.
 

--- a/releases/eucalyptus/3/bare/CHANGELOG.md
+++ b/releases/eucalyptus/3/bare/CHANGELOG.md
@@ -9,6 +9,13 @@ release.
 
 ## [Unreleased]
 
+## [eucalyptus.3-1.0.2] - 2019-12-10
+
+### Fixed
+
+- Set CELERY_ACCEPT_CONTENT CMS setting to 'json' to prevent permission issues
+  while running in an OpenShift context
+
 ## [eucalyptus.3-1.0.1] - 2019-11-29
 
 ### Fixed
@@ -21,6 +28,7 @@ release.
 
 - First experimental release of OpenEdx `eucalyptus.3` (bare flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.1...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.2...HEAD
+[eucalyptus.3-1.0.2]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.1...eucalyptus.3-1.0.2
 [eucalyptus.3-1.0.1]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.0...eucalyptus.3-1.0.1
 [eucalyptus.3-1.0.0]: https://github.com/openfun/openedx-docker/releases/tag/eucalyptus.3-1.0.0

--- a/releases/eucalyptus/3/bare/config/cms/docker_run_production.py
+++ b/releases/eucalyptus/3/bare/config/cms/docker_run_production.py
@@ -121,6 +121,12 @@ CELERY_QUEUES.update(
 
 CELERY_ROUTES = "cms.celery.Router"
 
+# Force accepted content to "json" only. If we also accept pickle-serialized
+# messages, the worker will crash when it's running with a privileged user (even
+# if it's not the root user but a user belonging to the root group, which is our
+# case with OpenShift).
+CELERY_ACCEPT_CONTENT = ["json"]
+
 ############# NON-SECURE ENV CONFIG ##############################
 # Things like server locations, ports, etc.
 

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,13 @@ release.
 
 ## [Unreleased]
 
+## [eucalyptus.3-1.0.2-wb] - 2019-12-10
+
+### Fixed
+
+- Set CELERY_ACCEPT_CONTENT CMS setting to 'json' to prevent permission issues
+  while running in an OpenShift context
+
 ## [eucalyptus.3-1.0.1-wb] - 2019-12-04
 
 ### Fixed
@@ -23,6 +30,7 @@ release.
 - Set replicaSet and read_preference in mongodb connection
 - Add missing support for redis sentinel
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.1-wb...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.2-wb...HEAD
+[eucalyptus.3-1.0.2-wb]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.1-wb...eucalyptus.3-1.0.2-wb
 [eucalyptus.3-1.0.1-wb]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.0-wb...eucalyptus.3-1.0.1-wb
 [eucalyptus.3-1.0.0-wb]: https://github.com/openfun/openedx-docker/releases/tag/eucalyptus.3-1.0.0-wb

--- a/releases/eucalyptus/3/wb/config/cms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/cms/docker_run_production.py
@@ -121,6 +121,12 @@ CELERY_QUEUES.update(
 
 CELERY_ROUTES = "cms.celery.Router"
 
+# Force accepted content to "json" only. If we also accept pickle-serialized
+# messages, the worker will crash when it's running with a privileged user (even
+# if it's not the root user but a user belonging to the root group, which is our
+# case with OpenShift).
+CELERY_ACCEPT_CONTENT = ["json"]
+
 ############# NON-SECURE ENV CONFIG ##############################
 # Things like server locations, ports, etc.
 
@@ -197,8 +203,12 @@ SESSION_REDIS_PORT = config("SESSION_REDIS_PORT", default=6379, formatter=int)
 SESSION_REDIS_DB = config("SESSION_REDIS_DB", default=1, formatter=int)
 SESSION_REDIS_PASSWORD = config("SESSION_REDIS_PASSWORD", default=None)
 SESSION_REDIS_PREFIX = config("SESSION_REDIS_PREFIX", default="session")
-SESSION_REDIS_SOCKET_TIMEOUT = config("SESSION_REDIS_SOCKET_TIMEOUT", default=1, formatter=int)
-SESSION_REDIS_RETRY_ON_TIMEOUT = config("SESSION_REDIS_RETRY_ON_TIMEOUT", default=False, formatter=bool)
+SESSION_REDIS_SOCKET_TIMEOUT = config(
+    "SESSION_REDIS_SOCKET_TIMEOUT", default=1, formatter=int
+)
+SESSION_REDIS_RETRY_ON_TIMEOUT = config(
+    "SESSION_REDIS_RETRY_ON_TIMEOUT", default=False, formatter=bool
+)
 
 SESSION_REDIS = config(
     "SESSION_REDIS",
@@ -213,8 +223,12 @@ SESSION_REDIS = config(
     },
     formatter=json.loads,
 )
-SESSION_REDIS_SENTINEL_LIST = config("SESSION_REDIS_SENTINEL_LIST", default=None, formatter=json.loads)
-SESSION_REDIS_SENTINEL_MASTER_ALIAS = config("SESSION_REDIS_SENTINEL_MASTER_ALIAS", default=None)
+SESSION_REDIS_SENTINEL_LIST = config(
+    "SESSION_REDIS_SENTINEL_LIST", default=None, formatter=json.loads
+)
+SESSION_REDIS_SENTINEL_MASTER_ALIAS = config(
+    "SESSION_REDIS_SENTINEL_MASTER_ALIAS", default=None
+)
 
 # social sharing settings
 SOCIAL_SHARING_SETTINGS = config(
@@ -566,9 +580,11 @@ BROKER_URL = "{transport}://{user}:{password}@{host}:{port}/{vhost}".format(
     port=CELERY_BROKER_PORT,
     vhost=CELERY_BROKER_VHOST,
 )
-# To use redis-sentinel, refer to the documenation here 
+# To use redis-sentinel, refer to the documenation here
 # https://celery-redis-sentinel.readthedocs.io/en/latest/
-BROKER_TRANSPORT_OPTIONS = config("BROKER_TRANSPORT_OPTIONS", default={}, formatter=json.loads)
+BROKER_TRANSPORT_OPTIONS = config(
+    "BROKER_TRANSPORT_OPTIONS", default={}, formatter=json.loads
+)
 
 # Event tracking
 TRACKING_BACKENDS.update(config("TRACKING_BACKENDS", default={}, formatter=json.loads))


### PR DESCRIPTION
## Purpose

CMS's celery worker refuses to start using the `root` user/group ID. This bug impacts all dogwood and eucalyptus releases.

## Proposal

- [x] set `CELERY_ACCEPT_CONTENT` to `json`
- [x] bump `(eucalyptus|dogwood)/*` releases
