### PR TITLE
Fix configurable LTI XBlock settings

### DIFF
--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow configuring the configurable LTI consumer xblock
+
 ### Security
 
 - Remove selftest from installed apps to stop exposing settings on a url

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Security
+
+- Remove selftest from installed apps to stop exposing settings on a url
+
 ## [dogwood.3-fun-1.4.1] - 2019-12-24
 
 ### Fixed

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-1.4.2] - 2019-12-26
+
 ### Fixed
 
 - Allow configuring the configurable LTI consumer xblock
@@ -122,7 +124,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.4.1...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.4.2...HEAD
+[dogwood.3-fun-1.4.2]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.4.1...dogwood.3-fun-1.4.2
 [dogwood.3-fun-1.4.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.4.0...dogwood.3-fun-1.4.1
 [dogwood.3-fun-1.4.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.8...dogwood.3-fun-1.4.0
 [dogwood.3-fun-1.3.8]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.7...dogwood.3-fun-1.3.8

--- a/releases/dogwood/3/fun/config/cms/fun.py
+++ b/releases/dogwood/3/fun/config/cms/fun.py
@@ -86,11 +86,6 @@ MAKO_TEMPLATES["main"] = [FUN_BASE_ROOT / "fun/templates/cms"] + MAKO_TEMPLATES[
 # JS static override
 DEFAULT_TEMPLATE_ENGINE["DIRS"].append(FUN_BASE_ROOT / "funsite/templates/lms")
 
-# Generic LTI configuration
-LTI_XBLOCK_CONFIGURATIONS = config(
-    "LTI_XBLOCK_CONFIGURATIONS", default=[], formatter=json.loads
-)
-
 # Locale paths
 # Here we rewrite LOCAL_PATHS to give precedence to our applications above edx-platform's ones,
 # then we add xblocks which provide translations as there is no native mechanism to handle this
@@ -103,3 +98,31 @@ LOCALE_PATHS.append(path(pkgutil.get_loader("proctor_exam").filename) / "locale"
 # Force Edx to use `libcast_xblock` as default video player
 # in the studio (big green button) and if any xblock is called `video`
 XBLOCK_SELECT_FUNCTION = prefer_fun_video
+
+################ CONFIGURABLE LTI CONSUMER ###############
+
+# Add just the standard LTI consumer by default, forcing it to open in a new window and ask
+# the user before sending email and username:
+LTI_XBLOCK_CONFIGURATIONS = config(
+    "LTI_XBLOCK_CONFIGURATIONS",
+    default=[
+        {
+            "display_name": "LTI consumer",
+            "pattern": ".*",
+            "hidden_fields": [
+                "ask_to_send_email",
+                "ask_to_send_username",
+                "new_window",
+            ],
+            "defaults": {
+                "ask_to_send_email": True,
+                "ask_to_send_username": True,
+                "launch_target": "new_window",
+            },
+        },
+    ],
+    formatter=json.loads,
+)
+LTI_XBLOCK_SECRETS = config(
+    "LTI_XBLOCK_SECRETS", default={}, formatter=json.loads
+)

--- a/releases/dogwood/3/fun/config/cms/fun.py
+++ b/releases/dogwood/3/fun/config/cms/fun.py
@@ -26,7 +26,6 @@ INSTALLED_APPS += (
     "haystack",
     "password_container",
     "raven.contrib.django.raven_compat",
-    "selftest",
     "teachers",
     "universities",
     "videoproviders",

--- a/releases/dogwood/3/fun/config/lms/fun.py
+++ b/releases/dogwood/3/fun/config/lms/fun.py
@@ -47,7 +47,6 @@ INSTALLED_APPS += (
     "pure_pagination",
     "raven.contrib.django.raven_compat",
     "rest_framework.authtoken",
-    "selftest",
     "teachers",
     "universities",
     "videoproviders",

--- a/releases/dogwood/3/fun/config/lms/fun.py
+++ b/releases/dogwood/3/fun/config/lms/fun.py
@@ -256,31 +256,6 @@ TEMPLATES = [DEFAULT_TEMPLATE_ENGINE]
 # This force Edx Studio to use our own video provider Xblock on default button
 FUN_DEFAULT_VIDEO_PLAYER = "libcast_xblock"
 
-
-def prefer_fun_xmodules(identifier, entry_points):
-    """
-    Make sure that we use the correct FUN xmodule for video in the studio
-    """
-    from django.conf import settings
-    from xmodule.modulestore import prefer_xmodules
-
-    if identifier == "video" and settings.FUN_DEFAULT_VIDEO_PLAYER is not None:
-        import pkg_resources
-        from xblock.core import XBlock
-
-        # These entry points are listed in the setup.py of the libcast module
-        # Inspired by the XBlock.load_class method
-        entry_points = list(
-            pkg_resources.iter_entry_points(
-                XBlock.entry_point, name=settings.FUN_DEFAULT_VIDEO_PLAYER
-            )
-        )
-    return prefer_xmodules(identifier, entry_points)
-
-
-XBLOCK_SELECT_FUNCTION = prefer_fun_xmodules
-
-
 MIDDLEWARE_CLASSES += (
     "fun.middleware.LegalAcceptance",
     "backoffice.middleware.PathLimitedMasqueradeMiddleware",

--- a/releases/dogwood/3/fun/config/lms/fun.py
+++ b/releases/dogwood/3/fun/config/lms/fun.py
@@ -246,10 +246,6 @@ GLOWBL_LAUNCH_URL = config(
 )
 GLOWBL_COLL_OPT = config("GLOWBL_COLL_OPT", default="FunMoocJdR")
 
-LTI_XBLOCK_CONFIGURATIONS = config(
-    "LTI_XBLOCK_CONFIGURATIONS", default=[], formatter=json.loads
-)
-
 DEFAULT_TEMPLATE_ENGINE["DIRS"].append(FUN_BASE_ROOT / "funsite/templates/lms")
 DEFAULT_TEMPLATE_ENGINE["OPTIONS"]["context_processors"].append(
     "fun.context_processor.fun_settings"
@@ -382,3 +378,31 @@ ANALYTICS_DASHBOARD_URL = config(
 # Force Edx to use `libcast_xblock` as default video player
 # in the studio (big green button) and if any xblock is called `video`
 XBLOCK_SELECT_FUNCTION = prefer_fun_video
+
+################ CONFIGURABLE LTI CONSUMER ###############
+
+# Add just the standard LTI consumer by default, forcing it to open in a new window and ask
+# the user before sending email and username:
+LTI_XBLOCK_CONFIGURATIONS = config(
+    "LTI_XBLOCK_CONFIGURATIONS",
+    default=[
+        {
+            "display_name": "LTI consumer",
+            "pattern": ".*",
+            "hidden_fields": [
+                "ask_to_send_email",
+                "ask_to_send_username",
+                "new_window",
+            ],
+            "defaults": {
+                "ask_to_send_email": True,
+                "ask_to_send_username": True,
+                "launch_target": "new_window",
+            },
+        },
+    ],
+    formatter=json.loads,
+)
+LTI_XBLOCK_SECRETS = config(
+    "LTI_XBLOCK_SECRETS", default={}, formatter=json.loads
+)

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Security
+
+- Remove selftest from installed apps to stop exposing settings on a url
+
 ## [eucalyptus.3-wb-1.2.1] - 2019-12-24
 
 ### Fixed

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow configuring the configurable LTI consumer xblock
+
 ### Security
 
 - Remove selftest from installed apps to stop exposing settings on a url

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [eucalyptus.3-wb-1.2.2] - 2019-12-26
+
 ### Fixed
 
 - Allow configuring the configurable LTI consumer xblock
@@ -88,7 +90,8 @@ release.
 - Set replicaSet and read_preference in mongodb connection
 - Add missing support for redis sentinel
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.2.1...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.2.2...HEAD
+[eucalyptus.3-wb-1.2.2]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.2.1...eucalyptus.3-wb-1.2.2
 [eucalyptus.3-wb-1.2.1]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.2.0...eucalyptus.3-wb-1.2.1
 [eucalyptus.3-wb-1.2.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.1.0...eucalyptus.3-wb-1.2.0
 [eucalyptus.3-wb-1.1.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.0.5...eucalyptus.3-wb-1.1.0

--- a/releases/eucalyptus/3/wb/config/cms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/cms/docker_run_production.py
@@ -719,3 +719,31 @@ PARTNER_SUPPORT_EMAIL = config("PARTNER_SUPPORT_EMAIL", default=PARTNER_SUPPORT_
 
 # Affiliate cookie tracking
 AFFILIATE_COOKIE_NAME = config("AFFILIATE_COOKIE_NAME", default=AFFILIATE_COOKIE_NAME)
+
+################ CONFIGURABLE LTI CONSUMER ###############
+
+# Add just the standard LTI consumer by default, forcing it to open in a new window and ask
+# the user before sending email and username:
+LTI_XBLOCK_CONFIGURATIONS = config(
+    "LTI_XBLOCK_CONFIGURATIONS",
+    default=[
+        {
+            "display_name": "LTI consumer",
+            "pattern": ".*",
+            "hidden_fields": [
+                "ask_to_send_email",
+                "ask_to_send_username",
+                "new_window",
+            ],
+            "defaults": {
+                "ask_to_send_email": True,
+                "ask_to_send_username": True,
+                "launch_target": "new_window",
+            },
+        },
+    ],
+    formatter=json.loads,
+)
+LTI_XBLOCK_SECRETS = config(
+    "LTI_XBLOCK_SECRETS", default={}, formatter=json.loads
+)

--- a/releases/eucalyptus/3/wb/config/cms/fun.py
+++ b/releases/eucalyptus/3/wb/config/cms/fun.py
@@ -44,9 +44,6 @@ FUN_BASE_ROOT = path(os.path.dirname(imp.find_module("funsite")[1]))
 # CMS templates
 MAKO_TEMPLATES["main"] = [FUN_BASE_ROOT / "fun/templates/cms"] + MAKO_TEMPLATES["main"]
 
-# Generic LTI configuration
-LTI_XBLOCK_CONFIGURATIONS = [{"display_name": "LTI consumer"}]
-
 # Force Edx to use `libcast_xblock` as default video player
 # in the studio (big green button) and if any xblock is called `video`
 XBLOCK_SELECT_FUNCTION = prefer_fun_video

--- a/releases/eucalyptus/3/wb/config/cms/fun.py
+++ b/releases/eucalyptus/3/wb/config/cms/fun.py
@@ -18,7 +18,6 @@ INSTALLED_APPS += (
     "universities",
     "easy_thumbnails",
     "ckeditor",
-    "selftest",
     "raven.contrib.django.raven_compat",
 )
 

--- a/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
@@ -1279,3 +1279,31 @@ APP_UPGRADE_CACHE_TIMEOUT = config(
 )
 
 AFFILIATE_COOKIE_NAME = config("AFFILIATE_COOKIE_NAME", default=AFFILIATE_COOKIE_NAME)
+
+################ CONFIGURABLE LTI CONSUMER ###############
+
+# Add just the standard LTI consumer by default, forcing it to open in a new window and ask
+# the user before sending email and username:
+LTI_XBLOCK_CONFIGURATIONS = config(
+    "LTI_XBLOCK_CONFIGURATIONS",
+    default=[
+        {
+            "display_name": "LTI consumer",
+            "pattern": ".*",
+            "hidden_fields": [
+                "ask_to_send_email",
+                "ask_to_send_username",
+                "new_window",
+            ],
+            "defaults": {
+                "ask_to_send_email": True,
+                "ask_to_send_username": True,
+                "launch_target": "new_window",
+            },
+        },
+    ],
+    formatter=json.loads,
+)
+LTI_XBLOCK_SECRETS = config(
+    "LTI_XBLOCK_SECRETS", default={}, formatter=json.loads
+)

--- a/releases/eucalyptus/3/wb/config/lms/fun.py
+++ b/releases/eucalyptus/3/wb/config/lms/fun.py
@@ -25,7 +25,6 @@ INSTALLED_APPS += (
     "bootstrapform",
     "raven.contrib.django.raven_compat",
     "pure_pagination",
-    "selftest",
     "teachers",
     "edx_gea",
 )


### PR DESCRIPTION
## Purpose

The `LTI_XBLOCK_CONFIGURATIONS` and `LTI_XBLOCK_SECRETS` settings were not set properly in our "new" `dogwood.3-fun` and `eucalyptus-wb images`.

## Proposal

Add  `LTI_XBLOCK_CONFIGURATIONS` and `LTI_XBLOCK_SECRETS` settings that can be configured via yaml files and secrets.

While working on this PR, I noticed that we forgot removing the `selftest` app which poses security issues.
