### PR TITLE
Bump fun-apps to 5.2.0  in dogwood.3-fun and 2.2.0+wb in eucalyptus.3-wb

### DIFF
--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -15,6 +15,10 @@ release.
   to activate `videoupload` templates
 - Configure all cache backends as they are in FUN's production instance
 
+### Changed
+
+- Upgrade fun-apps to 5.2.0
+
 ## [dogwood.3-fun-1.6.0] - 2020-01-03
 
 ### Changed

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -4,7 +4,7 @@
 # ==== core ====
 edx-gea==0.2.0
 fonzie==0.2.0
-fun-apps==5.0.0
+fun-apps==5.2.0
 
 # ==== xblocks ====
 configurable_lti_consumer-xblock==1.3.0

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -17,6 +17,7 @@ release.
 
 ### Changed
 
+- Upgrade fun-apps to 2.2.0+wb
 - Make ORA2 configurable and use filesystem backend by default
 
 ## [eucalyptus.3-wb-1.4.0] - 2020-01-03

--- a/releases/eucalyptus/3/wb/requirements.txt
+++ b/releases/eucalyptus/3/wb/requirements.txt
@@ -4,7 +4,7 @@
 # ==== core ====
 configurable-lti-consumer-xblock==1.3.0
 edx-gea==0.2.0
-fun-apps==2.0.1+wb
+fun-apps==2.2.0+wb
 libcast-xblock==0.5.0
 password-container-xblock==0.3.0
 xblock-proctor-exam==0.9.0b0


### PR DESCRIPTION
## Purpose

We want to bump the `fun-apps` dependency to its latest version in our `dogwood.3-fun` and `eucalyptus.3-wb` releases. 

## Proposal

- [x] Bump `fun-apps` to 5.2.0 in `dogwood.3-fun`
- [x] Bump `fun-apps` to 2.2.0+wb in `eucalyptus.3-wb`
