### PR TITLE
Dogwood: fix SSL certificate checking errors

### DIFF
--- a/releases/dogwood/3/bare/CHANGELOG.md
+++ b/releases/dogwood/3/bare/CHANGELOG.md
@@ -12,6 +12,7 @@ release.
 ### Fixed
 
 - Properly configure locales
+- Use pyOpenSSL instead of local openssl library for SSL certificate checking
 
 ## [dogwood.3-1.1.2] - 2019-12-10
 

--- a/releases/dogwood/3/bare/CHANGELOG.md
+++ b/releases/dogwood/3/bare/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-1.1.3] - 2019-12-15
+
 ### Fixed
 
 - Properly configure locales
@@ -39,7 +41,8 @@ release.
 
 First experimental release of OpenEdx `dogwood.3` (bare flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-1.1.2...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-1.1.3...HEAD
+[dogwood.3-1.1.3]: https://github.com/openfun/openedx-docker/compare/tag/dogwood.3-1.1.2...dogwood.3-1.1.3
 [dogwood.3-1.1.2]: https://github.com/openfun/openedx-docker/compare/tag/dogwood.3-1.1.1...dogwood.3-1.1.2
 [dogwood.3-1.1.1]: https://github.com/openfun/openedx-docker/compare/tag/dogwood.3-1.1.0...dogwood.3-1.1.1
 [dogwood.3-1.1.0]: https://github.com/openfun/openedx-docker/compare/tag/dogwood.3-1.0.0...dogwood.3-1.1.0

--- a/releases/dogwood/3/bare/Dockerfile
+++ b/releases/dogwood/3/bare/Dockerfile
@@ -156,10 +156,19 @@ RUN pip install -r requirements/edx/base.txt
 RUN pip install -r requirements/edx/paver.txt
 RUN pip install -r requirements/edx/post.txt
 RUN pip install -r requirements/edx/local.txt
+# Install extras dependencies
+#
 # Redis is an extra requirement of Celery, we need to install it explicitly so
-# that celery workers are effective
-RUN pip install redis==3.3.7
-
+# that celery workers are effective.
+#
+# Requests should be upgraded with a recent secure flavor of urrllib3 to
+# prevent SSL certificate validation failure (we should use pyOpenSSL instead
+# of the local openssl library). For reference, see:
+# https://urllib3.readthedocs.io/en/latest/user-guide.html#ssl-py2
+RUN pip install --upgrade \
+      redis==3.3.7 \
+      requests==2.22.0 \
+      urllib3[secure]==1.25.7
 # Update assets skipping collectstatic (it should be done during deployment)
 RUN NO_PREREQ_INSTALL=1 \
     paver update_assets --settings=fun.docker_build --skip-collect

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -12,6 +12,7 @@ release.
 ### Fixed
 
 - Properly configure locales
+- Use pyOpenSSL instead of local openssl library for SSL certificate checking
 
 ## [dogwood.3-fun-1.3.5] - 2019-12-12
 

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-1.3.6] - 2019-12-15
+
 ### Fixed
 
 - Properly configure locales
@@ -82,7 +84,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.5...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.6...HEAD
+[dogwood.3-fun-1.3.6]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.5...dogwood.3-fun-1.3.6
 [dogwood.3-fun-1.3.5]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.4...dogwood.3-fun-1.3.5
 [dogwood.3-fun-1.3.4]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.3...dogwood.3-fun-1.3.4
 [dogwood.3-fun-1.3.3]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.2...dogwood.3-fun-1.3.3

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -21,3 +21,9 @@ celery-redis-sentinel==0.3.0
 django-redis-sessions==0.6.1
 raven==6.9.0
 redis==2.10.6
+# Upgrade requests and urllib3 to prevent SSL certificate validation failure
+# (we should use pyOpenSSL instead of the local openssl library). For
+# reference, see:
+# https://urllib3.readthedocs.io/en/latest/user-guide.html#ssl-py2
+requests==2.22.0
+urllib3[secure]==1.25.7


### PR DESCRIPTION
## Purpose

Python2 openssl support in Ubuntu 12.04 relies on the outdated system openssl library, leading to SSL certicate verification failures (lack of SNI support, etc.). To mitigate this issue, it is recommended to install a recent release of urllib3 that uses pyOpenSSL instead to achieve the checking step.

## Proposal

- [x] upgrade `requests` to a recent release
- [x] install `urllib3[secure]`
