### PR TITLE
[Dogwood/Eucalyptus] fix PIPELINE settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,8 @@ $(FLAVORED_EDX_RELEASE_PATH)/src/edx-demo-course/README.md:
 	tar xzf /tmp/edx-demo.tgz -C $(FLAVORED_EDX_RELEASE_PATH)/src/edx-demo-course --strip-components=1
 
 bootstrap: \
+  stop \
+  clean \
   clean-db \
   tree \
   build \
@@ -129,7 +131,9 @@ build:  ## build the edxapp production image
 .PHONY: build
 
 clean:  ## remove downloaded sources
-	rm -fr $(FLAVORED_EDX_RELEASE_PATH)/src/*
+	rm -Ir \
+	  $(FLAVORED_EDX_RELEASE_PATH)/src/* \
+	  $(FLAVORED_EDX_RELEASE_PATH)/data/* || exit
 .PHONY: clean
 
 clean-db: \

--- a/releases/dogwood/3/bare/CHANGELOG.md
+++ b/releases/dogwood/3/bare/CHANGELOG.md
@@ -9,10 +9,13 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix broken CMS JS build by enabling Pipeline's static files storage
+
 ### Added
 
 - Configure `general` cache backend including cache keys sanitizing function
-
 
 ## [dogwood.3-1.1.3] - 2019-12-15
 

--- a/releases/dogwood/3/bare/config/cms/docker_run_production.py
+++ b/releases/dogwood/3/bare/config/cms/docker_run_production.py
@@ -117,9 +117,12 @@ CELERY_ACCEPT_CONTENT = ["json"]
 # for course data
 GITHUB_REPO_ROOT = config("GITHUB_REPO_ROOT", default=GITHUB_REPO_ROOT)
 
+STATIC_URL_BASE = "/static/"
 STATIC_URL = "/static/studio/"
 STATIC_ROOT_BASE = path("/edx/app/edxapp/staticfiles")
 STATIC_ROOT = path("/edx/app/edxapp/staticfiles/studio")
+STATICFILES_STORAGE = "pipeline.storage.PipelineCachedStorage"
+PIPELINE = True
 
 EMAIL_BACKEND = config(
     "EMAIL_BACKEND", default="django.core.mail.backends.smtp.EmailBackend"

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix broken CMS JS build by enabling Pipeline's static files storage
+
 ## [dogwood.3-fun-1.3.7] - 2019-12-16
 
 ### Added

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,13 +9,15 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-1.3.8] - 2019-12-16
+
 ### Fixed
 
 - Fix broken CMS JS build by enabling Pipeline's static files storage
 
 ## [dogwood.3-fun-1.3.7] - 2019-12-16
 
-### Added
+### Fixed
 
 - Configure `general` cache backend including cache keys sanitizing function
 
@@ -94,7 +96,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.7...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.8...HEAD
+[dogwood.3-fun-1.3.8]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.7...dogwood.3-fun-1.3.8
 [dogwood.3-fun-1.3.7]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.6...dogwood.3-fun-1.3.7
 [dogwood.3-fun-1.3.6]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.5...dogwood.3-fun-1.3.6
 [dogwood.3-fun-1.3.5]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.4...dogwood.3-fun-1.3.5

--- a/releases/dogwood/3/fun/config/cms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/cms/docker_run_production.py
@@ -121,9 +121,12 @@ CELERY_ACCEPT_CONTENT = ["json"]
 # for course data
 GITHUB_REPO_ROOT = config("GITHUB_REPO_ROOT", default=GITHUB_REPO_ROOT)
 
+STATIC_URL_BASE = "/static/"
 STATIC_URL = "/static/studio/"
 STATIC_ROOT_BASE = path("/edx/app/edxapp/staticfiles")
 STATIC_ROOT = path("/edx/app/edxapp/staticfiles/studio")
+STATICFILES_STORAGE = "pipeline.storage.PipelineCachedStorage"
+PIPELINE = True
 
 EMAIL_BACKEND = config(
     "EMAIL_BACKEND", default="django.core.mail.backends.smtp.EmailBackend"

--- a/releases/eucalyptus/3/bare/CHANGELOG.md
+++ b/releases/eucalyptus/3/bare/CHANGELOG.md
@@ -17,6 +17,7 @@ release.
 ### Fixed
 
 - Properly configure locales
+- Fix broken CMS JS build by enabling Pipeline's static files storage
 
 ## [eucalyptus.3-1.0.2] - 2019-12-10
 

--- a/releases/eucalyptus/3/bare/config/cms/docker_run_production.py
+++ b/releases/eucalyptus/3/bare/config/cms/docker_run_production.py
@@ -137,9 +137,12 @@ DEFAULT_COURSE_ABOUT_IMAGE_URL = config(
 # for course data
 GITHUB_REPO_ROOT = config("GITHUB_REPO_ROOT", default=GITHUB_REPO_ROOT)
 
+STATIC_URL_BASE = "/static/"
 STATIC_URL = "/static/studio/"
 STATIC_ROOT_BASE = path("/edx/app/edxapp/staticfiles")
 STATIC_ROOT = path("/edx/app/edxapp/staticfiles/studio")
+STATICFILES_STORAGE = "pipeline.storage.PipelineCachedStorage"
+PIPELINE = True
 
 EMAIL_BACKEND = config(
     "EMAIL_BACKEND", default="django.core.mail.backends.smtp.EmailBackend"

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,14 +9,13 @@ release.
 
 ## [Unreleased]
 
-### Added
-
-- Configure `general` cache backend including cache keys sanitizing function
+## [eucalyptus.3-wb-1.0.5] - 2019-12-16
 
 ### Fixed
 
 - Properly configure locales
 - Remove duplicated `redis` package installation
+- Configure `general` cache backend including cache keys sanitizing function
 - Fix broken CMS JS build by enabling Pipeline's static files storage
 
 ## [eucalyptus.3-wb-1.0.4] - 2019-12-12
@@ -53,7 +52,8 @@ release.
 - Set replicaSet and read_preference in mongodb connection
 - Add missing support for redis sentinel
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.0.4...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.0.5...HEAD
+[eucalyptus.3-wb-1.0.5]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.0.4...eucalyptus.3-wb-1.0.5
 [eucalyptus.3-wb-1.0.4]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.0.3...eucalyptus.3-wb-1.0.4
 [eucalyptus.3-wb-1.0.3]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.0.2...eucalyptus.3-wb-1.0.3
 [eucalyptus.3-wb-1.0.2]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.0.1...eucalyptus.3-wb-1.0.2

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -17,6 +17,7 @@ release.
 
 - Properly configure locales
 - Remove duplicated `redis` package installation
+- Fix broken CMS JS build by enabling Pipeline's static files storage
 
 ## [eucalyptus.3-wb-1.0.4] - 2019-12-12
 

--- a/releases/eucalyptus/3/wb/config/cms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/cms/docker_run_production.py
@@ -137,9 +137,12 @@ DEFAULT_COURSE_ABOUT_IMAGE_URL = config(
 # for course data
 GITHUB_REPO_ROOT = config("GITHUB_REPO_ROOT", default=GITHUB_REPO_ROOT)
 
+STATIC_URL_BASE = "/static/"
 STATIC_URL = "/static/studio/"
 STATIC_ROOT_BASE = path("/edx/app/edxapp/staticfiles")
 STATIC_ROOT = path("/edx/app/edxapp/staticfiles/studio")
+STATICFILES_STORAGE = "pipeline.storage.PipelineCachedStorage"
+PIPELINE = True
 
 EMAIL_BACKEND = config(
     "EMAIL_BACKEND", default="django.core.mail.backends.smtp.EmailBackend"


### PR DESCRIPTION
## Purpose

Compiled JS sources are not properly compiled and broke courses edition in the studio.

## Proposal

- [x] use Django Pipeline static files storage (Fix #155)

During this PR I've also:

- [x] ensure sources consistency in development (Fix #158)
