### PR TITLE
🐛(project) ensure the clean target never fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ build:  ## build the edxapp production image
 clean:  ## remove downloaded sources
 	rm -Ir \
 	  $(FLAVORED_EDX_RELEASE_PATH)/src/* \
-	  $(FLAVORED_EDX_RELEASE_PATH)/data/* || exit
+	  $(FLAVORED_EDX_RELEASE_PATH)/data/* || exit 0
 .PHONY: clean
 
 clean-db: \


### PR DESCRIPTION
## Purpose

We recently changed the clean Makefile target to remove sources and data for a flavored release. We decided to make it interactive so that one cannot delete data by mistake.

The counterpart of this behavior is that we cannot force the removal and thus the `rm` command can fail when target files do not exist.

When using the clean target directly it is not an issue at all, but when used as a dependency if the clean target fails, the expected target cannot execute (_e.g._ bootstrap). So, to make a long story short, we ignore clean target errors by always returning a success exit code.

## Proposal

- [x] always return 0 exit code in the `clean` Makefile target