### PR TITLE
Set redis as default session backend

### DIFF
--- a/releases/dogwood/3/bare/config/cms/docker_run_production.py
+++ b/releases/dogwood/3/bare/config/cms/docker_run_production.py
@@ -163,11 +163,11 @@ SESSION_COOKIE_DOMAIN = config("SESSION_COOKIE_DOMAIN", default=None)
 SESSION_COOKIE_HTTPONLY = config(
     "SESSION_COOKIE_HTTPONLY", default=True, formatter=bool
 )
-SESSION_ENGINE = config(
-    "SESSION_ENGINE", default="django.contrib.sessions.backends.cache"
-)
 SESSION_COOKIE_SECURE = config(
     "SESSION_COOKIE_SECURE", default=SESSION_COOKIE_SECURE, formatter=bool
+)
+SESSION_ENGINE = config(
+    "SESSION_ENGINE", default="django.contrib.sessions.backends.cache"
 )
 SESSION_SAVE_EVERY_REQUEST = config(
     "SESSION_SAVE_EVERY_REQUEST", default=SESSION_SAVE_EVERY_REQUEST, formatter=bool

--- a/releases/dogwood/3/bare/config/cms/docker_run_production.py
+++ b/releases/dogwood/3/bare/config/cms/docker_run_production.py
@@ -53,9 +53,6 @@ CONFIG_PREFIX = SERVICE_VARIANT + "." if SERVICE_VARIANT else ""
 RELEASE = config("RELEASE", default=None)
 DEBUG = False
 
-EMAIL_BACKEND = "django_ses.SESBackend"
-SESSION_ENGINE = "django.contrib.sessions.backends.cache"
-
 # IMPORTANT: With this enabled, the server must always be behind a proxy that
 # strips the header HTTP_X_FORWARDED_PROTO from client requests. Otherwise,
 # a user can fool our server into thinking it was an https connection.

--- a/releases/dogwood/3/bare/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/bare/config/lms/docker_run_production.py
@@ -61,10 +61,6 @@ RELEASE = config("RELEASE", default=None)
 DEBUG = False
 DEFAULT_TEMPLATE_ENGINE["OPTIONS"]["debug"] = False
 
-SESSION_ENGINE = config(
-    "SESSION_ENGINE", default="django.contrib.sessions.backends.cache"
-)
-
 # IMPORTANT: With this enabled, the server must always be behind a proxy that
 # strips the header HTTP_X_FORWARDED_PROTO from client requests. Otherwise,
 # a user can fool our server into thinking it was an https connection.
@@ -169,7 +165,10 @@ EMAIL_PORT = config("EMAIL_PORT", default=25)  # django default is 25
 EMAIL_USE_TLS = config("EMAIL_USE_TLS", default=False)  # django default is False
 SITE_NAME = config("SITE_NAME", default=None)
 HTTPS = config("HTTPS", default=HTTPS)
-SESSION_ENGINE = config("SESSION_ENGINE", default=SESSION_ENGINE)
+
+SESSION_ENGINE = config(
+    "SESSION_ENGINE", default="django.contrib.sessions.backends.cache"
+)
 SESSION_COOKIE_DOMAIN = config("SESSION_COOKIE_DOMAIN", default=None)
 SESSION_COOKIE_HTTPONLY = config(
     "SESSION_COOKIE_HTTPONLY", default=True, formatter=bool

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-1.3.5] - 2019-12-12
+
 ### Changed
 
 - Declare redis as the default session engine
@@ -75,7 +77,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.4...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.5...HEAD
+[dogwood.3-fun-1.3.5]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.4...dogwood.3-fun-1.3.5
 [dogwood.3-fun-1.3.4]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.3...dogwood.3-fun-1.3.4
 [dogwood.3-fun-1.3.3]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.2...dogwood.3-fun-1.3.3
 [dogwood.3-fun-1.3.2]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.1...dogwood.3-fun-1.3.2

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Changed
+
+- Declare redis as the default session engine
+
 ### Added
 
 - Add Glowbl xblock settings

--- a/releases/dogwood/3/fun/config/cms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/cms/docker_run_production.py
@@ -167,12 +167,10 @@ SESSION_COOKIE_DOMAIN = config("SESSION_COOKIE_DOMAIN", default=None)
 SESSION_COOKIE_HTTPONLY = config(
     "SESSION_COOKIE_HTTPONLY", default=True, formatter=bool
 )
-SESSION_ENGINE = config(
-    "SESSION_ENGINE", default="django.contrib.sessions.backends.cache"
-)
 SESSION_COOKIE_SECURE = config(
     "SESSION_COOKIE_SECURE", default=SESSION_COOKIE_SECURE, formatter=bool
 )
+SESSION_ENGINE = config("SESSION_ENGINE", default="redis_sessions.session")
 SESSION_SAVE_EVERY_REQUEST = config(
     "SESSION_SAVE_EVERY_REQUEST", default=SESSION_SAVE_EVERY_REQUEST, formatter=bool
 )

--- a/releases/dogwood/3/fun/config/cms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/cms/docker_run_production.py
@@ -54,9 +54,6 @@ CONFIG_PREFIX = SERVICE_VARIANT + "." if SERVICE_VARIANT else ""
 RELEASE = config("RELEASE", default=None)
 DEBUG = False
 
-EMAIL_BACKEND = "django_ses.SESBackend"
-SESSION_ENGINE = "django.contrib.sessions.backends.cache"
-
 # IMPORTANT: With this enabled, the server must always be behind a proxy that
 # strips the header HTTP_X_FORWARDED_PROTO from client requests. Otherwise,
 # a user can fool our server into thinking it was an https connection.

--- a/releases/dogwood/3/fun/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/lms/docker_run_production.py
@@ -62,10 +62,6 @@ RELEASE = config("RELEASE", default=None)
 DEBUG = False
 DEFAULT_TEMPLATE_ENGINE["OPTIONS"]["debug"] = False
 
-SESSION_ENGINE = config(
-    "SESSION_ENGINE", default="django.contrib.sessions.backends.cache"
-)
-
 # IMPORTANT: With this enabled, the server must always be behind a proxy that
 # strips the header HTTP_X_FORWARDED_PROTO from client requests. Otherwise,
 # a user can fool our server into thinking it was an https connection.
@@ -170,7 +166,6 @@ EMAIL_FILE_PATH = config("EMAIL_FILE_PATH", default=None)
 EMAIL_HOST = config("EMAIL_HOST", default="localhost")
 EMAIL_PORT = config("EMAIL_PORT", default=25)  # django default is 25
 EMAIL_USE_TLS = config("EMAIL_USE_TLS", default=False)  # django default is False
-SITE_NAME = config("SITE_NAME", default=None)
 HTTPS = config("HTTPS", default=HTTPS)
 SESSION_ENGINE = config("SESSION_ENGINE", default=SESSION_ENGINE)
 SESSION_COOKIE_DOMAIN = config("SESSION_COOKIE_DOMAIN", default=None)

--- a/releases/dogwood/3/fun/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/lms/docker_run_production.py
@@ -167,7 +167,7 @@ EMAIL_HOST = config("EMAIL_HOST", default="localhost")
 EMAIL_PORT = config("EMAIL_PORT", default=25)  # django default is 25
 EMAIL_USE_TLS = config("EMAIL_USE_TLS", default=False)  # django default is False
 HTTPS = config("HTTPS", default=HTTPS)
-SESSION_ENGINE = config("SESSION_ENGINE", default=SESSION_ENGINE)
+
 SESSION_COOKIE_DOMAIN = config("SESSION_COOKIE_DOMAIN", default=None)
 SESSION_COOKIE_HTTPONLY = config(
     "SESSION_COOKIE_HTTPONLY", default=True, formatter=bool
@@ -175,6 +175,7 @@ SESSION_COOKIE_HTTPONLY = config(
 SESSION_COOKIE_SECURE = config(
     "SESSION_COOKIE_SECURE", default=SESSION_COOKIE_SECURE, formatter=bool
 )
+SESSION_ENGINE = config("SESSION_ENGINE", default="redis_sessions.session")
 SESSION_SAVE_EVERY_REQUEST = config(
     "SESSION_SAVE_EVERY_REQUEST", default=SESSION_SAVE_EVERY_REQUEST, formatter=bool
 )

--- a/releases/eucalyptus/3/bare/config/cms/docker_run_production.py
+++ b/releases/eucalyptus/3/bare/config/cms/docker_run_production.py
@@ -183,11 +183,11 @@ SESSION_COOKIE_DOMAIN = config("SESSION_COOKIE_DOMAIN", default=None)
 SESSION_COOKIE_HTTPONLY = config(
     "SESSION_COOKIE_HTTPONLY", default=True, formatter=bool
 )
-SESSION_ENGINE = config(
-    "SESSION_ENGINE", default="django.contrib.sessions.backends.cache"
-)
 SESSION_COOKIE_SECURE = config(
     "SESSION_COOKIE_SECURE", default=SESSION_COOKIE_SECURE, formatter=bool
+)
+SESSION_ENGINE = config(
+    "SESSION_ENGINE", default="django.contrib.sessions.backends.cache"
 )
 SESSION_SAVE_EVERY_REQUEST = config(
     "SESSION_SAVE_EVERY_REQUEST", default=SESSION_SAVE_EVERY_REQUEST, formatter=bool

--- a/releases/eucalyptus/3/bare/config/cms/docker_run_production.py
+++ b/releases/eucalyptus/3/bare/config/cms/docker_run_production.py
@@ -53,9 +53,6 @@ CONFIG_PREFIX = SERVICE_VARIANT + "." if SERVICE_VARIANT else ""
 RELEASE = config("RELEASE", default=None)
 DEBUG = False
 
-EMAIL_BACKEND = "django_ses.SESBackend"
-SESSION_ENGINE = "django.contrib.sessions.backends.cache"
-
 # IMPORTANT: With this enabled, the server must always be behind a proxy that
 # strips the header HTTP_X_FORWARDED_PROTO from client requests. Otherwise,
 # a user can fool our server into thinking it was an https connection.

--- a/releases/eucalyptus/3/bare/config/lms/docker_run_production.py
+++ b/releases/eucalyptus/3/bare/config/lms/docker_run_production.py
@@ -62,10 +62,6 @@ RELEASE = config("RELEASE", default=None)
 DEBUG = False
 DEFAULT_TEMPLATE_ENGINE["OPTIONS"]["debug"] = False
 
-SESSION_ENGINE = config(
-    "SESSION_ENGINE", default="django.contrib.sessions.backends.cache"
-)
-
 # IMPORTANT: With this enabled, the server must always be behind a proxy that
 # strips the header HTTP_X_FORWARDED_PROTO from client requests. Otherwise,
 # a user can fool our server into thinking it was an https connection.
@@ -183,7 +179,10 @@ EMAIL_PORT = config("EMAIL_PORT", default=25)  # django default is 25
 EMAIL_USE_TLS = config("EMAIL_USE_TLS", default=False)  # django default is False
 SITE_NAME = config("SITE_NAME", default=None)
 HTTPS = config("HTTPS", default=HTTPS)
-SESSION_ENGINE = config("SESSION_ENGINE", default=SESSION_ENGINE)
+
+SESSION_ENGINE = config(
+    "SESSION_ENGINE", default="django.contrib.sessions.backends.cache"
+)
 SESSION_COOKIE_DOMAIN = config("SESSION_COOKIE_DOMAIN", default=None)
 SESSION_COOKIE_HTTPONLY = config(
     "SESSION_COOKIE_HTTPONLY", default=True, formatter=bool

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [eucalyptus.3-wb-1.0.4] - 2019-12-12
+
 ### Changed
 
 - Declare redis as the default session engine
@@ -41,7 +43,8 @@ release.
 - Set replicaSet and read_preference in mongodb connection
 - Add missing support for redis sentinel
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.0.3...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.0.4...HEAD
+[eucalyptus.3-wb-1.0.4]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.0.3...eucalyptus.3-wb-1.0.4
 [eucalyptus.3-wb-1.0.3]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.0.2...eucalyptus.3-wb-1.0.3
 [eucalyptus.3-wb-1.0.2]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.0.1...eucalyptus.3-wb-1.0.2
 [eucalyptus.3-wb-1.0.1]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.0.0...eucalyptus.3-wb-1.0.1

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Changed
+
+- Declare redis as the default session engine
+
 ## [eucalyptus.3-wb-1.0.3] - 2019-12-10
 
 ### Fixed

--- a/releases/eucalyptus/3/wb/config/cms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/cms/docker_run_production.py
@@ -53,9 +53,6 @@ CONFIG_PREFIX = SERVICE_VARIANT + "." if SERVICE_VARIANT else ""
 RELEASE = config("RELEASE", default=None)
 DEBUG = False
 
-EMAIL_BACKEND = "django_ses.SESBackend"
-SESSION_ENGINE = "django.contrib.sessions.backends.cache"
-
 # IMPORTANT: With this enabled, the server must always be behind a proxy that
 # strips the header HTTP_X_FORWARDED_PROTO from client requests. Otherwise,
 # a user can fool our server into thinking it was an https connection.

--- a/releases/eucalyptus/3/wb/config/cms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/cms/docker_run_production.py
@@ -183,12 +183,10 @@ SESSION_COOKIE_DOMAIN = config("SESSION_COOKIE_DOMAIN", default=None)
 SESSION_COOKIE_HTTPONLY = config(
     "SESSION_COOKIE_HTTPONLY", default=True, formatter=bool
 )
-SESSION_ENGINE = config(
-    "SESSION_ENGINE", default="django.contrib.sessions.backends.cache"
-)
 SESSION_COOKIE_SECURE = config(
     "SESSION_COOKIE_SECURE", default=SESSION_COOKIE_SECURE, formatter=bool
 )
+SESSION_ENGINE = config("SESSION_ENGINE", default="redis_sessions.session")
 SESSION_SAVE_EVERY_REQUEST = config(
     "SESSION_SAVE_EVERY_REQUEST", default=SESSION_SAVE_EVERY_REQUEST, formatter=bool
 )

--- a/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
@@ -63,10 +63,6 @@ RELEASE = config("RELEASE", default=None)
 DEBUG = False
 DEFAULT_TEMPLATE_ENGINE["OPTIONS"]["debug"] = False
 
-SESSION_ENGINE = config(
-    "SESSION_ENGINE", default="django.contrib.sessions.backends.cache"
-)
-
 # IMPORTANT: With this enabled, the server must always be behind a proxy that
 # strips the header HTTP_X_FORWARDED_PROTO from client requests. Otherwise,
 # a user can fool our server into thinking it was an https connection.
@@ -182,7 +178,7 @@ EMAIL_FILE_PATH = config("EMAIL_FILE_PATH", default=None)
 EMAIL_HOST = config("EMAIL_HOST", default="localhost")
 EMAIL_PORT = config("EMAIL_PORT", default=25)  # django default is 25
 EMAIL_USE_TLS = config("EMAIL_USE_TLS", default=False)  # django default is False
-SITE_NAME = config("SITE_NAME", default=None)
+
 HTTPS = config("HTTPS", default=HTTPS)
 SESSION_ENGINE = config("SESSION_ENGINE", default=SESSION_ENGINE)
 SESSION_COOKIE_DOMAIN = config("SESSION_COOKIE_DOMAIN", default=None)

--- a/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
@@ -180,7 +180,7 @@ EMAIL_PORT = config("EMAIL_PORT", default=25)  # django default is 25
 EMAIL_USE_TLS = config("EMAIL_USE_TLS", default=False)  # django default is False
 
 HTTPS = config("HTTPS", default=HTTPS)
-SESSION_ENGINE = config("SESSION_ENGINE", default=SESSION_ENGINE)
+
 SESSION_COOKIE_DOMAIN = config("SESSION_COOKIE_DOMAIN", default=None)
 SESSION_COOKIE_HTTPONLY = config(
     "SESSION_COOKIE_HTTPONLY", default=True, formatter=bool
@@ -188,6 +188,7 @@ SESSION_COOKIE_HTTPONLY = config(
 SESSION_COOKIE_SECURE = config(
     "SESSION_COOKIE_SECURE", default=SESSION_COOKIE_SECURE, formatter=bool
 )
+SESSION_ENGINE = config("SESSION_ENGINE", default="redis_sessions.session")
 SESSION_SAVE_EVERY_REQUEST = config(
     "SESSION_SAVE_EVERY_REQUEST", default=SESSION_SAVE_EVERY_REQUEST, formatter=bool
 )


### PR DESCRIPTION
## Purpose

We want Redis to be the default session engine on our specific images. It was not the case on `dogwood.3-fun` and `eucalyptus.3-wb`.

We want our settings to be as clean as possible.

## Proposal

- [x] Define redis as default session engine for `dogwood.3-fun`
- [x] Define redis as default session engine for `eucalyptus.3-wb`
- [x] Remove duplicate `EMAIL_BACKEND`, `SITE_NAME` and `SESSION_ENGINE` settings
