### PR TITLE
🐛([dogwood|eucalyptus]/3/*) fix locales

### DIFF
--- a/releases/dogwood/3/bare/CHANGELOG.md
+++ b/releases/dogwood/3/bare/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Properly configure locales
+
 ## [dogwood.3-1.1.2] - 2019-12-10
 
 ### Fixed

--- a/releases/dogwood/3/bare/Dockerfile
+++ b/releases/dogwood/3/bare/Dockerfile
@@ -18,12 +18,13 @@ FROM ubuntu:12.04 as base
 # Configure locales and timezone
 RUN apt-get update && \
     apt-get install -y \
-    gettext \
-    locales \
-    tzdata && \
+      gettext \
+      libreadline6 \
+      locales \
+      tzdata && \
     rm -rf /var/lib/apt/lists/*
-RUN echo 'LC_ALL="en_US.UTF-8"' > /etc/default/locale && \
-    locale-gen
+RUN echo 'en_US.UTF-8 UTF-8' > /var/lib/locales/supported.d/local && \
+    dpkg-reconfigure locales
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Properly configure locales
+
 ## [dogwood.3-fun-1.3.5] - 2019-12-12
 
 ### Changed

--- a/releases/dogwood/3/fun/Dockerfile
+++ b/releases/dogwood/3/fun/Dockerfile
@@ -18,12 +18,13 @@ FROM ubuntu:12.04 as base
 # Configure locales and timezone
 RUN apt-get update && \
     apt-get install -y \
-    gettext \
-    locales \
-    tzdata && \
+      gettext \
+      libreadline6 \
+      locales \
+      tzdata && \
     rm -rf /var/lib/apt/lists/*
-RUN echo 'LC_ALL="en_US.UTF-8"' > /etc/default/locale && \
-    locale-gen
+RUN echo 'en_US.UTF-8 UTF-8' > /var/lib/locales/supported.d/local && \
+    dpkg-reconfigure locales
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8

--- a/releases/eucalyptus/3/bare/CHANGELOG.md
+++ b/releases/eucalyptus/3/bare/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Properly configure locales
+
 ## [eucalyptus.3-1.0.2] - 2019-12-10
 
 ### Fixed

--- a/releases/eucalyptus/3/bare/Dockerfile
+++ b/releases/eucalyptus/3/bare/Dockerfile
@@ -14,18 +14,20 @@ ARG EDX_RELEASE_REF=open-release/eucalyptus.3
 # === BASE ===
 FROM ubuntu:16.04 as base
 
-# Configure locales & timezone
+# Configure locales and timezone
 RUN apt-get update && \
     apt-get install -y \
       gettext \
+      libreadline6 \
       locales \
       tzdata && \
     rm -rf /var/lib/apt/lists/*
-RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+RUN sed -i 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     locale-gen
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
+
 
 # === DOWNLOAD ===
 FROM base as downloads

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Properly configure locales
+
 ## [eucalyptus.3-wb-1.0.4] - 2019-12-12
 
 ### Changed

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -12,6 +12,7 @@ release.
 ### Fixed
 
 - Properly configure locales
+- Remove duplicated `redis` package installation
 
 ## [eucalyptus.3-wb-1.0.4] - 2019-12-12
 

--- a/releases/eucalyptus/3/wb/Dockerfile
+++ b/releases/eucalyptus/3/wb/Dockerfile
@@ -124,9 +124,6 @@ RUN pip install -r requirements/edx/base.txt
 RUN pip install -r requirements/edx/paver.txt
 RUN pip install -r requirements/edx/post.txt
 RUN pip install -r requirements/edx/local.txt
-# Redis is an extra requirement of Celery, we need to install it explicitly so
-# that celery workers are effective
-RUN pip install redis==3.3.7
 # Installing FUN requirements needs a recent pip release (we are using
 # setup.cfg declarative packages)
 RUN pip install -r requirements/edx/fun.txt

--- a/releases/eucalyptus/3/wb/Dockerfile
+++ b/releases/eucalyptus/3/wb/Dockerfile
@@ -15,14 +15,15 @@ ARG EDX_ARCHIVE_URL=https://github.com/openfun/edx-platform/archive/fun/whitebra
 # === BASE ===
 FROM ubuntu:16.04 as base
 
-# Configure locales & timezone
+# Configure locales and timezone
 RUN apt-get update && \
     apt-get install -y \
       gettext \
+      libreadline6 \
       locales \
       tzdata && \
     rm -rf /var/lib/apt/lists/*
-RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+RUN sed -i 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     locale-gen
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en


### PR DESCRIPTION
## Purpose

Dogwood & Eucalyptus images locales are not properly configured for an ubuntu-based image.

## Proposal

- [x] use `dpkg-reconfigure`
- [x] install `readline` library
- [x] remove duplicated `redis` python library installation (`eucalyptus/3/wb`)