### PR TITLE
🐛(flavors/*) Ensure all required directories exists inside each volume

### DIFF
--- a/releases/dogwood/3/bare/CHANGELOG.md
+++ b/releases/dogwood/3/bare/CHANGELOG.md
@@ -21,6 +21,7 @@ release.
 
 ### Fixed
 
+- Ensure all required directories exists inside each volume
 - Refactor settings to repair and clean what is cms versus lms, configurable
   versus defined by code.
 

--- a/releases/dogwood/3/bare/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/bare/config/lms/docker_run_production.py
@@ -30,7 +30,7 @@ from xmodule.modulestore.modulestore_settings import (
 )
 
 from ..common import *
-from .utils import Configuration
+from .utils import Configuration, ensure_directory_exists
 
 # Load custom configuration parameters from yaml files
 config = Configuration(os.path.dirname(__file__))
@@ -807,7 +807,13 @@ ORA2_FILE_PREFIX = config("ORA2_FILE_PREFIX", default=ORA2_FILE_PREFIX)
 
 # If backend is "filesystem"
 ORA2_FILEUPLOAD_ROOT = DATA_DIR / "openassessment_submissions"
-ORA2_FILEUPLOAD_CACHE_NAME = config("ORA2_FILEUPLOAD_CACHE_NAME", default="openassessment_submissions")
+# The code in edX ORA2 is missing appropriate checks so we must ensure here that this
+# directory exists:
+ensure_directory_exists(ORA2_FILEUPLOAD_ROOT)
+
+ORA2_FILEUPLOAD_CACHE_NAME = config(
+    "ORA2_FILEUPLOAD_CACHE_NAME", default="openassessment_submissions"
+)
 
 # If backend is "swift"
 ORA2_SWIFT_KEY = config("ORA2_SWIFT_KEY", default="")

--- a/releases/dogwood/3/bare/config/lms/utils.py
+++ b/releases/dogwood/3/bare/config/lms/utils.py
@@ -108,3 +108,9 @@ class Configuration(dict):
             #    - make a PR to Open edX to provide a better default for this setting.
             default = None
         return self(name, default=default)
+
+
+def ensure_directory_exists(directory):
+    """This function creates a directory if it does not exist on the filesystem."""
+    if not os.path.exists(directory):
+        os.mkdir(directory)

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensure all required directories exists inside each volume
+
 ## [dogwood.3-fun-1.7.0] - 2020-01-08
 
 ### Changed

--- a/releases/dogwood/3/fun/config/lms/docker_run_development.py
+++ b/releases/dogwood/3/fun/config/lms/docker_run_development.py
@@ -2,7 +2,7 @@
 # settings of the `production` environment
 
 from docker_run_production import *
-from .utils import Configuration
+from .utils import Configuration, ensure_directory_exists
 
 # Load custom configuration parameters from yaml files
 config = Configuration(os.path.dirname(__file__))
@@ -27,15 +27,10 @@ FEATURES["AUTOMATIC_AUTH_FOR_TESTING"] = True
 # ORA2 fileupload
 ORA2_FILEUPLOAD_BACKEND = "filesystem"
 ORA2_FILEUPLOAD_ROOT = os.path.join(SHARED_ROOT, "openassessment_submissions")
+# The code in edX ORA2 is missing appropriate checks so we must ensure here that this
+# directory exists:
+ensure_directory_exists(ORA2_FILEUPLOAD_ROOT)
+
 ORA2_FILEUPLOAD_CACHE_ROOT = os.path.join(
     SHARED_ROOT, "openassessment_submissions_cache"
 )
-
-
-def ensure_directory_exists(directory):
-    if not os.path.exists(directory):
-        os.makedirs(directory)
-
-
-ensure_directory_exists(ORA2_FILEUPLOAD_ROOT)
-ensure_directory_exists(ORA2_FILEUPLOAD_CACHE_ROOT)

--- a/releases/dogwood/3/fun/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/lms/docker_run_production.py
@@ -37,7 +37,7 @@ from xmodule.modulestore.modulestore_settings import (
 )
 
 from ..common import *
-from .utils import Configuration, prefer_fun_video
+from .utils import Configuration, ensure_directory_exists, prefer_fun_video
 
 # Load custom configuration parameters from yaml files
 config = Configuration(os.path.dirname(__file__))
@@ -1365,6 +1365,10 @@ LOCALE_PATHS.append(path(pkgutil.get_loader("proctor_exam").filename) / "locale"
 # -- Certificates
 CERTIFICATE_BASE_URL = MEDIA_URL + "attestations/"
 CERTIFICATES_DIRECTORY = MEDIA_ROOT / "certificates"
+# The code in fun-apps is missing appropriate checks so we must ensure here that this
+# directory exists:
+ensure_directory_exists(CERTIFICATES_DIRECTORY)
+
 FUN_LOGO_PATH = FUN_BASE_ROOT / "funsite/static" / FUN_BIG_LOGO_RELATIVE_PATH
 FUN_ATTESTATION_LOGO_PATH = (
     FUN_BASE_ROOT / "funsite/static" / "funsite/images/logos/funmoocattest.png"

--- a/releases/dogwood/3/fun/config/lms/utils.py
+++ b/releases/dogwood/3/fun/config/lms/utils.py
@@ -109,6 +109,12 @@ class Configuration(dict):
         return self(name, default=default)
 
 
+def ensure_directory_exists(directory):
+    """This function creates a directory if it does not exist on the filesystem."""
+    if not os.path.exists(directory):
+        os.mkdir(directory)
+
+
 def prefer_fun_video(identifier, entry_points):
     """
     This function will be affected to XBLOCK_SELECT_FUNCTION which is used to

--- a/releases/eucalyptus/3/bare/CHANGELOG.md
+++ b/releases/eucalyptus/3/bare/CHANGELOG.md
@@ -25,6 +25,7 @@ release.
 
 ### Fixed
 
+- Ensure all required directories exists inside each volume
 - Refactor settings to repair and clean what is cms versus lms, configurable
   versus defined by code.
 

--- a/releases/eucalyptus/3/bare/config/lms/docker_run_production.py
+++ b/releases/eucalyptus/3/bare/config/lms/docker_run_production.py
@@ -31,7 +31,7 @@ from xmodule.modulestore.modulestore_settings import (
 )
 
 from ..common import *
-from .utils import Configuration
+from .utils import Configuration, ensure_directory_exists
 
 # Load custom configuration parameters from yaml files
 config = Configuration(os.path.dirname(__file__))
@@ -884,7 +884,13 @@ ORA2_FILE_PREFIX = config("ORA2_FILE_PREFIX", default=ORA2_FILE_PREFIX)
 
 # If backend is "filesystem"
 ORA2_FILEUPLOAD_ROOT = DATA_DIR / "openassessment_submissions"
-ORA2_FILEUPLOAD_CACHE_NAME = config("ORA2_FILEUPLOAD_CACHE_NAME", default="openassessment_submissions")
+# The code in edX ORA2 is missing appropriate checks so we must ensure here that this
+# directory exists:
+ensure_directory_exists(ORA2_FILEUPLOAD_ROOT)
+
+ORA2_FILEUPLOAD_CACHE_NAME = config(
+    "ORA2_FILEUPLOAD_CACHE_NAME", default="openassessment_submissions"
+)
 
 # If backend is "swift"
 ORA2_SWIFT_KEY = config("ORA2_SWIFT_KEY", default="")

--- a/releases/eucalyptus/3/bare/config/lms/utils.py
+++ b/releases/eucalyptus/3/bare/config/lms/utils.py
@@ -108,3 +108,9 @@ class Configuration(dict):
             #    - make a PR to Open edX to provide a better default for this setting.
             default = None
         return self(name, default=default)
+
+
+def ensure_directory_exists(directory):
+    """This function creates a directory if it does not exist on the filesystem."""
+    if not os.path.exists(directory):
+        os.mkdir(directory)

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -12,6 +12,7 @@ release.
 ### Fixed
 
 - Neutralize thumbnails creation as `eucalyptus.3-wb` is not using them
+- Ensure all required directories exists inside each volume
 
 ### Removed
 

--- a/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
@@ -33,7 +33,7 @@ from xmodule.modulestore.modulestore_settings import (
 )
 
 from ..common import *
-from .utils import Configuration, prefer_fun_video
+from .utils import Configuration, ensure_directory_exists, prefer_fun_video
 
 # Load custom configuration parameters from yaml files
 config = Configuration(os.path.dirname(__file__))
@@ -327,7 +327,7 @@ CACHES = config(
         "video_subtitles": {
             "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",
             "KEY_PREFIX": "video_subtitles",
-            "LOCATION": "/edx/var/edxapp/shared/video_subtitles_cache"
+            "LOCATION": "/edx/var/edxapp/shared/video_subtitles_cache",
         },
     },
     formatter=json.loads,
@@ -932,7 +932,13 @@ ORA2_FILE_PREFIX = config("ORA2_FILE_PREFIX", default=ORA2_FILE_PREFIX)
 
 # If backend is "filesystem"
 ORA2_FILEUPLOAD_ROOT = DATA_DIR / "openassessment_submissions"
-ORA2_FILEUPLOAD_CACHE_NAME = config("ORA2_FILEUPLOAD_CACHE_NAME", default="openassessment_submissions")
+# The code in edX ORA2 is missing appropriate checks so we must ensure here that this
+# directory exists:
+ensure_directory_exists(ORA2_FILEUPLOAD_ROOT)
+
+ORA2_FILEUPLOAD_CACHE_NAME = config(
+    "ORA2_FILEUPLOAD_CACHE_NAME", default="openassessment_submissions"
+)
 
 # If backend is "swift"
 ORA2_SWIFT_KEY = config("ORA2_SWIFT_KEY", default="")
@@ -1394,6 +1400,10 @@ FUN_THUMBNAIL_OPTIONS = {}
 # -- Certificates
 CERTIFICATE_BASE_URL = MEDIA_URL + "attestations/"
 CERTIFICATES_DIRECTORY = MEDIA_ROOT / "certificates"
+# The code in fun-apps is missing appropriate checks so we must ensure here that this
+# directory exists:
+ensure_directory_exists(CERTIFICATES_DIRECTORY)
+
 STUDENT_NAME_FOR_TEST_CERTIFICATE = "Test User"
 
 # Used by pure-pagination app,

--- a/releases/eucalyptus/3/wb/config/lms/utils.py
+++ b/releases/eucalyptus/3/wb/config/lms/utils.py
@@ -105,6 +105,12 @@ class Configuration(dict):
         return self(name, default=default)
 
 
+def ensure_directory_exists(directory):
+    """This function creates a directory if it does not exist on the filesystem."""
+    if not os.path.exists(directory):
+        os.mkdir(directory)
+
+
 def prefer_fun_video(identifier, entry_points):
     """
     This function will be affected to XBLOCK_SELECT_FUNCTION which is used to

--- a/releases/hawthorn/1/bare/CHANGELOG.md
+++ b/releases/hawthorn/1/bare/CHANGELOG.md
@@ -15,6 +15,7 @@ release.
 
 ### Changed
 
+- Move DATA_DIR to same location as for other flavors
 - Make ORA2 configurable and use filesystem backend by default
 - Stop inheriting from MKTG_URL_LINK_MAP default setting
 

--- a/releases/hawthorn/1/bare/CHANGELOG.md
+++ b/releases/hawthorn/1/bare/CHANGELOG.md
@@ -21,6 +21,7 @@ release.
 
 ### Fixed
 
+- Ensure all required directories exists inside each volume
 - Make Celery result backend configurable
 
 ## [hawthorn.1-2.8.0] - 2019-11-22

--- a/releases/hawthorn/1/bare/config/lms/docker_run_production.py
+++ b/releases/hawthorn/1/bare/config/lms/docker_run_production.py
@@ -17,7 +17,7 @@ from xmodule.modulestore.modulestore_settings import (
 )
 
 from ..common import *
-from .utils import Configuration
+from .utils import Configuration, ensure_directory_exists
 
 # Load custom configuration parameters from yaml files
 config = Configuration(os.path.dirname(__file__))
@@ -888,7 +888,13 @@ ORA2_FILE_PREFIX = config("ORA2_FILE_PREFIX", default=ORA2_FILE_PREFIX)
 
 # If backend is "filesystem"
 ORA2_FILEUPLOAD_ROOT = DATA_DIR / "openassessment_submissions"
-ORA2_FILEUPLOAD_CACHE_NAME = config("ORA2_FILEUPLOAD_CACHE_NAME", default="openassessment_submissions")
+# The code in edX ORA2 is missing appropriate checks so we must ensure here that this
+# directory exists:
+ensure_directory_exists(ORA2_FILEUPLOAD_ROOT)
+
+ORA2_FILEUPLOAD_CACHE_NAME = config(
+    "ORA2_FILEUPLOAD_CACHE_NAME", default="openassessment_submissions"
+)
 
 # If backend is "swift"
 ORA2_SWIFT_KEY = config("ORA2_SWIFT_KEY", default="")

--- a/releases/hawthorn/1/bare/config/lms/docker_run_production.py
+++ b/releases/hawthorn/1/bare/config/lms/docker_run_production.py
@@ -112,7 +112,7 @@ MEDIA_ROOT = path("/edx/var/edxapp/media/")
 MEDIA_URL = "/media/"
 
 LOG_DIR = config("LOG_DIR", default=path("/edx/var/logs/edx"), formatter=path)
-DATA_DIR = config("DATA_DIR", default=path("/edx/var/edxapp"), formatter=path)
+DATA_DIR = config("DATA_DIR", default=path("/edx/app/edxapp/data"), formatter=path)
 
 # DEFAULT_COURSE_ABOUT_IMAGE_URL specifies the default image to show for courses that don't provide one
 DEFAULT_COURSE_ABOUT_IMAGE_URL = config(

--- a/releases/hawthorn/1/bare/config/lms/utils.py
+++ b/releases/hawthorn/1/bare/config/lms/utils.py
@@ -108,3 +108,9 @@ class Configuration(dict):
             #    - make a PR to Open edX to provide a better default for this setting.
             default = None
         return self(name, default=default)
+
+
+def ensure_directory_exists(directory):
+    """This function creates a directory if it does not exist on the filesystem."""
+    if not os.path.exists(directory):
+        os.mkdir(directory)

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -21,6 +21,7 @@ release.
 
 ### Fixed
 
+- Ensure all required directories exists inside each volume
 - Make Celery result backend configurable
 
 ## [hawthorn.1-oee-2.12.3] - 2019-12-10

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -15,6 +15,7 @@ release.
 
 ### Changed
 
+- Move DATA_DIR to same location as for other flavors
 - Make ORA2 configurable and use filesystem backend by default
 - Stop inheriting from MKTG_URL_LINK_MAP default setting
 

--- a/releases/hawthorn/1/oee/config/lms/docker_run_production.py
+++ b/releases/hawthorn/1/oee/config/lms/docker_run_production.py
@@ -18,7 +18,7 @@ from xmodule.modulestore.modulestore_settings import (
 )
 
 from ..common import *
-from .utils import Configuration
+from .utils import Configuration, ensure_directory_exists
 
 # Load custom configuration parameters from yaml files
 config = Configuration(os.path.dirname(__file__))
@@ -953,7 +953,13 @@ ORA2_FILE_PREFIX = config("ORA2_FILE_PREFIX", default=ORA2_FILE_PREFIX)
 
 # If backend is "filesystem"
 ORA2_FILEUPLOAD_ROOT = DATA_DIR / "openassessment_submissions"
-ORA2_FILEUPLOAD_CACHE_NAME = config("ORA2_FILEUPLOAD_CACHE_NAME", default="openassessment_submissions")
+# The code in edX ORA2 is missing appropriate checks so we must ensure here that this
+# directory exists:
+ensure_directory_exists(ORA2_FILEUPLOAD_ROOT)
+
+ORA2_FILEUPLOAD_CACHE_NAME = config(
+    "ORA2_FILEUPLOAD_CACHE_NAME", default="openassessment_submissions"
+)
 
 # If backend is "swift"
 ORA2_SWIFT_KEY = config("ORA2_SWIFT_KEY", default="")

--- a/releases/hawthorn/1/oee/config/lms/docker_run_production.py
+++ b/releases/hawthorn/1/oee/config/lms/docker_run_production.py
@@ -146,7 +146,7 @@ MEDIA_ROOT = path("/edx/var/edxapp/media/")
 MEDIA_URL = "/media/"
 
 LOG_DIR = config("LOG_DIR", default=path("/edx/var/logs/edx"), formatter=path)
-DATA_DIR = config("DATA_DIR", default=path("/edx/var/edxapp"), formatter=path)
+DATA_DIR = config("DATA_DIR", default=path("/edx/app/edxapp/data"), formatter=path)
 
 # DEFAULT_COURSE_ABOUT_IMAGE_URL specifies the default image to show for courses that don't provide one
 DEFAULT_COURSE_ABOUT_IMAGE_URL = config(

--- a/releases/hawthorn/1/oee/config/lms/utils.py
+++ b/releases/hawthorn/1/oee/config/lms/utils.py
@@ -108,3 +108,9 @@ class Configuration(dict):
             #    - make a PR to Open edX to provide a better default for this setting.
             default = None
         return self(name, default=default)
+
+
+def ensure_directory_exists(directory):
+    """This function creates a directory if it does not exist on the filesystem."""
+    if not os.path.exists(directory):
+        os.mkdir(directory)

--- a/releases/master/bare/config/lms/docker_run_production.py
+++ b/releases/master/bare/config/lms/docker_run_production.py
@@ -17,7 +17,7 @@ from xmodule.modulestore.modulestore_settings import (
 )
 
 from ..common import *
-from .utils import Configuration
+from .utils import Configuration, ensure_directory_exists
 
 # Load custom configuration parameters from yaml files
 config = Configuration(os.path.dirname(__file__))
@@ -889,7 +889,13 @@ ORA2_FILE_PREFIX = config("ORA2_FILE_PREFIX", default=ORA2_FILE_PREFIX)
 
 # If backend is "filesystem"
 ORA2_FILEUPLOAD_ROOT = DATA_DIR / "openassessment_submissions"
-ORA2_FILEUPLOAD_CACHE_NAME = config("ORA2_FILEUPLOAD_CACHE_NAME", default="openassessment_submissions")
+# The code in edX ORA2 is missing appropriate checks so we must ensure here that this
+# directory exists:
+ensure_directory_exists(ORA2_FILEUPLOAD_ROOT)
+
+ORA2_FILEUPLOAD_CACHE_NAME = config(
+    "ORA2_FILEUPLOAD_CACHE_NAME", default="openassessment_submissions"
+)
 
 # If backend is "swift"
 ORA2_SWIFT_KEY = config("ORA2_SWIFT_KEY", default="")

--- a/releases/master/bare/config/lms/docker_run_production.py
+++ b/releases/master/bare/config/lms/docker_run_production.py
@@ -112,7 +112,7 @@ MEDIA_ROOT = path("/edx/var/edxapp/media/")
 MEDIA_URL = "/media/"
 
 LOG_DIR = config("LOG_DIR", default=path("/edx/var/logs/edx"), formatter=path)
-DATA_DIR = config("DATA_DIR", default=path("/edx/var/edxapp"), formatter=path)
+DATA_DIR = config("DATA_DIR", default=path("/edx/app/edxapp/data"), formatter=path)
 
 # DEFAULT_COURSE_ABOUT_IMAGE_URL specifies the default image to show for courses that don't provide one
 DEFAULT_COURSE_ABOUT_IMAGE_URL = config(

--- a/releases/master/bare/config/lms/utils.py
+++ b/releases/master/bare/config/lms/utils.py
@@ -108,3 +108,9 @@ class Configuration(dict):
             #    - make a PR to Open edX to provide a better default for this setting.
             default = None
         return self(name, default=default)
+
+
+def ensure_directory_exists(directory):
+    """This function creates a directory if it does not exist on the filesystem."""
+    if not os.path.exists(directory):
+        os.mkdir(directory)


### PR DESCRIPTION
## Purpose

Some required directories were missing inside volumes. It seems that edX does not ensure this by code when using these locations.

### Proposal

Add a check in setetings to make sure all required directories exist upon startup.

This was ported from [fun-apps](https://github.com/openfun/fun-apps/blob/0af5fab8ae6967428bb0a44568bdd84bccbbfcea/fun/envs/common.py#L238)
