### PR TITLE
✨([dogwood|eucalyptus]/3/[fun|wb]) activate studio's `videoupload` page

### DIFF
--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Add missing `fun` application templates directory to default templates directories
+  to activate `videoupload` templates
 - Configure all cache backends as they are in FUN's production instance
 
 ## [dogwood.3-fun-1.6.0] - 2020-01-03

--- a/releases/dogwood/3/fun/config/cms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/cms/docker_run_production.py
@@ -783,6 +783,8 @@ GLOWBL_COLL_OPT = config("GLOWBL_COLL_OPT", default="FunMoocJdR")
 
 # This is dist-packages path where all fun-apps are
 FUN_BASE_ROOT = path(os.path.dirname(pkgutil.get_loader("funsite").filename))
+# Add to Mako template dirs path to `videoupload` panel templates
+DEFAULT_TEMPLATE_ENGINE["DIRS"].append(FUN_BASE_ROOT / "fun/templates/cms")
 
 # Add 'theme/cms/templates' directory to MAKO template finder to override some
 # CMS templates

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,9 +9,11 @@ release.
 
 ## [Unreleased]
 
-### Added
+### Fixed
 
 - Configure all cache backends as they are in FUN's production instance
+- Add missing `fun` application templates directory to default templates directories
+  to activate `videoupload` templates
 
 ### Changed
 

--- a/releases/eucalyptus/3/wb/config/cms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/cms/docker_run_production.py
@@ -821,6 +821,13 @@ FUN_BASE_ROOT = path(os.path.dirname(imp.find_module("funsite")[1]))
 # CMS templates
 MAKO_TEMPLATES["main"] = [FUN_BASE_ROOT / "fun/templates/cms"] + MAKO_TEMPLATES["main"]
 
+# Add to Mako templates dirs path to `videoupload` panel templates
+DEFAULT_TEMPLATE_ENGINE["DIRS"].append(FUN_BASE_ROOT / "fun/templates/cms")
+
+# In `eucalyptus/wb` flavor, this constant has to be set to True (not None)
+# for `videofront` upload dashboard to show up in studio menues.
+FUN_DEFAULT_VIDEO_PLAYER = config("FUN_DEFAULT_VIDEO_PLAYER", default=True, formatter=bool)
+
 # Max size of asset uploads to GridFS
 MAX_ASSET_UPLOAD_FILE_SIZE_IN_MB = config(
     "MAX_ASSET_UPLOAD_FILE_SIZE_IN_MB", default=10, formatter=int


### PR DESCRIPTION
Both FUN flavors were missing some settings to correctly show up
`videoupload` page.

This is what it looks like if you wonder :-D
![Capture d’écran 2019-12-20 à 15 16 56](https://user-images.githubusercontent.com/89626/71260722-d7df4e00-233b-11ea-80cf-2ec7976822e2.png)

