### PR TITLE
♻️(flavors/*) make ORA2 configurable on all flavors

### DIFF
--- a/releases/dogwood/3/bare/CHANGELOG.md
+++ b/releases/dogwood/3/bare/CHANGELOG.md
@@ -15,6 +15,7 @@ release.
 
 ### Changed
 
+- Make ORA2 configurable and use filesystem backend by default
 - Stop inheriting from MKTG_URL_LINK_MAP default setting
 
 ### Fixed

--- a/releases/dogwood/3/bare/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/bare/config/lms/docker_run_production.py
@@ -133,6 +133,9 @@ STATIC_URL = "/static/"
 MEDIA_ROOT = path("/edx/var/edxapp/media/")
 MEDIA_URL = "/media/"
 
+LOG_DIR = config("LOG_DIR", default=path("/edx/var/logs/edx"), formatter=path)
+DATA_DIR = config("DATA_DIR", default=path("/edx/app/edxapp/data"), formatter=path)
+
 # DEFAULT_COURSE_ABOUT_IMAGE_URL specifies the default image to show for courses that don't provide one
 DEFAULT_COURSE_ABOUT_IMAGE_URL = config(
     "DEFAULT_COURSE_ABOUT_IMAGE_URL", default=DEFAULT_COURSE_ABOUT_IMAGE_URL
@@ -241,6 +244,12 @@ CACHES = config(
             "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
             "KEY_FUNCTION": "util.memcache.safe_key",
         },
+        "openassessment_submissions": {
+            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
+            "KEY_FUNCTION": "util.memcache.safe_key",
+            "KEY_PREFIX": "openassessment_submissions",
+        },
     },
     formatter=json.loads,
 )
@@ -336,11 +345,6 @@ for app in config("ADDL_INSTALLED_APPS", default=[], formatter=json.loads):
 
 WIKI_ENABLED = config("WIKI_ENABLED", default=WIKI_ENABLED, formatter=bool)
 local_loglevel = config("LOCAL_LOGLEVEL", default="INFO")
-
-# Configure Logging
-
-LOG_DIR = config("LOG_DIR", default=path("/edx/var/logs/edx"), formatter=path)
-DATA_DIR = config("DATA_DIR", default=path("/edx/app/edxapp/data"), formatter=path)
 
 # Default format for syslog logging
 standard_format = "%(asctime)s %(levelname)s %(process)d [%(name)s] %(filename)s:%(lineno)d - %(message)s"
@@ -774,10 +778,19 @@ FINANCIAL_REPORTS = config(
 )
 
 ##### ORA2 ######
+ORA2_FILEUPLOAD_BACKEND = config("ORA2_FILEUPLOAD_BACKEND", default="filesystem")
+FILE_UPLOAD_STORAGE_BUCKET_NAME = "uploads"
 # Prefix for uploads of example-based assessment AI classifiers
 # This can be used to separate uploads for different environments
-# within the same S3 bucket.
 ORA2_FILE_PREFIX = config("ORA2_FILE_PREFIX", default=ORA2_FILE_PREFIX)
+
+# If backend is "filesystem"
+ORA2_FILEUPLOAD_ROOT = DATA_DIR / "openassessment_submissions"
+ORA2_FILEUPLOAD_CACHE_NAME = config("ORA2_FILEUPLOAD_CACHE_NAME", default="openassessment_submissions")
+
+# If backend is "swift"
+ORA2_SWIFT_KEY = config("ORA2_SWIFT_KEY", default="")
+ORA2_SWIFT_URL = config("ORA2_SWIFT_URL", default="")
 
 ##### ACCOUNT LOCKOUT DEFAULT PARAMETERS #####
 MAX_FAILED_LOGIN_ATTEMPTS_ALLOWED = config(

--- a/releases/dogwood/3/fun/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/lms/docker_run_production.py
@@ -826,12 +826,6 @@ FINANCIAL_REPORTS = config(
     "FINANCIAL_REPORTS", default=FINANCIAL_REPORTS, formatter=json.loads
 )
 
-##### ORA2 ######
-# Prefix for uploads of example-based assessment AI classifiers
-# This can be used to separate uploads for different environments
-# within the same S3 bucket.
-ORA2_FILE_PREFIX = config("ORA2_FILE_PREFIX", default=ORA2_FILE_PREFIX)
-
 ##### ACCOUNT LOCKOUT DEFAULT PARAMETERS #####
 MAX_FAILED_LOGIN_ATTEMPTS_ALLOWED = config(
     "MAX_FAILED_LOGIN_ATTEMPTS_ALLOWED", default=5, formatter=int
@@ -1358,12 +1352,16 @@ FUN_THUMBNAIL_OPTIONS = {
 THUMBNAIL_PRESERVE_EXTENSIONS = True
 THUMBNAIL_EXTENSION = "png"
 
-# ora2 fileupload
+##### ORA2 ######
 ORA2_FILEUPLOAD_BACKEND = "swift"
-ORA2_FILEUPLOAD_CACHE_NAME = "openassessment_submissions"
-FILE_UPLOAD_STORAGE_BUCKET_NAME = "uploads"
 ORA2_SWIFT_KEY = config("ORA2_SWIFT_KEY", default="")
 ORA2_SWIFT_URL = config("ORA2_SWIFT_URL", default="")
+
+FILE_UPLOAD_STORAGE_BUCKET_NAME = "uploads"
+
+# Prefix for uploads of example-based assessment AI classifiers
+# This can be used to separate uploads for different environments
+ORA2_FILE_PREFIX = config("ORA2_FILE_PREFIX", default=ORA2_FILE_PREFIX)
 
 # Profile image upload
 PROFILE_IMAGE_BACKEND = {

--- a/releases/eucalyptus/3/bare/CHANGELOG.md
+++ b/releases/eucalyptus/3/bare/CHANGELOG.md
@@ -15,6 +15,7 @@ release.
 
 ### Changed
 
+- Make ORA2 configurable and use filesystem backend by default
 - Stop inheriting from MKTG_URL_LINK_MAP default setting
 
 ### Fixed

--- a/releases/eucalyptus/3/bare/config/lms/docker_run_production.py
+++ b/releases/eucalyptus/3/bare/config/lms/docker_run_production.py
@@ -147,6 +147,9 @@ STATIC_URL = "/static/"
 MEDIA_ROOT = path("/edx/var/edxapp/media/")
 MEDIA_URL = "/media/"
 
+LOG_DIR = config("LOG_DIR", default=path("/edx/var/logs/edx"), formatter=path)
+DATA_DIR = config("DATA_DIR", default=path("/edx/app/edxapp/data"), formatter=path)
+
 # DEFAULT_COURSE_ABOUT_IMAGE_URL specifies the default image to show for courses that don't provide one
 DEFAULT_COURSE_ABOUT_IMAGE_URL = config(
     "DEFAULT_COURSE_ABOUT_IMAGE_URL", default=DEFAULT_COURSE_ABOUT_IMAGE_URL
@@ -275,6 +278,12 @@ CACHES = config(
             "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
             "KEY_FUNCTION": "util.memcache.safe_key",
         },
+        "openassessment_submissions": {
+            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
+            "KEY_FUNCTION": "util.memcache.safe_key",
+            "KEY_PREFIX": "openassessment_submissions",
+        },
     },
     formatter=json.loads,
 )
@@ -388,11 +397,6 @@ for app in config("ADDL_INSTALLED_APPS", default=[], formatter=json.loads):
 
 WIKI_ENABLED = config("WIKI_ENABLED", default=WIKI_ENABLED, formatter=bool)
 local_loglevel = config("LOCAL_LOGLEVEL", default="INFO")
-
-# Configure Logging
-
-LOG_DIR = config("LOG_DIR", default=path("/edx/var/logs/edx"), formatter=path)
-DATA_DIR = config("DATA_DIR", default=path("/edx/app/edxapp/data"), formatter=path)
 
 # Default format for syslog logging
 standard_format = "%(asctime)s %(levelname)s %(process)d [%(name)s] %(filename)s:%(lineno)d - %(message)s"
@@ -860,10 +864,19 @@ FINANCIAL_REPORTS = config(
 )
 
 ##### ORA2 ######
+ORA2_FILEUPLOAD_BACKEND = config("ORA2_FILEUPLOAD_BACKEND", default="filesystem")
+FILE_UPLOAD_STORAGE_BUCKET_NAME = "uploads"
 # Prefix for uploads of example-based assessment AI classifiers
 # This can be used to separate uploads for different environments
-# within the same S3 bucket.
 ORA2_FILE_PREFIX = config("ORA2_FILE_PREFIX", default=ORA2_FILE_PREFIX)
+
+# If backend is "filesystem"
+ORA2_FILEUPLOAD_ROOT = DATA_DIR / "openassessment_submissions"
+ORA2_FILEUPLOAD_CACHE_NAME = config("ORA2_FILEUPLOAD_CACHE_NAME", default="openassessment_submissions")
+
+# If backend is "swift"
+ORA2_SWIFT_KEY = config("ORA2_SWIFT_KEY", default="")
+ORA2_SWIFT_URL = config("ORA2_SWIFT_URL", default="")
 
 ##### ACCOUNT LOCKOUT DEFAULT PARAMETERS #####
 MAX_FAILED_LOGIN_ATTEMPTS_ALLOWED = config(

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Changed
+
+- Make ORA2 configurable and use filesystem backend by default
+
 ## [eucalyptus.3-wb-1.4.0] - 2020-01-03
 
 ### Changed

--- a/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
@@ -149,6 +149,9 @@ STATIC_URL = "/static/"
 MEDIA_ROOT = path("/edx/var/edxapp/media/")
 MEDIA_URL = "/media/"
 
+LOG_DIR = config("LOG_DIR", default=path("/edx/var/logs/edx"), formatter=path)
+DATA_DIR = config("DATA_DIR", default=path("/edx/app/edxapp/data"), formatter=path)
+
 # DEFAULT_COURSE_ABOUT_IMAGE_URL specifies the default image to show for courses that don't provide one
 DEFAULT_COURSE_ABOUT_IMAGE_URL = config(
     "DEFAULT_COURSE_ABOUT_IMAGE_URL", default=DEFAULT_COURSE_ABOUT_IMAGE_URL
@@ -309,6 +312,12 @@ CACHES = config(
             "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
             "KEY_FUNCTION": "util.memcache.safe_key",
         },
+        "openassessment_submissions": {
+            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
+            "KEY_FUNCTION": "util.memcache.safe_key",
+            "KEY_PREFIX": "openassessment_submissions",
+        },
     },
     formatter=json.loads,
 )
@@ -422,11 +431,6 @@ for app in config("ADDL_INSTALLED_APPS", default=[], formatter=json.loads):
 
 WIKI_ENABLED = config("WIKI_ENABLED", default=WIKI_ENABLED, formatter=bool)
 local_loglevel = config("LOCAL_LOGLEVEL", default="INFO")
-
-# Configure Logging
-
-LOG_DIR = config("LOG_DIR", default=path("/edx/var/logs/edx"), formatter=path)
-DATA_DIR = config("DATA_DIR", default=path("/edx/app/edxapp/data"), formatter=path)
 
 # Default format for syslog logging
 standard_format = "%(asctime)s %(levelname)s %(process)d [%(name)s] %(filename)s:%(lineno)d - %(message)s"
@@ -909,10 +913,19 @@ FINANCIAL_REPORTS = config(
 )
 
 ##### ORA2 ######
+ORA2_FILEUPLOAD_BACKEND = config("ORA2_FILEUPLOAD_BACKEND", default="filesystem")
+FILE_UPLOAD_STORAGE_BUCKET_NAME = "uploads"
 # Prefix for uploads of example-based assessment AI classifiers
 # This can be used to separate uploads for different environments
-# within the same S3 bucket.
 ORA2_FILE_PREFIX = config("ORA2_FILE_PREFIX", default=ORA2_FILE_PREFIX)
+
+# If backend is "filesystem"
+ORA2_FILEUPLOAD_ROOT = DATA_DIR / "openassessment_submissions"
+ORA2_FILEUPLOAD_CACHE_NAME = config("ORA2_FILEUPLOAD_CACHE_NAME", default="openassessment_submissions")
+
+# If backend is "swift"
+ORA2_SWIFT_KEY = config("ORA2_SWIFT_KEY", default="")
+ORA2_SWIFT_URL = config("ORA2_SWIFT_URL", default="")
 
 ##### ACCOUNT LOCKOUT DEFAULT PARAMETERS #####
 MAX_FAILED_LOGIN_ATTEMPTS_ALLOWED = config(

--- a/releases/hawthorn/1/bare/CHANGELOG.md
+++ b/releases/hawthorn/1/bare/CHANGELOG.md
@@ -15,6 +15,7 @@ release.
 
 ### Changed
 
+- Make ORA2 configurable and use filesystem backend by default
 - Stop inheriting from MKTG_URL_LINK_MAP default setting
 
 ### Fixed

--- a/releases/hawthorn/1/bare/config/lms/docker_run_production.py
+++ b/releases/hawthorn/1/bare/config/lms/docker_run_production.py
@@ -111,6 +111,9 @@ WEBPACK_LOADER["DEFAULT"]["STATS_FILE"] = STATIC_ROOT / "webpack-stats.json"
 MEDIA_ROOT = path("/edx/var/edxapp/media/")
 MEDIA_URL = "/media/"
 
+LOG_DIR = config("LOG_DIR", default=path("/edx/var/logs/edx"), formatter=path)
+DATA_DIR = config("DATA_DIR", default=path("/edx/var/edxapp"), formatter=path)
+
 # DEFAULT_COURSE_ABOUT_IMAGE_URL specifies the default image to show for courses that don't provide one
 DEFAULT_COURSE_ABOUT_IMAGE_URL = config(
     "DEFAULT_COURSE_ABOUT_IMAGE_URL", default=DEFAULT_COURSE_ABOUT_IMAGE_URL
@@ -230,6 +233,12 @@ CACHES = config(
             "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
             "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
             "KEY_FUNCTION": "util.memcache.safe_key",
+        },
+        "openassessment_submissions": {
+            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
+            "KEY_FUNCTION": "util.memcache.safe_key",
+            "KEY_PREFIX": "openassessment_submissions",
         },
     },
     formatter=json.loads,
@@ -389,11 +398,6 @@ for app in config("ADDL_INSTALLED_APPS", default=[], formatter=json.loads):
 
 WIKI_ENABLED = config("WIKI_ENABLED", default=WIKI_ENABLED, formatter=bool)
 local_loglevel = config("LOCAL_LOGLEVEL", default="INFO")
-
-# Configure Logging
-
-LOG_DIR = config("LOG_DIR", default=path("/edx/var/logs/edx"), formatter=path)
-DATA_DIR = config("DATA_DIR", default=path("/edx/var/edxapp"), formatter=path)
 
 # Default format for syslog logging
 standard_format = "%(asctime)s %(levelname)s %(process)d [%(name)s] %(filename)s:%(lineno)d - %(message)s"
@@ -851,10 +855,19 @@ FINANCIAL_REPORTS = config(
 )
 
 ##### ORA2 ######
+ORA2_FILEUPLOAD_BACKEND = config("ORA2_FILEUPLOAD_BACKEND", default="filesystem")
+FILE_UPLOAD_STORAGE_BUCKET_NAME = "uploads"
 # Prefix for uploads of example-based assessment AI classifiers
 # This can be used to separate uploads for different environments
-# within the same S3 bucket.
 ORA2_FILE_PREFIX = config("ORA2_FILE_PREFIX", default=ORA2_FILE_PREFIX)
+
+# If backend is "filesystem"
+ORA2_FILEUPLOAD_ROOT = DATA_DIR / "openassessment_submissions"
+ORA2_FILEUPLOAD_CACHE_NAME = config("ORA2_FILEUPLOAD_CACHE_NAME", default="openassessment_submissions")
+
+# If backend is "swift"
+ORA2_SWIFT_KEY = config("ORA2_SWIFT_KEY", default="")
+ORA2_SWIFT_URL = config("ORA2_SWIFT_URL", default="")
 
 ##### ACCOUNT LOCKOUT DEFAULT PARAMETERS #####
 MAX_FAILED_LOGIN_ATTEMPTS_ALLOWED = config(

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -15,6 +15,7 @@ release.
 
 ### Changed
 
+- Make ORA2 configurable and use filesystem backend by default
 - Stop inheriting from MKTG_URL_LINK_MAP default setting
 
 ### Fixed

--- a/releases/hawthorn/1/oee/config/lms/docker_run_production.py
+++ b/releases/hawthorn/1/oee/config/lms/docker_run_production.py
@@ -41,8 +41,12 @@ SESSION_REDIS_PORT = config("SESSION_REDIS_PORT", default=6379, formatter=int)
 SESSION_REDIS_DB = config("SESSION_REDIS_DB", default=1, formatter=int)
 SESSION_REDIS_PASSWORD = config("SESSION_REDIS_PASSWORD", default=None)
 SESSION_REDIS_PREFIX = config("SESSION_REDIS_PREFIX", default="session")
-SESSION_REDIS_SOCKET_TIMEOUT = config("SESSION_REDIS_SOCKET_TIMEOUT", default=1, formatter=int)
-SESSION_REDIS_RETRY_ON_TIMEOUT = config("SESSION_REDIS_RETRY_ON_TIMEOUT", default=False, formatter=bool)
+SESSION_REDIS_SOCKET_TIMEOUT = config(
+    "SESSION_REDIS_SOCKET_TIMEOUT", default=1, formatter=int
+)
+SESSION_REDIS_RETRY_ON_TIMEOUT = config(
+    "SESSION_REDIS_RETRY_ON_TIMEOUT", default=False, formatter=bool
+)
 
 SESSION_REDIS = config(
     "SESSION_REDIS",
@@ -57,8 +61,12 @@ SESSION_REDIS = config(
     },
     formatter=json.loads,
 )
-SESSION_REDIS_SENTINEL_LIST = config("SESSION_REDIS_SENTINEL_LIST", default=None, formatter=json.loads)
-SESSION_REDIS_SENTINEL_MASTER_ALIAS = config("SESSION_REDIS_SENTINEL_MASTER_ALIAS", default=None)
+SESSION_REDIS_SENTINEL_LIST = config(
+    "SESSION_REDIS_SENTINEL_LIST", default=None, formatter=json.loads
+)
+SESSION_REDIS_SENTINEL_MASTER_ALIAS = config(
+    "SESSION_REDIS_SENTINEL_MASTER_ALIAS", default=None
+)
 
 # Override edX LMS urls with Fonzie's
 ROOT_URLCONF = "lms.root_urls"
@@ -136,6 +144,9 @@ WEBPACK_LOADER["DEFAULT"]["STATS_FILE"] = STATIC_ROOT / "webpack-stats.json"
 
 MEDIA_ROOT = path("/edx/var/edxapp/media/")
 MEDIA_URL = "/media/"
+
+LOG_DIR = config("LOG_DIR", default=path("/edx/var/logs/edx"), formatter=path)
+DATA_DIR = config("DATA_DIR", default=path("/edx/var/edxapp"), formatter=path)
 
 # DEFAULT_COURSE_ABOUT_IMAGE_URL specifies the default image to show for courses that don't provide one
 DEFAULT_COURSE_ABOUT_IMAGE_URL = config(
@@ -256,6 +267,12 @@ CACHES = config(
             "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
             "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
             "KEY_FUNCTION": "util.memcache.safe_key",
+        },
+        "openassessment_submissions": {
+            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
+            "KEY_FUNCTION": "util.memcache.safe_key",
+            "KEY_PREFIX": "openassessment_submissions",
         },
     },
     formatter=json.loads,
@@ -415,11 +432,6 @@ for app in config("ADDL_INSTALLED_APPS", default=[], formatter=json.loads):
 
 WIKI_ENABLED = config("WIKI_ENABLED", default=WIKI_ENABLED, formatter=bool)
 local_loglevel = config("LOCAL_LOGLEVEL", default="INFO")
-
-# Configure Logging
-
-LOG_DIR = config("LOG_DIR", default=path("/edx/var/logs/edx"), formatter=path)
-DATA_DIR = config("DATA_DIR", default=path("/edx/var/edxapp"), formatter=path)
 
 # Default format for syslog logging
 standard_format = "%(asctime)s %(levelname)s %(process)d [%(name)s] %(filename)s:%(lineno)d - %(message)s"
@@ -806,7 +818,9 @@ BROKER_URL = "{transport}://{user}:{password}@{host}:{port}/{vhost}".format(
 BROKER_USE_SSL = config("CELERY_BROKER_USE_SSL", default=False, formatter=bool)
 # To use redis-sentinel, refer to the documentation here
 # https://celery-redis-sentinel.readthedocs.io/en/latest/
-BROKER_TRANSPORT_OPTIONS = config("BROKER_TRANSPORT_OPTIONS", default={}, formatter=json.loads)
+BROKER_TRANSPORT_OPTIONS = config(
+    "BROKER_TRANSPORT_OPTIONS", default={}, formatter=json.loads
+)
 
 # Block Structures
 BLOCK_STRUCTURES_SETTINGS = config(
@@ -906,10 +920,19 @@ FINANCIAL_REPORTS = config(
 )
 
 ##### ORA2 ######
+ORA2_FILEUPLOAD_BACKEND = config("ORA2_FILEUPLOAD_BACKEND", default="filesystem")
+FILE_UPLOAD_STORAGE_BUCKET_NAME = "uploads"
 # Prefix for uploads of example-based assessment AI classifiers
 # This can be used to separate uploads for different environments
-# within the same S3 bucket.
 ORA2_FILE_PREFIX = config("ORA2_FILE_PREFIX", default=ORA2_FILE_PREFIX)
+
+# If backend is "filesystem"
+ORA2_FILEUPLOAD_ROOT = DATA_DIR / "openassessment_submissions"
+ORA2_FILEUPLOAD_CACHE_NAME = config("ORA2_FILEUPLOAD_CACHE_NAME", default="openassessment_submissions")
+
+# If backend is "swift"
+ORA2_SWIFT_KEY = config("ORA2_SWIFT_KEY", default="")
+ORA2_SWIFT_URL = config("ORA2_SWIFT_URL", default="")
 
 ##### ACCOUNT LOCKOUT DEFAULT PARAMETERS #####
 MAX_FAILED_LOGIN_ATTEMPTS_ALLOWED = config(

--- a/releases/master/bare/config/lms/docker_run_production.py
+++ b/releases/master/bare/config/lms/docker_run_production.py
@@ -111,6 +111,9 @@ WEBPACK_LOADER["DEFAULT"]["STATS_FILE"] = STATIC_ROOT / "webpack-stats.json"
 MEDIA_ROOT = path("/edx/var/edxapp/media/")
 MEDIA_URL = "/media/"
 
+LOG_DIR = config("LOG_DIR", default=path("/edx/var/logs/edx"), formatter=path)
+DATA_DIR = config("DATA_DIR", default=path("/edx/var/edxapp"), formatter=path)
+
 # DEFAULT_COURSE_ABOUT_IMAGE_URL specifies the default image to show for courses that don't provide one
 DEFAULT_COURSE_ABOUT_IMAGE_URL = config(
     "DEFAULT_COURSE_ABOUT_IMAGE_URL", default=DEFAULT_COURSE_ABOUT_IMAGE_URL
@@ -231,6 +234,12 @@ CACHES = config(
             "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
             "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
             "KEY_FUNCTION": "util.memcache.safe_key",
+        },
+        "openassessment_submissions": {
+            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
+            "KEY_FUNCTION": "util.memcache.safe_key",
+            "KEY_PREFIX": "openassessment_submissions",
         },
     },
     formatter=json.loads,
@@ -390,11 +399,6 @@ for app in config("ADDL_INSTALLED_APPS", default=[], formatter=json.loads):
 
 WIKI_ENABLED = config("WIKI_ENABLED", default=WIKI_ENABLED, formatter=bool)
 local_loglevel = config("LOCAL_LOGLEVEL", default="INFO")
-
-# Configure Logging
-
-LOG_DIR = config("LOG_DIR", default=path("/edx/var/logs/edx"), formatter=path)
-DATA_DIR = config("DATA_DIR", default=path("/edx/var/edxapp"), formatter=path)
 
 # Default format for syslog logging
 standard_format = "%(asctime)s %(levelname)s %(process)d [%(name)s] %(filename)s:%(lineno)d - %(message)s"
@@ -852,10 +856,19 @@ FINANCIAL_REPORTS = config(
 )
 
 ##### ORA2 ######
+ORA2_FILEUPLOAD_BACKEND = config("ORA2_FILEUPLOAD_BACKEND", default="filesystem")
+FILE_UPLOAD_STORAGE_BUCKET_NAME = "uploads"
 # Prefix for uploads of example-based assessment AI classifiers
 # This can be used to separate uploads for different environments
-# within the same S3 bucket.
 ORA2_FILE_PREFIX = config("ORA2_FILE_PREFIX", default=ORA2_FILE_PREFIX)
+
+# If backend is "filesystem"
+ORA2_FILEUPLOAD_ROOT = DATA_DIR / "openassessment_submissions"
+ORA2_FILEUPLOAD_CACHE_NAME = config("ORA2_FILEUPLOAD_CACHE_NAME", default="openassessment_submissions")
+
+# If backend is "swift"
+ORA2_SWIFT_KEY = config("ORA2_SWIFT_KEY", default="")
+ORA2_SWIFT_URL = config("ORA2_SWIFT_URL", default="")
 
 ##### ACCOUNT LOCKOUT DEFAULT PARAMETERS #####
 MAX_FAILED_LOGIN_ATTEMPTS_ALLOWED = config(


### PR DESCRIPTION
## Purpose

We want to make ORA2 work on all flavors. Except for `dogwood.3-fun`, the default backend should be set to the filesystem but everything should be configurable via yaml configuration files.

## Proposal

- [x] add a cache backend dedicated to ORA2 using memcached like the default cache but on which we set a specific key prefix,
- [x] add missing settings to each flavor with a `config` getter,
- [x] clean-up the configuration of the `dogwood.3-fun` image which uses Swift.
