### PR TITLE
Add missing setting lms root url and release fixes for dogwood and eucalyptus images

### DIFF
--- a/releases/dogwood/3/bare/CHANGELOG.md
+++ b/releases/dogwood/3/bare/CHANGELOG.md
@@ -11,6 +11,7 @@ release.
 
 ### Fixed
 
+- Add missing setting `LMS_ROOT_URL` used to compute absolute urls
 - Fix broken CMS JS build by enabling Pipeline's static files storage
 
 ### Added

--- a/releases/dogwood/3/bare/CHANGELOG.md
+++ b/releases/dogwood/3/bare/CHANGELOG.md
@@ -9,13 +9,12 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-1.1.4] - 2019-12-19
+
 ### Fixed
 
 - Add missing setting `LMS_ROOT_URL` used to compute absolute urls
 - Fix broken CMS JS build by enabling Pipeline's static files storage
-
-### Added
-
 - Configure `general` cache backend including cache keys sanitizing function
 - Fix `GITHUB_REPO_ROOT` and `DATA_DIR` settings
 
@@ -51,7 +50,8 @@ release.
 
 First experimental release of OpenEdx `dogwood.3` (bare flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-1.1.3...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-1.1.4...HEAD
+[dogwood.3-1.1.4]: https://github.com/openfun/openedx-docker/compare/tag/dogwood.3-1.1.3...dogwood.3-1.1.4
 [dogwood.3-1.1.3]: https://github.com/openfun/openedx-docker/compare/tag/dogwood.3-1.1.2...dogwood.3-1.1.3
 [dogwood.3-1.1.2]: https://github.com/openfun/openedx-docker/compare/tag/dogwood.3-1.1.1...dogwood.3-1.1.2
 [dogwood.3-1.1.1]: https://github.com/openfun/openedx-docker/compare/tag/dogwood.3-1.1.0...dogwood.3-1.1.1

--- a/releases/dogwood/3/bare/CHANGELOG.md
+++ b/releases/dogwood/3/bare/CHANGELOG.md
@@ -17,6 +17,7 @@ release.
 ### Added
 
 - Configure `general` cache backend including cache keys sanitizing function
+- Fix `GITHUB_REPO_ROOT` and `DATA_DIR` settings
 
 ## [dogwood.3-1.1.3] - 2019-12-15
 

--- a/releases/dogwood/3/bare/config/cms/docker_run_production.py
+++ b/releases/dogwood/3/bare/config/cms/docker_run_production.py
@@ -136,6 +136,9 @@ EMAIL_USE_TLS = config("EMAIL_USE_TLS", default=False, formatter=bool)
 LMS_BASE = config("LMS_BASE", default="localhost:8072")
 CMS_BASE = config("CMS_BASE", default="localhost:8082")
 
+LMS_ROOT_URL = config("LMS_ROOT_URL", default="http://{:s}".format(LMS_BASE))
+LMS_INTERNAL_ROOT_URL = config("LMS_INTERNAL_ROOT_URL", default=LMS_ROOT_URL)
+
 SITE_NAME = config("SITE_NAME", default=CMS_BASE)
 
 ALLOWED_HOSTS = config(

--- a/releases/dogwood/3/bare/config/cms/docker_run_production.py
+++ b/releases/dogwood/3/bare/config/cms/docker_run_production.py
@@ -113,9 +113,8 @@ CELERY_ACCEPT_CONTENT = ["json"]
 ############# NON-SECURE ENV CONFIG ##############################
 # Things like server locations, ports, etc.
 
-# GITHUB_REPO_ROOT is the base directory
-# for course data
-GITHUB_REPO_ROOT = config("GITHUB_REPO_ROOT", default=GITHUB_REPO_ROOT)
+# GITHUB_REPO_ROOT is the base directory for course data
+GITHUB_REPO_ROOT = config("GITHUB_REPO_ROOT", default="/edx/app/edxapp/data")
 
 STATIC_URL_BASE = "/static/"
 STATIC_URL = "/static/studio/"

--- a/releases/dogwood/3/bare/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/bare/config/lms/docker_run_production.py
@@ -201,6 +201,9 @@ FEATURES.update(CONFIG_FEATURES)
 LMS_BASE = config("LMS_BASE", default="localhost:8072")
 CMS_BASE = config("CMS_BASE", default="localhost:8082")
 
+LMS_ROOT_URL = config("LMS_ROOT_URL", default="http://{:s}".format(LMS_BASE))
+LMS_INTERNAL_ROOT_URL = config("LMS_INTERNAL_ROOT_URL", default=LMS_ROOT_URL)
+
 SITE_NAME = config("SITE_NAME", default=LMS_BASE)
 
 ALLOWED_HOSTS = config(

--- a/releases/dogwood/3/bare/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/bare/config/lms/docker_run_production.py
@@ -338,7 +338,7 @@ local_loglevel = config("LOCAL_LOGLEVEL", default="INFO")
 # Configure Logging
 
 LOG_DIR = config("LOG_DIR", default="/edx/var/logs/edx")
-DATA_DIR = config("DATA_DIR", default="/edx/var/edxapp")
+DATA_DIR = config("DATA_DIR", default="/edx/app/edxapp/data")
 
 # Default format for syslog logging
 standard_format = "%(asctime)s %(levelname)s %(process)d [%(name)s] %(filename)s:%(lineno)d - %(message)s"

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,10 +9,12 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-1.4.0] - 2019-12-19
+
 ### Added
 
 - Force edX to use `libcast_xblock` as default video xblock
-- # Use custom demo course for FUN's flavors
+- Use custom demo course for FUN's flavors
 
 ### Fixed
 
@@ -106,7 +108,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.8...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.4.0...HEAD
+[dogwood.3-fun-1.4.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.8...dogwood.3-fun-1.4.0
 [dogwood.3-fun-1.3.8]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.7...dogwood.3-fun-1.3.8
 [dogwood.3-fun-1.3.7]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.6...dogwood.3-fun-1.3.7
 [dogwood.3-fun-1.3.6]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.5...dogwood.3-fun-1.3.6

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -17,6 +17,7 @@ release.
 ### Fixed
 
 - Add missing setting `LMS_ROOT_URL` used to compute absolute urls
+- Fix `GITHUB_REPO_ROOT` and `DATA_DIR` settings
 
 ## [dogwood.3-fun-1.3.8] - 2019-12-16
 

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -12,7 +12,11 @@ release.
 ### Added
 
 - Force edX to use `libcast_xblock` as default video xblock
-- Use custom demo course for FUN's flavors
+- # Use custom demo course for FUN's flavors
+
+### Fixed
+
+- Add missing setting `LMS_ROOT_URL` used to compute absolute urls
 
 ## [dogwood.3-fun-1.3.8] - 2019-12-16
 

--- a/releases/dogwood/3/fun/config/cms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/cms/docker_run_production.py
@@ -140,6 +140,9 @@ EMAIL_USE_TLS = config("EMAIL_USE_TLS", default=False, formatter=bool)
 LMS_BASE = config("LMS_BASE", default="localhost:8072")
 CMS_BASE = config("CMS_BASE", default="localhost:8082")
 
+LMS_ROOT_URL = config("LMS_ROOT_URL", default="http://{:s}".format(LMS_BASE))
+LMS_INTERNAL_ROOT_URL = config("LMS_INTERNAL_ROOT_URL", default=LMS_ROOT_URL)
+
 SITE_NAME = config("SITE_NAME", default=CMS_BASE)
 
 ALLOWED_HOSTS = config(

--- a/releases/dogwood/3/fun/config/cms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/cms/docker_run_production.py
@@ -117,9 +117,8 @@ CELERY_ACCEPT_CONTENT = ["json"]
 ############# NON-SECURE ENV CONFIG ##############################
 # Things like server locations, ports, etc.
 
-# GITHUB_REPO_ROOT is the base directory
-# for course data
-GITHUB_REPO_ROOT = config("GITHUB_REPO_ROOT", default=GITHUB_REPO_ROOT)
+# GITHUB_REPO_ROOT is the base directory for course data
+GITHUB_REPO_ROOT = config("GITHUB_REPO_ROOT", default="/edx/app/edxapp/data")
 
 STATIC_URL_BASE = "/static/"
 STATIC_URL = "/static/studio/"

--- a/releases/dogwood/3/fun/config/cms/fun.py
+++ b/releases/dogwood/3/fun/config/cms/fun.py
@@ -52,10 +52,6 @@ SUBTITLE_SUPPORTED_LANGUAGES = LazyChoicesSorter(
     if code not in ("zh-cn", "zh-tw")
 )
 
-# This constant as nothing to do with github.
-# Path is used to store tar.gz courses before import process
-GITHUB_REPO_ROOT = DATA_DIR
-
 # Haystack configuration (default is minimal working configuration)
 HAYSTACK_CONNECTIONS = config(
     "HAYSTACK_CONNECTIONS",

--- a/releases/dogwood/3/fun/config/cms/settings.yml
+++ b/releases/dogwood/3/fun/config/cms/settings.yml
@@ -49,7 +49,7 @@ LANGUAGES:
 PIPELINE: true
 STATICFILES_STORAGE: pipeline.storage.PipelineCachedStorage
 
-GITHUB_REPO_ROOT: /edx/var/edxapp/data
+GITHUB_REPO_ROOT: /edx/app/edxapp/data
 
 # Make sure we see the draft on preview....
 HOSTNAME_MODULESTORE_DEFAULT_MAPPINGS:

--- a/releases/dogwood/3/fun/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/lms/docker_run_production.py
@@ -372,7 +372,7 @@ local_loglevel = config("LOCAL_LOGLEVEL", default="INFO")
 # Configure Logging
 
 LOG_DIR = config("LOG_DIR", default="/edx/var/logs/edx")
-DATA_DIR = config("DATA_DIR", default="/edx/var/edxapp")
+DATA_DIR = config("DATA_DIR", default="/edx/app/edxapp/data")
 
 # Default format for syslog logging
 standard_format = "%(asctime)s %(levelname)s %(process)d [%(name)s] %(filename)s:%(lineno)d - %(message)s"

--- a/releases/dogwood/3/fun/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/lms/docker_run_production.py
@@ -235,6 +235,9 @@ FEATURES.update(CONFIG_FEATURES)
 LMS_BASE = config("LMS_BASE", default="localhost:8072")
 CMS_BASE = config("CMS_BASE", default="localhost:8082")
 
+LMS_ROOT_URL = config("LMS_ROOT_URL", default="http://{:s}".format(LMS_BASE))
+LMS_INTERNAL_ROOT_URL = config("LMS_INTERNAL_ROOT_URL", default=LMS_ROOT_URL)
+
 SITE_NAME = config("SITE_NAME", default=LMS_BASE)
 
 ALLOWED_HOSTS = config(

--- a/releases/eucalyptus/3/bare/CHANGELOG.md
+++ b/releases/eucalyptus/3/bare/CHANGELOG.md
@@ -19,6 +19,7 @@ release.
 
 ### Fixed
 
+- Add missing setting `LMS_ROOT_URL` used to compute absolute urls
 - Properly configure locales
 
 ## [eucalyptus.3-1.0.2] - 2019-12-10

--- a/releases/eucalyptus/3/bare/CHANGELOG.md
+++ b/releases/eucalyptus/3/bare/CHANGELOG.md
@@ -21,6 +21,7 @@ release.
 
 - Add missing setting `LMS_ROOT_URL` used to compute absolute urls
 - Properly configure locales
+- Fix `GITHUB_REPO_ROOT` and `DATA_DIR` settings
 
 ## [eucalyptus.3-1.0.2] - 2019-12-10
 

--- a/releases/eucalyptus/3/bare/CHANGELOG.md
+++ b/releases/eucalyptus/3/bare/CHANGELOG.md
@@ -9,17 +9,13 @@ release.
 
 ## [Unreleased]
 
-### Changed
-
-- Upgrade to nodejs 10 engine
-
-### Added
-
-- Configure `general` cache backend including cache keys sanitizing function
+## [eucalyptus.3-1.0.3] - 2019-12-19
 
 ### Fixed
 
+- Upgrade to nodejs 10 engine to repair failing image build
 - Add missing setting `LMS_ROOT_URL` used to compute absolute urls
+- Configure `general` cache backend including cache keys sanitizing function
 - Properly configure locales
 - Fix `GITHUB_REPO_ROOT` and `DATA_DIR` settings
 
@@ -42,7 +38,8 @@ release.
 
 - First experimental release of OpenEdx `eucalyptus.3` (bare flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.2...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.3...HEAD
+[eucalyptus.3-1.0.3]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.2...eucalyptus.3-1.0.3
 [eucalyptus.3-1.0.2]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.1...eucalyptus.3-1.0.2
 [eucalyptus.3-1.0.1]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.0...eucalyptus.3-1.0.1
 [eucalyptus.3-1.0.0]: https://github.com/openfun/openedx-docker/releases/tag/eucalyptus.3-1.0.0

--- a/releases/eucalyptus/3/bare/config/cms/docker_run_production.py
+++ b/releases/eucalyptus/3/bare/config/cms/docker_run_production.py
@@ -133,9 +133,8 @@ DEFAULT_COURSE_ABOUT_IMAGE_URL = config(
     "DEFAULT_COURSE_ABOUT_IMAGE_URL", default=DEFAULT_COURSE_ABOUT_IMAGE_URL
 )
 
-# GITHUB_REPO_ROOT is the base directory
-# for course data
-GITHUB_REPO_ROOT = config("GITHUB_REPO_ROOT", default=GITHUB_REPO_ROOT)
+# GITHUB_REPO_ROOT is the base directory for course data
+GITHUB_REPO_ROOT = config("GITHUB_REPO_ROOT", default="/edx/app/edxapp/data")
 
 STATIC_URL = "/static/studio/"
 STATIC_ROOT_BASE = path("/edx/app/edxapp/staticfiles")

--- a/releases/eucalyptus/3/bare/config/cms/docker_run_production.py
+++ b/releases/eucalyptus/3/bare/config/cms/docker_run_production.py
@@ -153,6 +153,9 @@ EMAIL_USE_TLS = config("EMAIL_USE_TLS", default=False, formatter=bool)
 LMS_BASE = config("LMS_BASE", default="localhost:8072")
 CMS_BASE = config("CMS_BASE", default="localhost:8082")
 
+LMS_ROOT_URL = config("LMS_ROOT_URL", default="http://{:s}".format(LMS_BASE))
+LMS_INTERNAL_ROOT_URL = config("LMS_INTERNAL_ROOT_URL", default=LMS_ROOT_URL)
+
 SITE_NAME = config("SITE_NAME", default=CMS_BASE)
 
 ALLOWED_HOSTS = config(

--- a/releases/eucalyptus/3/bare/config/lms/docker_run_production.py
+++ b/releases/eucalyptus/3/bare/config/lms/docker_run_production.py
@@ -235,6 +235,9 @@ if "ENABLE_S3_GRADE_DOWNLOADS" in FEATURES:
 LMS_BASE = config("LMS_BASE", default="localhost:8072")
 CMS_BASE = config("CMS_BASE", default="localhost:8082")
 
+LMS_ROOT_URL = config("LMS_ROOT_URL", default="http://{:s}".format(LMS_BASE))
+LMS_INTERNAL_ROOT_URL = config("LMS_INTERNAL_ROOT_URL", default=LMS_ROOT_URL)
+
 SITE_NAME = config("SITE_NAME", default=LMS_BASE)
 
 ALLOWED_HOSTS = config(

--- a/releases/eucalyptus/3/bare/config/lms/docker_run_production.py
+++ b/releases/eucalyptus/3/bare/config/lms/docker_run_production.py
@@ -390,7 +390,7 @@ local_loglevel = config("LOCAL_LOGLEVEL", default="INFO")
 # Configure Logging
 
 LOG_DIR = config("LOG_DIR", default="/edx/var/logs/edx")
-DATA_DIR = config("DATA_DIR", default="/edx/var/edxapp")
+DATA_DIR = config("DATA_DIR", default="/edx/app/edxapp/data")
 
 # Default format for syslog logging
 standard_format = "%(asctime)s %(levelname)s %(process)d [%(name)s] %(filename)s:%(lineno)d - %(message)s"

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -14,6 +14,10 @@ release.
 - Force edX to use `libcast_xblock` as default video xblock
 - Use custom demo course for FUN's flavors
 
+### Fixed
+
+- Add missing setting `LMS_ROOT_URL` used to compute absolute urls
+
 ## [eucalyptus.3-wb-1.1.0] - 2019-12-18
 
 ### Changed

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [eucalyptus.3-wb-1.2.0] - 2019-12-20
+
 ### Added
 
 - Force edX to use `libcast_xblock` as default video xblock
@@ -72,7 +74,8 @@ release.
 - Set replicaSet and read_preference in mongodb connection
 - Add missing support for redis sentinel
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.1.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.2.0...HEAD
+[eucalyptus.3-wb-1.2.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.1.0...eucalyptus.3-wb-1.2.0
 [eucalyptus.3-wb-1.1.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.0.5...eucalyptus.3-wb-1.1.0
 [eucalyptus.3-wb-1.0.5]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.0.4...eucalyptus.3-wb-1.0.5
 [eucalyptus.3-wb-1.0.4]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.0.3...eucalyptus.3-wb-1.0.4

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -17,6 +17,7 @@ release.
 ### Fixed
 
 - Add missing setting `LMS_ROOT_URL` used to compute absolute urls
+- Fix `GITHUB_REPO_ROOT` and `DATA_DIR` settings
 
 ## [eucalyptus.3-wb-1.1.0] - 2019-12-18
 

--- a/releases/eucalyptus/3/wb/config/cms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/cms/docker_run_production.py
@@ -133,9 +133,8 @@ DEFAULT_COURSE_ABOUT_IMAGE_URL = config(
     "DEFAULT_COURSE_ABOUT_IMAGE_URL", default=DEFAULT_COURSE_ABOUT_IMAGE_URL
 )
 
-# GITHUB_REPO_ROOT is the base directory
-# for course data
-GITHUB_REPO_ROOT = config("GITHUB_REPO_ROOT", default=GITHUB_REPO_ROOT)
+# GITHUB_REPO_ROOT is the base directory for course data
+GITHUB_REPO_ROOT = config("GITHUB_REPO_ROOT", default="/edx/app/edxapp/data")
 
 STATIC_URL = "/static/studio/"
 STATIC_ROOT_BASE = path("/edx/app/edxapp/staticfiles")

--- a/releases/eucalyptus/3/wb/config/cms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/cms/docker_run_production.py
@@ -153,6 +153,9 @@ EMAIL_USE_TLS = config("EMAIL_USE_TLS", default=False, formatter=bool)
 LMS_BASE = config("LMS_BASE", default="localhost:8072")
 CMS_BASE = config("CMS_BASE", default="localhost:8082")
 
+LMS_ROOT_URL = config("LMS_ROOT_URL", default="http://{:s}".format(LMS_BASE))
+LMS_INTERNAL_ROOT_URL = config("LMS_INTERNAL_ROOT_URL", default=LMS_ROOT_URL)
+
 SITE_NAME = config("SITE_NAME", default=CMS_BASE)
 
 ALLOWED_HOSTS = config(

--- a/releases/eucalyptus/3/wb/config/cms/fun.py
+++ b/releases/eucalyptus/3/wb/config/cms/fun.py
@@ -24,10 +24,6 @@ INSTALLED_APPS += (
 
 ROOT_URLCONF = "fun.cms.urls"
 
-# This constant as nothing to do with github.
-# Path is used to store tar.gz courses before import process
-GITHUB_REPO_ROOT = DATA_DIR
-
 # ### THIRD-PARTY SETTINGS ###
 
 # Haystack configuration (default is minimal working configuration)

--- a/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
@@ -200,8 +200,12 @@ SESSION_REDIS_PORT = config("SESSION_REDIS_PORT", default=6379, formatter=int)
 SESSION_REDIS_DB = config("SESSION_REDIS_DB", default=1, formatter=int)
 SESSION_REDIS_PASSWORD = config("SESSION_REDIS_PASSWORD", default=None)
 SESSION_REDIS_PREFIX = config("SESSION_REDIS_PREFIX", default="session")
-SESSION_REDIS_SOCKET_TIMEOUT = config("SESSION_REDIS_SOCKET_TIMEOUT", default=1, formatter=int)
-SESSION_REDIS_RETRY_ON_TIMEOUT = config("SESSION_REDIS_RETRY_ON_TIMEOUT", default=False, formatter=bool)
+SESSION_REDIS_SOCKET_TIMEOUT = config(
+    "SESSION_REDIS_SOCKET_TIMEOUT", default=1, formatter=int
+)
+SESSION_REDIS_RETRY_ON_TIMEOUT = config(
+    "SESSION_REDIS_RETRY_ON_TIMEOUT", default=False, formatter=bool
+)
 
 SESSION_REDIS = config(
     "SESSION_REDIS",
@@ -216,8 +220,12 @@ SESSION_REDIS = config(
     },
     formatter=json.loads,
 )
-SESSION_REDIS_SENTINEL_LIST = config("SESSION_REDIS_SENTINEL_LIST", default=None, formatter=json.loads)
-SESSION_REDIS_SENTINEL_MASTER_ALIAS = config("SESSION_REDIS_SENTINEL_MASTER_ALIAS", default=None)
+SESSION_REDIS_SENTINEL_LIST = config(
+    "SESSION_REDIS_SENTINEL_LIST", default=None, formatter=json.loads
+)
+SESSION_REDIS_SENTINEL_MASTER_ALIAS = config(
+    "SESSION_REDIS_SENTINEL_MASTER_ALIAS", default=None
+)
 
 AWS_SES_REGION_NAME = config("AWS_SES_REGION_NAME", default="us-east-1")
 AWS_SES_REGION_ENDPOINT = config(
@@ -415,7 +423,7 @@ local_loglevel = config("LOCAL_LOGLEVEL", default="INFO")
 # Configure Logging
 
 LOG_DIR = config("LOG_DIR", default="/edx/var/logs/edx")
-DATA_DIR = config("DATA_DIR", default="/edx/var/edxapp")
+DATA_DIR = config("DATA_DIR", default="/edx/app/edxapp/data")
 
 # Default format for syslog logging
 standard_format = "%(asctime)s %(levelname)s %(process)d [%(name)s] %(filename)s:%(lineno)d - %(message)s"
@@ -836,7 +844,9 @@ BROKER_URL = "{transport}://{user}:{password}@{host}:{port}/{vhost}".format(
 )
 # To use redis-sentinel, refer to the documenation here
 # https://celery-redis-sentinel.readthedocs.io/en/latest/
-BROKER_TRANSPORT_OPTIONS = config("BROKER_TRANSPORT_OPTIONS", default={}, formatter=json.loads)
+BROKER_TRANSPORT_OPTIONS = config(
+    "BROKER_TRANSPORT_OPTIONS", default={}, formatter=json.loads
+)
 
 # upload limits
 STUDENT_FILEUPLOAD_MAX_SIZE = config(

--- a/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
@@ -260,6 +260,9 @@ if "ENABLE_S3_GRADE_DOWNLOADS" in FEATURES:
 LMS_BASE = config("LMS_BASE", default="localhost:8072")
 CMS_BASE = config("CMS_BASE", default="localhost:8082")
 
+LMS_ROOT_URL = config("LMS_ROOT_URL", default="http://{:s}".format(LMS_BASE))
+LMS_INTERNAL_ROOT_URL = config("LMS_INTERNAL_ROOT_URL", default=LMS_ROOT_URL)
+
 SITE_NAME = config("SITE_NAME", default=LMS_BASE)
 
 ALLOWED_HOSTS = config(

--- a/releases/hawthorn/1/bare/config/cms/docker_run_production.py
+++ b/releases/hawthorn/1/bare/config/cms/docker_run_production.py
@@ -124,7 +124,7 @@ EMAIL_USE_TLS = config("EMAIL_USE_TLS", default=False, formatter=bool)
 LMS_BASE = config("LMS_BASE", default="localhost:8072")
 CMS_BASE = config("CMS_BASE", default="localhost:8082")
 
-LMS_ROOT_URL = config("LMS_ROOT_URL", default="http://localhost:8072")
+LMS_ROOT_URL = config("LMS_ROOT_URL", default="http://{:s}".format(LMS_BASE))
 LMS_INTERNAL_ROOT_URL = config("LMS_INTERNAL_ROOT_URL", default=LMS_ROOT_URL)
 ENTERPRISE_API_URL = config(
     "ENTERPRISE_API_URL", default=LMS_INTERNAL_ROOT_URL + "/enterprise/api/v1/"

--- a/releases/hawthorn/1/bare/config/lms/docker_run_production.py
+++ b/releases/hawthorn/1/bare/config/lms/docker_run_production.py
@@ -184,15 +184,15 @@ EDXMKTG_USER_INFO_COOKIE_NAME = config(
     "EDXMKTG_USER_INFO_COOKIE_NAME", default=EDXMKTG_USER_INFO_COOKIE_NAME
 )
 
-LMS_ROOT_URL = config("LMS_ROOT_URL", default="http://localhost:8000")
-LMS_INTERNAL_ROOT_URL = config("LMS_INTERNAL_ROOT_URL", default=LMS_ROOT_URL)
-
 # Override feature by feature by whatever is being redefined in the settings.yaml file
 CONFIG_FEATURES = config("FEATURES", default={}, formatter=json.loads)
 FEATURES.update(CONFIG_FEATURES)
 
 LMS_BASE = config("LMS_BASE", default="localhost:8072")
 CMS_BASE = config("CMS_BASE", default="localhost:8082")
+
+LMS_ROOT_URL = config("LMS_ROOT_URL", default="http://{:s}".format(LMS_BASE))
+LMS_INTERNAL_ROOT_URL = config("LMS_INTERNAL_ROOT_URL", default=LMS_ROOT_URL)
 
 SITE_NAME = config("SITE_NAME", default=LMS_BASE)
 

--- a/releases/hawthorn/1/oee/config/cms/docker_run_production.py
+++ b/releases/hawthorn/1/oee/config/cms/docker_run_production.py
@@ -125,7 +125,7 @@ EMAIL_USE_TLS = config("EMAIL_USE_TLS", default=False, formatter=bool)
 LMS_BASE = config("LMS_BASE", default="localhost:8072")
 CMS_BASE = config("CMS_BASE", default="localhost:8082")
 
-LMS_ROOT_URL = config("LMS_ROOT_URL", default="http://localhost:8072")
+LMS_ROOT_URL = config("LMS_ROOT_URL", default="http://{:s}".format(LMS_BASE))
 LMS_INTERNAL_ROOT_URL = config("LMS_INTERNAL_ROOT_URL", default=LMS_ROOT_URL)
 ENTERPRISE_API_URL = config(
     "ENTERPRISE_API_URL", default=LMS_INTERNAL_ROOT_URL + "/enterprise/api/v1/"

--- a/releases/hawthorn/1/oee/config/lms/docker_run_production.py
+++ b/releases/hawthorn/1/oee/config/lms/docker_run_production.py
@@ -210,15 +210,15 @@ EDXMKTG_USER_INFO_COOKIE_NAME = config(
     "EDXMKTG_USER_INFO_COOKIE_NAME", default=EDXMKTG_USER_INFO_COOKIE_NAME
 )
 
-LMS_ROOT_URL = config("LMS_ROOT_URL", default="http://localhost:8000")
-LMS_INTERNAL_ROOT_URL = config("LMS_INTERNAL_ROOT_URL", default=LMS_ROOT_URL)
-
 # Override feature by feature by whatever is being redefined in the settings.yaml file
 CONFIG_FEATURES = config("FEATURES", default={}, formatter=json.loads)
 FEATURES.update(CONFIG_FEATURES)
 
 LMS_BASE = config("LMS_BASE", default="localhost:8072")
 CMS_BASE = config("CMS_BASE", default="localhost:8082")
+
+LMS_ROOT_URL = config("LMS_ROOT_URL", default="http://{:s}".format(LMS_BASE))
+LMS_INTERNAL_ROOT_URL = config("LMS_INTERNAL_ROOT_URL", default=LMS_ROOT_URL)
 
 SITE_NAME = config("SITE_NAME", default=LMS_BASE)
 

--- a/releases/master/bare/CHANGELOG.md
+++ b/releases/master/bare/CHANGELOG.md
@@ -13,8 +13,4 @@ release.
 
 ## [Unreleased]
 
-### Added
-
-- Set replicaSet and read_preference in mongodb connection
-
 [unreleased]: https://github.com/openfun/openedx-docker

--- a/releases/master/bare/config/cms/docker_run_production.py
+++ b/releases/master/bare/config/cms/docker_run_production.py
@@ -124,8 +124,9 @@ EMAIL_USE_TLS = config("EMAIL_USE_TLS", default=False, formatter=bool)
 LMS_BASE = config("LMS_BASE", default="localhost:8072")
 CMS_BASE = config("CMS_BASE", default="localhost:8082")
 
-LMS_ROOT_URL = config("LMS_ROOT_URL", default="http://localhost:8072")
+LMS_ROOT_URL = config("LMS_ROOT_URL", default="http://{:s}".format(LMS_BASE))
 LMS_INTERNAL_ROOT_URL = config("LMS_INTERNAL_ROOT_URL", default=LMS_ROOT_URL)
+
 ENTERPRISE_API_URL = config(
     "ENTERPRISE_API_URL", default=LMS_INTERNAL_ROOT_URL + "/enterprise/api/v1/"
 )

--- a/releases/master/bare/config/lms/docker_run_production.py
+++ b/releases/master/bare/config/lms/docker_run_production.py
@@ -184,8 +184,6 @@ EDXMKTG_USER_INFO_COOKIE_NAME = config(
     "EDXMKTG_USER_INFO_COOKIE_NAME", default=EDXMKTG_USER_INFO_COOKIE_NAME
 )
 
-LMS_ROOT_URL = config("LMS_ROOT_URL", default="http://localhost:8000")
-LMS_INTERNAL_ROOT_URL = config("LMS_INTERNAL_ROOT_URL", default=LMS_ROOT_URL)
 
 # Override feature by feature by whatever is being redefined in the settings.yaml file
 CONFIG_FEATURES = config("FEATURES", default={}, formatter=json.loads)
@@ -193,6 +191,9 @@ FEATURES.update(CONFIG_FEATURES)
 
 LMS_BASE = config("LMS_BASE", default="localhost:8072")
 CMS_BASE = config("CMS_BASE", default="localhost:8082")
+
+LMS_ROOT_URL = config("LMS_ROOT_URL", default="http://{:s}".format(LMS_BASE))
+LMS_INTERNAL_ROOT_URL = config("LMS_INTERNAL_ROOT_URL", default=LMS_ROOT_URL)
 
 SITE_NAME = config("SITE_NAME", default=LMS_BASE)
 


### PR DESCRIPTION
## Purpose

The `LMS_ROOT_URL` setting is missing from dogwood and eucalyptus flavors settings.

This setting is required to compute absolute urls with protocol, domain and subdomains.

## Proposal

Add missing setting `LMS_ROOT_URL` in dogwood and eucalyptus flavors with a default value equal to the local address of the LMS as served in this project.
