### PR TITLE
([dogwood|eucalyptus]/3/*) make Gunicorn timout configurable

### DIFF
--- a/releases/dogwood/3/bare/CHANGELOG.md
+++ b/releases/dogwood/3/bare/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Added
+
+- Make Gunicorn timeout configurable via an environment variable
+
 ## [dogwood.3-1.1.5] - 2019-12-24
 
 ### Fixed

--- a/releases/dogwood/3/bare/Dockerfile
+++ b/releases/dogwood/3/bare/Dockerfile
@@ -267,6 +267,18 @@ USER 10000
 # (defaults to "lms")
 ENV SERVICE_VARIANT=lms
 
+# Gunicorn configuration
+#
+# As some synchronous requests may be quite long (e.g. courses import), we
+# should make timeout rather high and configurable so that it could be
+# increased without having to make a new release of this image
+ENV GUNICORN_TIMEOUT 300
+
 # Use Gunicorn in production as web server
 CMD DJANGO_SETTINGS_MODULE=${SERVICE_VARIANT}.envs.fun.docker_run \
-    gunicorn --name=${SERVICE_VARIANT} --bind=0.0.0.0:8000 --max-requests=1000 ${SERVICE_VARIANT}.wsgi:application
+    gunicorn \
+      --name=${SERVICE_VARIANT} \
+      --bind=0.0.0.0:8000 \
+      --max-requests=1000 \
+      --timeout=${GUNICORN_TIMEOUT} \
+      ${SERVICE_VARIANT}.wsgi:application

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Move LTI xblock configurations from fun settings to production
+
 ## [dogwood.3-fun-1.4.2] - 2019-12-26
 
 ### Fixed

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Added
+
+- Make Gunicorn timeout configurable via an environment variable
+
 ### Fixed
 
 - Move LTI xblock configurations from fun settings to production

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-1.5.0] - 2019-12-26
+
 ### Added
 
 - Make Gunicorn timeout configurable via an environment variable
@@ -132,7 +134,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.4.2...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.5.0...HEAD
+[dogwood.3-fun-1.5.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.4.2...dogwood.3-fun-1.5.0
 [dogwood.3-fun-1.4.2]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.4.1...dogwood.3-fun-1.4.2
 [dogwood.3-fun-1.4.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.4.0...dogwood.3-fun-1.4.1
 [dogwood.3-fun-1.4.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.3.8...dogwood.3-fun-1.4.0

--- a/releases/dogwood/3/fun/Dockerfile
+++ b/releases/dogwood/3/fun/Dockerfile
@@ -268,6 +268,19 @@ USER 10000
 # (defaults to "lms")
 ENV SERVICE_VARIANT=lms
 
+# Gunicorn configuration
+#
+# As some synchronous requests may be quite long (e.g. courses import), we
+# should make timeout rather high and configurable so that it could be
+# increased without having to make a new release of this image
+#
+ENV GUNICORN_TIMEOUT 300
+
 # Use Gunicorn in production as web server
 CMD DJANGO_SETTINGS_MODULE=${SERVICE_VARIANT}.envs.fun.docker_run \
-    gunicorn --name=${SERVICE_VARIANT} --bind=0.0.0.0:8000 --max-requests=1000 ${SERVICE_VARIANT}.wsgi:application
+    gunicorn \
+      --name=${SERVICE_VARIANT} \
+      --bind=0.0.0.0:8000 \
+      --max-requests=1000 \
+      --timeout=${GUNICORN_TIMEOUT} \
+      ${SERVICE_VARIANT}.wsgi:application

--- a/releases/dogwood/3/fun/config/cms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/cms/docker_run_production.py
@@ -627,3 +627,29 @@ PROCTORING_SETTINGS = config(
 
 # OpenID Connect issuer ID. Normally the URL of the authentication endpoint.
 OAUTH_OIDC_ISSUER = config("OAUTH_OIDC_ISSUER", default=None)
+
+################ CONFIGURABLE LTI CONSUMER ###############
+
+# Add just the standard LTI consumer by default, forcing it to open in a new window and ask
+# the user before sending email and username:
+LTI_XBLOCK_CONFIGURATIONS = config(
+    "LTI_XBLOCK_CONFIGURATIONS",
+    default=[
+        {
+            "display_name": "LTI consumer",
+            "pattern": ".*",
+            "hidden_fields": [
+                "ask_to_send_email",
+                "ask_to_send_username",
+                "new_window",
+            ],
+            "defaults": {
+                "ask_to_send_email": True,
+                "ask_to_send_username": True,
+                "launch_target": "new_window",
+            },
+        }
+    ],
+    formatter=json.loads,
+)
+LTI_XBLOCK_SECRETS = config("LTI_XBLOCK_SECRETS", default={}, formatter=json.loads)

--- a/releases/dogwood/3/fun/config/cms/fun.py
+++ b/releases/dogwood/3/fun/config/cms/fun.py
@@ -98,31 +98,3 @@ LOCALE_PATHS.append(path(pkgutil.get_loader("proctor_exam").filename) / "locale"
 # Force Edx to use `libcast_xblock` as default video player
 # in the studio (big green button) and if any xblock is called `video`
 XBLOCK_SELECT_FUNCTION = prefer_fun_video
-
-################ CONFIGURABLE LTI CONSUMER ###############
-
-# Add just the standard LTI consumer by default, forcing it to open in a new window and ask
-# the user before sending email and username:
-LTI_XBLOCK_CONFIGURATIONS = config(
-    "LTI_XBLOCK_CONFIGURATIONS",
-    default=[
-        {
-            "display_name": "LTI consumer",
-            "pattern": ".*",
-            "hidden_fields": [
-                "ask_to_send_email",
-                "ask_to_send_username",
-                "new_window",
-            ],
-            "defaults": {
-                "ask_to_send_email": True,
-                "ask_to_send_username": True,
-                "launch_target": "new_window",
-            },
-        },
-    ],
-    formatter=json.loads,
-)
-LTI_XBLOCK_SECRETS = config(
-    "LTI_XBLOCK_SECRETS", default={}, formatter=json.loads
-)

--- a/releases/dogwood/3/fun/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/lms/docker_run_production.py
@@ -1124,3 +1124,29 @@ if config("AUDIT_CERT_CUTOFF_DATE", default=None):
     AUDIT_CERT_CUTOFF_DATE = dateutil.parser.parse(
         config("AUDIT_CERT_CUTOFF_DATE", default=AUDIT_CERT_CUTOFF_DATE)
     )
+
+################ CONFIGURABLE LTI CONSUMER ###############
+
+# Add just the standard LTI consumer by default, forcing it to open in a new window and ask
+# the user before sending email and username:
+LTI_XBLOCK_CONFIGURATIONS = config(
+    "LTI_XBLOCK_CONFIGURATIONS",
+    default=[
+        {
+            "display_name": "LTI consumer",
+            "pattern": ".*",
+            "hidden_fields": [
+                "ask_to_send_email",
+                "ask_to_send_username",
+                "new_window",
+            ],
+            "defaults": {
+                "ask_to_send_email": True,
+                "ask_to_send_username": True,
+                "launch_target": "new_window",
+            },
+        }
+    ],
+    formatter=json.loads,
+)
+LTI_XBLOCK_SECRETS = config("LTI_XBLOCK_SECRETS", default={}, formatter=json.loads)

--- a/releases/dogwood/3/fun/config/lms/fun.py
+++ b/releases/dogwood/3/fun/config/lms/fun.py
@@ -353,31 +353,3 @@ ANALYTICS_DASHBOARD_URL = config(
 # Force Edx to use `libcast_xblock` as default video player
 # in the studio (big green button) and if any xblock is called `video`
 XBLOCK_SELECT_FUNCTION = prefer_fun_video
-
-################ CONFIGURABLE LTI CONSUMER ###############
-
-# Add just the standard LTI consumer by default, forcing it to open in a new window and ask
-# the user before sending email and username:
-LTI_XBLOCK_CONFIGURATIONS = config(
-    "LTI_XBLOCK_CONFIGURATIONS",
-    default=[
-        {
-            "display_name": "LTI consumer",
-            "pattern": ".*",
-            "hidden_fields": [
-                "ask_to_send_email",
-                "ask_to_send_username",
-                "new_window",
-            ],
-            "defaults": {
-                "ask_to_send_email": True,
-                "ask_to_send_username": True,
-                "launch_target": "new_window",
-            },
-        },
-    ],
-    formatter=json.loads,
-)
-LTI_XBLOCK_SECRETS = config(
-    "LTI_XBLOCK_SECRETS", default={}, formatter=json.loads
-)

--- a/releases/eucalyptus/3/bare/CHANGELOG.md
+++ b/releases/eucalyptus/3/bare/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Added
+
+- Make Gunicorn timeout configurable via an environment variable
+
 ## [eucalyptus.3-1.0.4] - 2019-12-24
 
 ### Fixed

--- a/releases/eucalyptus/3/bare/Dockerfile
+++ b/releases/eucalyptus/3/bare/Dockerfile
@@ -238,6 +238,18 @@ USER 10000
 # (defaults to "lms")
 ENV SERVICE_VARIANT=lms
 
+# Gunicorn configuration
+#
+# As some synchronous requests may be quite long (e.g. courses import), we
+# should make timeout rather high and configurable so that it could be
+# increased without having to make a new release of this image
+ENV GUNICORN_TIMEOUT 300
+
 # Use Gunicorn in production as web server
 CMD DJANGO_SETTINGS_MODULE=${SERVICE_VARIANT}.envs.fun.docker_run \
-    gunicorn --name=${SERVICE_VARIANT} --bind=0.0.0.0:8000 --max-requests=1000 ${SERVICE_VARIANT}.wsgi:application
+    gunicorn \
+      --name=${SERVICE_VARIANT} \
+      --bind=0.0.0.0:8000 \
+      --max-requests=1000 \
+      --timeout=${GUNICORN_TIMEOUT} \
+      ${SERVICE_VARIANT}.wsgi:application

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Added
+
+- Make Gunicorn timeout configurable via an environment variable
+
 ## [eucalyptus.3-wb-1.2.2] - 2019-12-26
 
 ### Fixed

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [eucalyptus.3-wb-1.3.0] - 2019-12-26
+
 ### Added
 
 - Make Gunicorn timeout configurable via an environment variable
@@ -94,7 +96,8 @@ release.
 - Set replicaSet and read_preference in mongodb connection
 - Add missing support for redis sentinel
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.2.2...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.3.0...HEAD
+[eucalyptus.3-wb-1.3.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.2.2...eucalyptus.3-wb-1.3.0
 [eucalyptus.3-wb-1.2.2]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.2.1...eucalyptus.3-wb-1.2.2
 [eucalyptus.3-wb-1.2.1]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.2.0...eucalyptus.3-wb-1.2.1
 [eucalyptus.3-wb-1.2.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.1.0...eucalyptus.3-wb-1.2.0

--- a/releases/eucalyptus/3/wb/Dockerfile
+++ b/releases/eucalyptus/3/wb/Dockerfile
@@ -238,6 +238,18 @@ USER 10000
 # (defaults to "lms")
 ENV SERVICE_VARIANT=lms
 
+# Gunicorn configuration
+#
+# As some synchronous requests may be quite long (e.g. courses import), we
+# should make timeout rather high and configurable so that it could be
+# increased without having to make a new release of this image
+ENV GUNICORN_TIMEOUT 300
+
 # Use Gunicorn in production as web server
 CMD DJANGO_SETTINGS_MODULE=${SERVICE_VARIANT}.envs.fun.docker_run \
-    gunicorn --name=${SERVICE_VARIANT} --bind=0.0.0.0:8000 --max-requests=1000 ${SERVICE_VARIANT}.wsgi:application
+    gunicorn \
+      --name=${SERVICE_VARIANT} \
+      --bind=0.0.0.0:8000 \
+      --max-requests=1000 \
+      --timeout=${GUNICORN_TIMEOUT} \
+      ${SERVICE_VARIANT}.wsgi:application


### PR DESCRIPTION
## Purpose

Some synchronous requests may be quite long (e.g. courses importation) leading to a gateway timeout response. We should be able to configure the WSGI server timeout to prevent unexpected failures.

## Proposal

- [x] make Gunicorn timeout configurable _via_ an environment variable

During this work I've also moved the badly placed `LTI_XBLOCK_CONFIGURATIONS` setting for the `dogwood.3-fun` release (follow up of #168).