### PR TITLE
🔧(dogwood/3/fun) add Glowbl xblock settings

### DIFF
--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Added
+
+- Add Glowbl xblock settings
+
 ## [dogwood.3-fun-1.3.4] - 2019-12-10
 
 ### Fixed

--- a/releases/dogwood/3/fun/config/cms/fun.py
+++ b/releases/dogwood/3/fun/config/cms/fun.py
@@ -67,6 +67,18 @@ HAYSTACK_CONNECTIONS = config(
 
 CKEDITOR_UPLOAD_PATH = "./"
 
+# Glowbl
+GLOWBL_LTI_ENDPOINT = config(
+    "GLOWBL_LTI_ENDPOINT", default="http://ltiapps.net/test/tp.php"
+)
+GLOWBL_LTI_KEY = config("GLOWBL_LTI_KEY", default="jisc.ac.uk")
+GLOWBL_LTI_SECRET = config("GLOWBL_LTI_SECRET", default="secret")
+GLOWBL_LTI_ID = config("GLOWBL_LTI_ID", default="testtoolconsumer")
+GLOWBL_LAUNCH_URL = config(
+    "GLOWBL_LAUNCH_URL", default="http://ltiapps.net/test/tp.php"
+)
+GLOWBL_COLL_OPT = config("GLOWBL_COLL_OPT", default="FunMoocJdR")
+
 # ### FUN-APPS SETTINGS ###
 
 # This is dist-packages path where all fun-apps are

--- a/releases/dogwood/3/fun/config/lms/fun.py
+++ b/releases/dogwood/3/fun/config/lms/fun.py
@@ -235,6 +235,17 @@ for group in ["base_vendor", "main_vendor"]:
     PIPELINE_JS[group]["source_filenames"].append("funsite/js/header.js")
     PIPELINE_JS[group]["source_filenames"].append("fun/js/cookie-banner.js")
 
+# Glowbl
+GLOWBL_LTI_ENDPOINT = config(
+    "GLOWBL_LTI_ENDPOINT", default="http://ltiapps.net/test/tp.php"
+)
+GLOWBL_LTI_KEY = config("GLOWBL_LTI_KEY", default="jisc.ac.uk")
+GLOWBL_LTI_SECRET = config("GLOWBL_LTI_SECRET", default="secret")
+GLOWBL_LTI_ID = config("GLOWBL_LTI_ID", default="testtoolconsumer")
+GLOWBL_LAUNCH_URL = config(
+    "GLOWBL_LAUNCH_URL", default="http://ltiapps.net/test/tp.php"
+)
+GLOWBL_COLL_OPT = config("GLOWBL_COLL_OPT", default="FunMoocJdR")
 
 LTI_XBLOCK_CONFIGURATIONS = config(
     "LTI_XBLOCK_CONFIGURATIONS", default=[], formatter=json.loads


### PR DESCRIPTION
## Purpose

Glowbl can be used via our dedicated xblock or LTI. The current production state enable both, I think we should follow.

## Proposal

- [x] add configurable `GLOWBL_*` settings
