### PR TITLE
Pin redis to 2.x.x

### DIFF
--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,11 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix redis release compatibility with celery-redis-sentinel (_e.g._ redis
+  2.x.x)
+
 ## [dogwood.3-fun-1.3.3] - 2019-12-10
 
 ### Fixed

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -13,6 +13,7 @@ release.
 
 - Fix redis release compatibility with celery-redis-sentinel (_e.g._ redis
   2.x.x)
+- Remove unusable static and media-related paths from settings.yml
 
 ## [dogwood.3-fun-1.3.3] - 2019-12-10
 

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-1.3.4] - 2019-12-10
+
 ### Fixed
 
 - Fix redis release compatibility with celery-redis-sentinel (_e.g._ redis
@@ -65,7 +67,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.3...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.4...HEAD
+[dogwood.3-fun-1.3.4]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.3...dogwood.3-fun-1.3.4
 [dogwood.3-fun-1.3.3]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.2...dogwood.3-fun-1.3.3
 [dogwood.3-fun-1.3.2]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.1...dogwood.3-fun-1.3.2
 [dogwood.3-fun-1.3.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.0...dogwood.3-fun-1.3.1

--- a/releases/dogwood/3/fun/config/cms/settings.yml
+++ b/releases/dogwood/3/fun/config/cms/settings.yml
@@ -49,13 +49,6 @@ LANGUAGES:
 PIPELINE: true
 STATICFILES_STORAGE: pipeline.storage.PipelineCachedStorage
 
-MEDIA_URL: /media/
-MEDIA_ROOT: /edx/var/edxapp/uploads
-
-STATIC_ROOT: /edx/var/edxapp/staticfiles
-
-SHARED_ROOT: /edx/var/edxapp/shared
-
 GITHUB_REPO_ROOT: /edx/var/edxapp/data
 
 # Make sure we see the draft on preview....

--- a/releases/dogwood/3/fun/config/lms/settings.yml
+++ b/releases/dogwood/3/fun/config/lms/settings.yml
@@ -49,13 +49,6 @@ LANGUAGES:
 PIPELINE: true
 STATICFILES_STORAGE: pipeline.storage.PipelineCachedStorage
 
-MEDIA_URL: /media/
-MEDIA_ROOT: /edx/var/edxapp/uploads
-
-STATIC_ROOT: /edx/var/edxapp/staticfiles
-
-SHARED_ROOT: /edx/var/edxapp/shared
-
 GITHUB_REPO_ROOT: /edx/var/edxapp/data
 
 # Make sure we see the draft on preview....

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -2,9 +2,9 @@
 --extra-index-url https://pypi.fury.io/openfun/
 
 # ==== core ====
+edx-gea==0.2.0
 fonzie==0.2.0
 fun-apps==5.0.0
-edx-gea==0.2.0
 
 # ==== xblocks ====
 configurable_lti_consumer-xblock==1.3.0
@@ -17,6 +17,7 @@ xblock-proctor-exam==0.9.0b0
 xblock-utils2==0.3.0
 
 # ==== third-party apps ====
-raven==6.9.0
-django-redis-sessions==0.6.1
 celery-redis-sentinel==0.3.0
+django-redis-sessions==0.6.1
+raven==6.9.0
+redis==2.10.6

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,25 +9,27 @@ release.
 
 ## [Unreleased]
 
+## [eucalyptus.3-wb-1.0.3] - 2019-12-10
+
 ### Fixed
 
 - Fix redis release compatibility with celery-redis-sentinel (_e.g._ redis
   2.x.x)
 
-## [eucalyptus.3-1.0.2-wb] - 2019-12-10
+## [eucalyptus.3-wb-1.0.2] - 2019-12-10
 
 ### Fixed
 
 - Set CELERY_ACCEPT_CONTENT CMS setting to 'json' to prevent permission issues
   while running in an OpenShift context
 
-## [eucalyptus.3-1.0.1-wb] - 2019-12-04
+## [eucalyptus.3-wb-1.0.1] - 2019-12-04
 
 ### Fixed
 
 - Fix SESSION_REDIS_PORT setting definition
 
-## [eucalyptus.3-1.0.0-wb] - 2019-11-14
+## [eucalyptus.3-wb-1.0.0] - 2019-11-14
 
 ### Added
 
@@ -35,7 +37,8 @@ release.
 - Set replicaSet and read_preference in mongodb connection
 - Add missing support for redis sentinel
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.2-wb...HEAD
-[eucalyptus.3-1.0.2-wb]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.1-wb...eucalyptus.3-1.0.2-wb
-[eucalyptus.3-1.0.1-wb]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.0-wb...eucalyptus.3-1.0.1-wb
-[eucalyptus.3-1.0.0-wb]: https://github.com/openfun/openedx-docker/releases/tag/eucalyptus.3-1.0.0-wb
+[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.0.3...HEAD
+[eucalyptus.3-wb-1.0.3]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.0.2...eucalyptus.3-wb-1.0.3
+[eucalyptus.3-wb-1.0.2]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.0.1...eucalyptus.3-wb-1.0.2
+[eucalyptus.3-wb-1.0.1]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.0.0...eucalyptus.3-wb-1.0.1
+[eucalyptus.3-wb-1.0.0]: https://github.com/openfun/openedx-docker/releases/tag/eucalyptus.3-wb-1.0.0

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,11 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix redis release compatibility with celery-redis-sentinel (_e.g._ redis
+  2.x.x)
+
 ## [eucalyptus.3-1.0.2-wb] - 2019-12-10
 
 ### Fixed

--- a/releases/eucalyptus/3/wb/requirements.txt
+++ b/releases/eucalyptus/3/wb/requirements.txt
@@ -3,14 +3,15 @@
 
 # ==== core ====
 configurable-lti-consumer-xblock==1.3.0
-fun-apps==2.0.1+wb
 edx-gea==0.2.0
+fun-apps==2.0.1+wb
 libcast-xblock==0.5.0
 password-container-xblock==0.3.0
 xblock-proctor-exam==0.9.0b0
 xblock-utils2==0.3.0
 
 # ==== third-party apps ====
-raven==6.9.0
-django-redis-sessions==0.6.1
 celery-redis-sentinel==0.3.0
+django-redis-sessions==0.6.1
+raven==6.9.0
+redis==2.10.6

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [hawthorn.1-oee-2.12.3] - 2019-12-10
+
 ### Fixed
 
 - Fix redis release compatibility with celery-redis-sentinel (_e.g._ redis
@@ -217,7 +219,8 @@ First release of OpenEdx extended.
 
 - Add a configurable LTI consumer xblock
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-2.12.2...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-2.12.3...HEAD
+[hawthorn.1-oee-2.12.3]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-2.12.2...hawthorn.1-oee-2.12.3
 [hawthorn.1-oee-2.12.2]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-2.12.1...hawthorn.1-oee-2.12.2
 [hawthorn.1-oee-2.12.1]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-2.12.0...hawthorn.1-oee-2.12.1
 [hawthorn.1-oee-2.12.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-2.11.0...hawthorn.1-oee-2.12.0

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -9,6 +9,11 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix redis release compatibility with celery-redis-sentinel (_e.g._ redis
+  2.x.x)
+
 ## [hawthorn.1-oee-2.12.2] - 2019-12-05
 
 ### Fixed

--- a/releases/hawthorn/1/oee/requirements.txt
+++ b/releases/hawthorn/1/oee/requirements.txt
@@ -7,6 +7,7 @@ fonzie==0.2.1
 configurable_lti_consumer-xblock==1.2.3
 
 # ==== third-party apps ====
-raven==6.9.0
-django-redis-sessions==0.6.1
 celery-redis-sentinel==0.3.0
+django-redis-sessions==0.6.1
+raven==6.9.0
+redis==2.10.6


### PR DESCRIPTION
## Purpose

Celery workers using `celery-redis-sentinel` are failing while using unpinned redis release (>3.x):

```[2019-12-10 19:46:25,952: ERROR/MainProcess] Unrecoverable error: AttributeError("'str' object has no attribute 'iteritems'",)
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/celery/worker/__init__.py", line 206, in start
    self.blueprint.start(self)
  File "/usr/local/lib/python2.7/dist-packages/celery/bootsteps.py", line 123, in start
    step.start(parent)
  File "/usr/local/lib/python2.7/dist-packages/celery/bootsteps.py", line 374, in start
    return self.obj.start()
  File "/usr/local/lib/python2.7/dist-packages/celery/worker/consumer.py", line 278, in start
    blueprint.start(self)
  File "/usr/local/lib/python2.7/dist-packages/celery/bootsteps.py", line 123, in start
    step.start(parent)
  File "/usr/local/lib/python2.7/dist-packages/celery/worker/consumer.py", line 821, in start
    c.loop(*c.loop_args())
  File "/usr/local/lib/python2.7/dist-packages/celery/worker/loops.py", line 70, in asynloop
    next(loop)
  File "/usr/local/lib/python2.7/dist-packages/kombu/async/hub.py", line 340, in create_loop
    cb(*cbargs)
  File "/usr/local/lib/python2.7/dist-packages/kombu/transport/redis.py", line 1019, in on_readable
    self._callbacks[queue](message)
  File "/usr/local/lib/python2.7/dist-packages/kombu/transport/virtual/__init__.py", line 534, in _callback
    self.qos.append(message, message.delivery_tag)
  File "/usr/local/lib/python2.7/dist-packages/kombu/transport/redis.py", line 146, in append
    pipe.zadd(self.unacked_index_key, delivery_tag, time()) \
  File "/usr/local/lib/python2.7/dist-packages/redis/client.py", line 2388, in zadd
    for pair in iteritems(mapping):
  File "/usr/local/lib/python2.7/dist-packages/redis/_compat.py", line 132, in iteritems
    return x.iteritems()
AttributeError: 'str' object has no attribute 'iteritems'
 -------------- celery@cms-default.%edxapp-cms-default-worker-d-191210-08h36m14s-2-c6jqm v3.1.18 (Cipater)
---- **** ----- 
--- * ***  * -- Linux-3.10.0-1062.4.1.el7.x86_64-x86_64-with-Ubuntu-12.04-precise
-- * - **** --- 
- ** ---------- [config]
- ** ---------- .> app:         proj:xx
- ** ---------- .> transport:   redis-sentinel://rfs-redis-sentinel:26379/0
- ** ---------- .> results:     djcelery.backends.database:DatabaseBackend
- *** --- * --- .> concurrency: 1 (prefork)
-- ******* ---- 
--- ***** ----- [queues]
 -------------- .> edx.cms.core.default-d-191210-08h36m14s exchange=edx.cms.core(direct) key=edx.cms.core.default-d-191210-08h36m14s
                .> edx.cms.core.high-d-191210-08h36m14s exchange=edx.cms.core(direct) key=edx.cms.core.high-d-191210-08h36m14s
                .> edx.cms.core.low-d-191210-08h36m14s exchange=edx.cms.core(direct) key=edx.cms.core.low-d-191210-08h36m14s
[tasks]
  . contentstore.tasks.push_course_update_task
  . contentstore.tasks.rerun_course
  . contentstore.tasks.update_library_index
  . contentstore.tasks.update_search_index
  . courses.tasks.update_courses_meta_data
  . fun.tasks.update_search_index
  . openedx.core.djangoapps.content.course_structures.tasks.update_course_structure
  . openedx.core.djangoapps.credit.tasks.update_credit_course_requirements
  . selftest.tasks.trigger_worker_error
  . service_status.tasks.delayed_ping
```

## Proposal

- [x] pin `redis` to its last 2.x release to fulfill `celery-redis-sentinel` requirement (_i.e._ `redis<3.0`)

In this PR I have also:

- [x] removed unusable settings from the `settings.yml` file (`dogwood.3-fun`)
- [x] fixed `eucalyptus.3-wb` tags pattern