### PR TITLE
🔥(eucalyptus/3/*) remove settings related to cross-process queues

### DIFF
--- a/releases/eucalyptus/3/bare/CHANGELOG.md
+++ b/releases/eucalyptus/3/bare/CHANGELOG.md
@@ -19,6 +19,10 @@ release.
 - Make ORA2 configurable and use filesystem backend by default
 - Stop inheriting from MKTG_URL_LINK_MAP default setting
 
+### Removed
+
+- Alternate queues settings to extend CELERY_QUEUES for cross-process workers
+
 ### Fixed
 
 - Refactor settings to repair and clean what is cms versus lms, configurable

--- a/releases/eucalyptus/3/bare/config/cms/docker_run_production.py
+++ b/releases/eucalyptus/3/bare/config/cms/docker_run_production.py
@@ -104,20 +104,6 @@ CELERY_QUEUES = config(
     formatter=json.loads,
 )
 
-# Setup alternate queues, to allow access to cross-process workers
-ALTERNATE_QUEUE_ENVS = config("ALTERNATE_WORKER_QUEUES", default="").split()
-ALTERNATE_QUEUES = [
-    DEFAULT_PRIORITY_QUEUE.replace("cms.", alternate + ".")
-    for alternate in ALTERNATE_QUEUE_ENVS
-]
-CELERY_QUEUES.update(
-    {
-        alternate: {}
-        for alternate in ALTERNATE_QUEUES
-        if alternate not in CELERY_QUEUES.keys()
-    }
-)
-
 CELERY_ROUTES = "cms.celery.Router"
 
 # Force accepted content to "json" only. If we also accept pickle-serialized

--- a/releases/eucalyptus/3/bare/config/lms/docker_run_production.py
+++ b/releases/eucalyptus/3/bare/config/lms/docker_run_production.py
@@ -114,19 +114,6 @@ CELERY_QUEUES = config(
     formatter=json.loads,
 )
 
-# Setup alternate queues, to allow access to cross-process workers
-ALTERNATE_QUEUE_ENVS = config("ALTERNATE_WORKER_QUEUES", default="").split()
-ALTERNATE_QUEUES = [
-    DEFAULT_PRIORITY_QUEUE.replace("lms.", alternate + ".")
-    for alternate in ALTERNATE_QUEUE_ENVS
-]
-CELERY_QUEUES.update(
-    {
-        alternate: {}
-        for alternate in ALTERNATE_QUEUES
-        if alternate not in CELERY_QUEUES.keys()
-    }
-)
 CELERY_ROUTES = "lms.celery.Router"
 
 # Force accepted content to "json" only. If we also accept pickle-serialized

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Removed
+
+- Alternate queues settings to extend CELERY_QUEUES for cross-process workers
+
 ## [eucalyptus.3-wb-1.5.0] - 2020-01-08
 
 ### Changed

--- a/releases/eucalyptus/3/wb/config/cms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/cms/docker_run_production.py
@@ -105,20 +105,6 @@ CELERY_QUEUES = config(
     formatter=json.loads,
 )
 
-# Setup alternate queues, to allow access to cross-process workers
-ALTERNATE_QUEUE_ENVS = config("ALTERNATE_WORKER_QUEUES", default="").split()
-ALTERNATE_QUEUES = [
-    DEFAULT_PRIORITY_QUEUE.replace("cms.", alternate + ".")
-    for alternate in ALTERNATE_QUEUE_ENVS
-]
-CELERY_QUEUES.update(
-    {
-        alternate: {}
-        for alternate in ALTERNATE_QUEUES
-        if alternate not in CELERY_QUEUES.keys()
-    }
-)
-
 CELERY_ROUTES = "cms.celery.Router"
 
 # Force accepted content to "json" only. If we also accept pickle-serialized

--- a/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
@@ -116,19 +116,6 @@ CELERY_QUEUES = config(
     formatter=json.loads,
 )
 
-# Setup alternate queues, to allow access to cross-process workers
-ALTERNATE_QUEUE_ENVS = config("ALTERNATE_WORKER_QUEUES", default="").split()
-ALTERNATE_QUEUES = [
-    DEFAULT_PRIORITY_QUEUE.replace("lms.", alternate + ".")
-    for alternate in ALTERNATE_QUEUE_ENVS
-]
-CELERY_QUEUES.update(
-    {
-        alternate: {}
-        for alternate in ALTERNATE_QUEUES
-        if alternate not in CELERY_QUEUES.keys()
-    }
-)
 CELERY_ROUTES = "lms.celery.Router"
 
 # Force accepted content to "json" only. If we also accept pickle-serialized


### PR DESCRIPTION
While debugging we understood that CMS wsgi pods can route celery
tasks to LMS workers, lms/cms basecode and settings being differents,
such task can't run on sender pod. Removed code was intended to configure
CELERY_QUEUES with other variant queues names for such cross-variant tasks.
We decided to remove it because its overly complicated and we will
handle this upstream in Arnold.
