### PR TITLE
🔧(*/flavors) configure `general` memcached cache backend

### DIFF
--- a/releases/dogwood/3/bare/CHANGELOG.md
+++ b/releases/dogwood/3/bare/CHANGELOG.md
@@ -9,6 +9,11 @@ release.
 
 ## [Unreleased]
 
+### Added
+
+- Configure `general` cache backend including cache keys sanitizing function
+
+
 ## [dogwood.3-1.1.3] - 2019-12-15
 
 ### Fixed

--- a/releases/dogwood/3/bare/config/cms/docker_run_production.py
+++ b/releases/dogwood/3/bare/config/cms/docker_run_production.py
@@ -155,6 +155,11 @@ CACHES = config(
             "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
             "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
         },
+        "general": {
+            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
+            "KEY_FUNCTION": "util.memcache.safe_key",
+        },
     },
     formatter=json.loads,
 )

--- a/releases/dogwood/3/bare/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/bare/config/lms/docker_run_production.py
@@ -231,6 +231,11 @@ CACHES = config(
             "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
             "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
         },
+        "general": {
+            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
+            "KEY_FUNCTION": "util.memcache.safe_key",
+        },
     },
     formatter=json.loads,
 )

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,11 @@ release.
 
 ## [Unreleased]
 
+### Added
+
+- Configure `general` cache backend including cache keys sanitizing function
+
+
 ## [dogwood.3-fun-1.3.6] - 2019-12-15
 
 ### Fixed

--- a/releases/dogwood/3/fun/config/cms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/cms/docker_run_production.py
@@ -159,6 +159,11 @@ CACHES = config(
             "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
             "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
         },
+        "general": {
+            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
+            "KEY_FUNCTION": "util.memcache.safe_key",
+        },
     },
     formatter=json.loads,
 )

--- a/releases/dogwood/3/fun/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/lms/docker_run_production.py
@@ -265,6 +265,11 @@ CACHES = config(
             "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
             "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
         },
+        "general": {
+            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
+            "KEY_FUNCTION": "util.memcache.safe_key",
+        },
     },
     formatter=json.loads,
 )

--- a/releases/eucalyptus/3/bare/CHANGELOG.md
+++ b/releases/eucalyptus/3/bare/CHANGELOG.md
@@ -9,6 +9,11 @@ release.
 
 ## [Unreleased]
 
+### Added
+
+- Configure `general` cache backend including cache keys sanitizing function
+
+
 ### Fixed
 
 - Properly configure locales

--- a/releases/eucalyptus/3/bare/config/cms/docker_run_production.py
+++ b/releases/eucalyptus/3/bare/config/cms/docker_run_production.py
@@ -175,6 +175,11 @@ CACHES = config(
             "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
             "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
         },
+        "general": {
+            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
+            "KEY_FUNCTION": "util.memcache.safe_key",
+        },
     },
     formatter=json.loads,
 )

--- a/releases/eucalyptus/3/bare/config/lms/docker_run_production.py
+++ b/releases/eucalyptus/3/bare/config/lms/docker_run_production.py
@@ -265,6 +265,11 @@ CACHES = config(
             "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
             "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
         },
+        "general": {
+            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
+            "KEY_FUNCTION": "util.memcache.safe_key",
+        },
     },
     formatter=json.loads,
 )

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Added
+
+- Configure `general` cache backend including cache keys sanitizing function
+
 ### Fixed
 
 - Properly configure locales

--- a/releases/eucalyptus/3/wb/config/cms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/cms/docker_run_production.py
@@ -175,6 +175,11 @@ CACHES = config(
             "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
             "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
         },
+        "general": {
+            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
+            "KEY_FUNCTION": "util.memcache.safe_key",
+        },
     },
     formatter=json.loads,
 )

--- a/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
@@ -290,6 +290,11 @@ CACHES = config(
             "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
             "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
         },
+        "general": {
+            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
+            "KEY_FUNCTION": "util.memcache.safe_key",
+        },
     },
     formatter=json.loads,
 )
@@ -826,7 +831,7 @@ BROKER_URL = "{transport}://{user}:{password}@{host}:{port}/{vhost}".format(
     port=CELERY_BROKER_PORT,
     vhost=CELERY_BROKER_VHOST,
 )
-# To use redis-sentinel, refer to the documenation here 
+# To use redis-sentinel, refer to the documenation here
 # https://celery-redis-sentinel.readthedocs.io/en/latest/
 BROKER_TRANSPORT_OPTIONS = config("BROKER_TRANSPORT_OPTIONS", default={}, formatter=json.loads)
 

--- a/releases/hawthorn/1/bare/CHANGELOG.md
+++ b/releases/hawthorn/1/bare/CHANGELOG.md
@@ -9,6 +9,11 @@ release.
 
 ## [Unreleased]
 
+### Added
+
+- Configure `general` cache backend including cache keys sanitizing function
+
+
 ## [hawthorn.1-2.8.0] - 2019-11-22
 
 ### Added

--- a/releases/hawthorn/1/bare/config/cms/docker_run_production.py
+++ b/releases/hawthorn/1/bare/config/cms/docker_run_production.py
@@ -156,7 +156,12 @@ CACHES = config(
         "default": {
             "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
             "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
-        }
+        },
+        "general": {
+            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
+            "KEY_FUNCTION": "util.memcache.safe_key",
+        },
     },
     formatter=json.loads,
 )

--- a/releases/hawthorn/1/bare/config/lms/docker_run_production.py
+++ b/releases/hawthorn/1/bare/config/lms/docker_run_production.py
@@ -224,6 +224,11 @@ CACHES = config(
             "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
             "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
         },
+        "general": {
+            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
+            "KEY_FUNCTION": "util.memcache.safe_key",
+        },
     },
     formatter=json.loads,
 )

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -9,6 +9,11 @@ release.
 
 ## [Unreleased]
 
+### Added
+
+- Configure `general` cache backend including cache keys sanitizing function
+
+
 ## [hawthorn.1-oee-2.12.3] - 2019-12-10
 
 ### Fixed

--- a/releases/hawthorn/1/oee/config/cms/docker_run_production.py
+++ b/releases/hawthorn/1/oee/config/cms/docker_run_production.py
@@ -157,7 +157,12 @@ CACHES = config(
         "default": {
             "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
             "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
-        }
+        },
+        "general": {
+            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
+            "KEY_FUNCTION": "util.memcache.safe_key",
+        },
     },
     formatter=json.loads,
 )
@@ -546,7 +551,7 @@ BROKER_URL = "{transport}://{user}:{password}@{host}:{port}/{vhost}".format(
     vhost=CELERY_BROKER_VHOST,
 )
 BROKER_USE_SSL = config("CELERY_BROKER_USE_SSL", default=False, formatter=bool)
-# To use redis-sentinel, refer to the documentation here 
+# To use redis-sentinel, refer to the documentation here
 # https://celery-redis-sentinel.readthedocs.io/en/latest/
 BROKER_TRANSPORT_OPTIONS = config("BROKER_TRANSPORT_OPTIONS", default={}, formatter=json.loads)
 

--- a/releases/hawthorn/1/oee/config/lms/docker_run_production.py
+++ b/releases/hawthorn/1/oee/config/lms/docker_run_production.py
@@ -250,6 +250,11 @@ CACHES = config(
             "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
             "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
         },
+        "general": {
+            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
+            "KEY_FUNCTION": "util.memcache.safe_key",
+        },
     },
     formatter=json.loads,
 )
@@ -795,7 +800,7 @@ BROKER_URL = "{transport}://{user}:{password}@{host}:{port}/{vhost}".format(
     vhost=CELERY_BROKER_VHOST,
 )
 BROKER_USE_SSL = config("CELERY_BROKER_USE_SSL", default=False, formatter=bool)
-# To use redis-sentinel, refer to the documentation here 
+# To use redis-sentinel, refer to the documentation here
 # https://celery-redis-sentinel.readthedocs.io/en/latest/
 BROKER_TRANSPORT_OPTIONS = config("BROKER_TRANSPORT_OPTIONS", default={}, formatter=json.loads)
 

--- a/releases/master/bare/config/cms/docker_run_production.py
+++ b/releases/master/bare/config/cms/docker_run_production.py
@@ -156,7 +156,12 @@ CACHES = config(
         "default": {
             "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
             "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
-        }
+        },
+        "general": {
+            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
+            "KEY_FUNCTION": "util.memcache.safe_key",
+        },
     },
     formatter=json.loads,
 )

--- a/releases/master/bare/config/lms/docker_run_production.py
+++ b/releases/master/bare/config/lms/docker_run_production.py
@@ -224,6 +224,11 @@ CACHES = config(
             "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
             "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
         },
+        "general": {
+            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
+            "KEY_FUNCTION": "util.memcache.safe_key",
+        },
     },
     formatter=json.loads,
 )


### PR DESCRIPTION
Edx code attempts to creates Memcached keys containing spaces which
is not allowed, so cache keys have to be sanitized.
Therefore default Django configuration is not suited, here we
set a `general` cache backend which is used by incorrect edx code and
provide a normalizing function.
