### PR TITLE
Fix wrong use of AUTH_TOKENS

### DIFF
--- a/releases/dogwood/3/bare/CHANGELOG.md
+++ b/releases/dogwood/3/bare/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-1.1.5] - 2019-12-24
+
 ### Fixed
 
 - `AUTH_TOKENS` was wrongly used as a dictionary and default values were lost
@@ -54,7 +56,8 @@ release.
 
 First experimental release of OpenEdx `dogwood.3` (bare flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-1.1.4...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-1.1.5...HEAD
+[dogwood.3-1.1.5]: https://github.com/openfun/openedx-docker/compare/tag/dogwood.3-1.1.4...dogwood.3-1.1.5
 [dogwood.3-1.1.4]: https://github.com/openfun/openedx-docker/compare/tag/dogwood.3-1.1.3...dogwood.3-1.1.4
 [dogwood.3-1.1.3]: https://github.com/openfun/openedx-docker/compare/tag/dogwood.3-1.1.2...dogwood.3-1.1.3
 [dogwood.3-1.1.2]: https://github.com/openfun/openedx-docker/compare/tag/dogwood.3-1.1.1...dogwood.3-1.1.2

--- a/releases/dogwood/3/bare/CHANGELOG.md
+++ b/releases/dogwood/3/bare/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- `AUTH_TOKENS` was wrongly used as a dictionary and default values were lost
+
 ## [dogwood.3-1.1.4] - 2019-12-19
 
 ### Fixed

--- a/releases/dogwood/3/bare/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/bare/config/lms/docker_run_production.py
@@ -831,15 +831,13 @@ if FEATURES.get("ENABLE_THIRD_PARTY_AUTH"):
     # The reduced session expiry time during the third party login pipeline. (Value in seconds)
     SOCIAL_AUTH_PIPELINE_TIMEOUT = config("SOCIAL_AUTH_PIPELINE_TIMEOUT", default=600)
 
-    # Most provider configuration is done via ConfigurationModels but for a few sensitive values
-    # we allow configuration via AUTH_TOKENS instead (optionally).
     # The SAML private/public key values do not need the delimiter lines (such as
     # "-----BEGIN PRIVATE KEY-----", default="-----END PRIVATE KEY-----" etc.) but they may be included
     # if you want (though it's easier to format the key values as JSON without the delimiters).
-    SOCIAL_AUTH_SAML_SP_PRIVATE_KEY = AUTH_TOKENS.get(
+    SOCIAL_AUTH_SAML_SP_PRIVATE_KEY = config(
         "SOCIAL_AUTH_SAML_SP_PRIVATE_KEY", default=""
     )
-    SOCIAL_AUTH_SAML_SP_PUBLIC_CERT = AUTH_TOKENS.get(
+    SOCIAL_AUTH_SAML_SP_PUBLIC_CERT = config(
         "SOCIAL_AUTH_SAML_SP_PUBLIC_CERT", default=""
     )
     SOCIAL_AUTH_OAUTH_SECRETS = config(
@@ -1016,7 +1014,7 @@ FIELD_OVERRIDE_PROVIDERS += (
 
 # PROFILE IMAGE CONFIG
 PROFILE_IMAGE_BACKEND = config("PROFILE_IMAGE_BACKEND", default=PROFILE_IMAGE_BACKEND)
-PROFILE_IMAGE_SECRET_KEY = AUTH_TOKENS.get(
+PROFILE_IMAGE_SECRET_KEY = config(
     "PROFILE_IMAGE_SECRET_KEY", default=PROFILE_IMAGE_SECRET_KEY
 )
 PROFILE_IMAGE_MAX_BYTES = config(

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- `AUTH_TOKENS` was wrongly used as a dictionary and default values were lost
+
 ## [dogwood.3-fun-1.4.0] - 2019-12-19
 
 ### Added

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-1.4.1] - 2019-12-24
+
 ### Fixed
 
 - `AUTH_TOKENS` was wrongly used as a dictionary and default values were lost
@@ -112,7 +114,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.4.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.4.1...HEAD
+[dogwood.3-fun-1.4.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.4.0...dogwood.3-fun-1.4.1
 [dogwood.3-fun-1.4.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.8...dogwood.3-fun-1.4.0
 [dogwood.3-fun-1.3.8]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.7...dogwood.3-fun-1.3.8
 [dogwood.3-fun-1.3.7]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.6...dogwood.3-fun-1.3.7

--- a/releases/dogwood/3/fun/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/lms/docker_run_production.py
@@ -878,15 +878,13 @@ if FEATURES.get("ENABLE_THIRD_PARTY_AUTH"):
     # The reduced session expiry time during the third party login pipeline. (Value in seconds)
     SOCIAL_AUTH_PIPELINE_TIMEOUT = config("SOCIAL_AUTH_PIPELINE_TIMEOUT", default=600)
 
-    # Most provider configuration is done via ConfigurationModels but for a few sensitive values
-    # we allow configuration via AUTH_TOKENS instead (optionally).
     # The SAML private/public key values do not need the delimiter lines (such as
     # "-----BEGIN PRIVATE KEY-----", default="-----END PRIVATE KEY-----" etc.) but they may be included
     # if you want (though it's easier to format the key values as JSON without the delimiters).
-    SOCIAL_AUTH_SAML_SP_PRIVATE_KEY = AUTH_TOKENS.get(
+    SOCIAL_AUTH_SAML_SP_PRIVATE_KEY = config(
         "SOCIAL_AUTH_SAML_SP_PRIVATE_KEY", default=""
     )
-    SOCIAL_AUTH_SAML_SP_PUBLIC_CERT = AUTH_TOKENS.get(
+    SOCIAL_AUTH_SAML_SP_PUBLIC_CERT = config(
         "SOCIAL_AUTH_SAML_SP_PUBLIC_CERT", default=""
     )
     SOCIAL_AUTH_OAUTH_SECRETS = config(
@@ -1065,7 +1063,7 @@ FIELD_OVERRIDE_PROVIDERS += (
 
 # PROFILE IMAGE CONFIG
 PROFILE_IMAGE_BACKEND = config("PROFILE_IMAGE_BACKEND", default=PROFILE_IMAGE_BACKEND)
-PROFILE_IMAGE_SECRET_KEY = AUTH_TOKENS.get(
+PROFILE_IMAGE_SECRET_KEY = config(
     "PROFILE_IMAGE_SECRET_KEY", default=PROFILE_IMAGE_SECRET_KEY
 )
 PROFILE_IMAGE_MAX_BYTES = config(

--- a/releases/eucalyptus/3/bare/CHANGELOG.md
+++ b/releases/eucalyptus/3/bare/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [eucalyptus.3-1.0.4] - 2019-12-24
+
 ### Fixed
 
 - `AUTH_TOKENS` was wrongly used as a dictionary and default values were lost
@@ -42,7 +44,8 @@ release.
 
 - First experimental release of OpenEdx `eucalyptus.3` (bare flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.3...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.4...HEAD
+[eucalyptus.3-1.0.4]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.3...eucalyptus.3-1.0.4
 [eucalyptus.3-1.0.3]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.2...eucalyptus.3-1.0.3
 [eucalyptus.3-1.0.2]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.1...eucalyptus.3-1.0.2
 [eucalyptus.3-1.0.1]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.0...eucalyptus.3-1.0.1

--- a/releases/eucalyptus/3/bare/CHANGELOG.md
+++ b/releases/eucalyptus/3/bare/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- `AUTH_TOKENS` was wrongly used as a dictionary and default values were lost
+
 ## [eucalyptus.3-1.0.3] - 2019-12-19
 
 ### Fixed

--- a/releases/eucalyptus/3/bare/config/lms/docker_run_production.py
+++ b/releases/eucalyptus/3/bare/config/lms/docker_run_production.py
@@ -913,15 +913,13 @@ if FEATURES.get("ENABLE_THIRD_PARTY_AUTH"):
     # The reduced session expiry time during the third party login pipeline. (Value in seconds)
     SOCIAL_AUTH_PIPELINE_TIMEOUT = config("SOCIAL_AUTH_PIPELINE_TIMEOUT", default=600)
 
-    # Most provider configuration is done via ConfigurationModels but for a few sensitive values
-    # we allow configuration via AUTH_TOKENS instead (optionally).
     # The SAML private/public key values do not need the delimiter lines (such as
     # "-----BEGIN PRIVATE KEY-----", default="-----END PRIVATE KEY-----" etc.) but they may be included
     # if you want (though it's easier to format the key values as JSON without the delimiters).
-    SOCIAL_AUTH_SAML_SP_PRIVATE_KEY = AUTH_TOKENS.get(
+    SOCIAL_AUTH_SAML_SP_PRIVATE_KEY = config(
         "SOCIAL_AUTH_SAML_SP_PRIVATE_KEY", default=""
     )
-    SOCIAL_AUTH_SAML_SP_PUBLIC_CERT = AUTH_TOKENS.get(
+    SOCIAL_AUTH_SAML_SP_PUBLIC_CERT = config(
         "SOCIAL_AUTH_SAML_SP_PUBLIC_CERT", default=""
     )
     SOCIAL_AUTH_OAUTH_SECRETS = config(
@@ -1126,7 +1124,7 @@ MODULESTORE_FIELD_OVERRIDE_PROVIDERS += (
 
 # PROFILE IMAGE CONFIG
 PROFILE_IMAGE_BACKEND = config("PROFILE_IMAGE_BACKEND", default=PROFILE_IMAGE_BACKEND)
-PROFILE_IMAGE_SECRET_KEY = AUTH_TOKENS.get(
+PROFILE_IMAGE_SECRET_KEY = config(
     "PROFILE_IMAGE_SECRET_KEY", default=PROFILE_IMAGE_SECRET_KEY
 )
 PROFILE_IMAGE_MAX_BYTES = config(

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- `AUTH_TOKENS` was wrongly used as a dictionary and default values were lost
+
 ## [eucalyptus.3-wb-1.2.0] - 2019-12-20
 
 ### Added

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [eucalyptus.3-wb-1.2.1] - 2019-12-24
+
 ### Fixed
 
 - `AUTH_TOKENS` was wrongly used as a dictionary and default values were lost
@@ -78,7 +80,8 @@ release.
 - Set replicaSet and read_preference in mongodb connection
 - Add missing support for redis sentinel
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.2.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.2.1...HEAD
+[eucalyptus.3-wb-1.2.1]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.2.0...eucalyptus.3-wb-1.2.1
 [eucalyptus.3-wb-1.2.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.1.0...eucalyptus.3-wb-1.2.0
 [eucalyptus.3-wb-1.1.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.0.5...eucalyptus.3-wb-1.1.0
 [eucalyptus.3-wb-1.0.5]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.0.4...eucalyptus.3-wb-1.0.5

--- a/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
@@ -961,15 +961,13 @@ if FEATURES.get("ENABLE_THIRD_PARTY_AUTH"):
     # The reduced session expiry time during the third party login pipeline. (Value in seconds)
     SOCIAL_AUTH_PIPELINE_TIMEOUT = config("SOCIAL_AUTH_PIPELINE_TIMEOUT", default=600)
 
-    # Most provider configuration is done via ConfigurationModels but for a few sensitive values
-    # we allow configuration via AUTH_TOKENS instead (optionally).
     # The SAML private/public key values do not need the delimiter lines (such as
     # "-----BEGIN PRIVATE KEY-----", default="-----END PRIVATE KEY-----" etc.) but they may be included
     # if you want (though it's easier to format the key values as JSON without the delimiters).
-    SOCIAL_AUTH_SAML_SP_PRIVATE_KEY = AUTH_TOKENS.get(
+    SOCIAL_AUTH_SAML_SP_PRIVATE_KEY = config(
         "SOCIAL_AUTH_SAML_SP_PRIVATE_KEY", default=""
     )
-    SOCIAL_AUTH_SAML_SP_PUBLIC_CERT = AUTH_TOKENS.get(
+    SOCIAL_AUTH_SAML_SP_PUBLIC_CERT = config(
         "SOCIAL_AUTH_SAML_SP_PUBLIC_CERT", default=""
     )
     SOCIAL_AUTH_OAUTH_SECRETS = config(
@@ -1174,7 +1172,7 @@ MODULESTORE_FIELD_OVERRIDE_PROVIDERS += (
 
 # PROFILE IMAGE CONFIG
 PROFILE_IMAGE_BACKEND = config("PROFILE_IMAGE_BACKEND", default=PROFILE_IMAGE_BACKEND)
-PROFILE_IMAGE_SECRET_KEY = AUTH_TOKENS.get(
+PROFILE_IMAGE_SECRET_KEY = config(
     "PROFILE_IMAGE_SECRET_KEY", default=PROFILE_IMAGE_SECRET_KEY
 )
 PROFILE_IMAGE_MAX_BYTES = config(

--- a/releases/hawthorn/1/bare/config/lms/docker_run_production.py
+++ b/releases/hawthorn/1/bare/config/lms/docker_run_production.py
@@ -909,8 +909,6 @@ if FEATURES.get("ENABLE_THIRD_PARTY_AUTH"):
         "SOCIAL_AUTH_PIPELINE_TIMEOUT", default=600, formatter=int
     )
 
-    # Most provider configuration is done via ConfigurationModels but for a few sensitive values
-    # we allow configuration via credentials.vault.yaml instead (optionally).
     # The SAML private/public key values do not need the delimiter lines (such as
     # "-----BEGIN PRIVATE KEY-----", "-----END PRIVATE KEY-----" etc.) but they may be included
     # if you want (though it's easier to format the key values as JSON without the delimiters).

--- a/releases/hawthorn/1/oee/config/lms/docker_run_production.py
+++ b/releases/hawthorn/1/oee/config/lms/docker_run_production.py
@@ -964,8 +964,6 @@ if FEATURES.get("ENABLE_THIRD_PARTY_AUTH"):
         "SOCIAL_AUTH_PIPELINE_TIMEOUT", default=600, formatter=int
     )
 
-    # Most provider configuration is done via ConfigurationModels but for a few sensitive values
-    # we allow configuration via credentials.vault.yaml instead (optionally).
     # The SAML private/public key values do not need the delimiter lines (such as
     # "-----BEGIN PRIVATE KEY-----", "-----END PRIVATE KEY-----" etc.) but they may be included
     # if you want (though it's easier to format the key values as JSON without the delimiters).

--- a/releases/master/bare/config/lms/docker_run_production.py
+++ b/releases/master/bare/config/lms/docker_run_production.py
@@ -910,8 +910,6 @@ if FEATURES.get("ENABLE_THIRD_PARTY_AUTH"):
         "SOCIAL_AUTH_PIPELINE_TIMEOUT", default=600, formatter=int
     )
 
-    # Most provider configuration is done via ConfigurationModels but for a few sensitive values
-    # we allow configuration via credentials.vault.yaml instead (optionally).
     # The SAML private/public key values do not need the delimiter lines (such as
     # "-----BEGIN PRIVATE KEY-----", "-----END PRIVATE KEY-----" etc.) but they may be included
     # if you want (though it's easier to format the key values as JSON without the delimiters).


### PR DESCRIPTION
## Purpose

Some settings were using AUTH_TOKENS wrongly. Calling the `get`  dictionary method and passing a `default` kwarg.

We noticed this because the `PROFILE_IMAGE_SECRET_KEY` was set to None in our containers.

## Proposal

Replace `AUTH_TOKENS` by our `config` helpers and call it correctly. :santa: :gift: 
