### PR TITLE
Gunicorn workers

### DIFF
--- a/releases/dogwood/3/bare/CHANGELOG.md
+++ b/releases/dogwood/3/bare/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-1.2.0] - 2020-01-10
+
 ### Added
 
 - Make Gunicorn timeout, workers and threads configurable via 
@@ -22,7 +24,7 @@ release.
 
 ### Fixed
 
-- Ensure all required directories exists inside each volume
+- Ensure all required directories exist inside each volume
 - Refactor settings to repair and clean what is cms versus lms, configurable
   versus defined by code.
 
@@ -73,7 +75,8 @@ release.
 
 First experimental release of OpenEdx `dogwood.3` (bare flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-1.1.5...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-1.2.0...HEAD
+[dogwood.3-1.2.0]: https://github.com/openfun/openedx-docker/compare/tag/dogwood.3-1.1.5...dogwood.3-1.2.0
 [dogwood.3-1.1.5]: https://github.com/openfun/openedx-docker/compare/tag/dogwood.3-1.1.4...dogwood.3-1.1.5
 [dogwood.3-1.1.4]: https://github.com/openfun/openedx-docker/compare/tag/dogwood.3-1.1.3...dogwood.3-1.1.4
 [dogwood.3-1.1.3]: https://github.com/openfun/openedx-docker/compare/tag/dogwood.3-1.1.2...dogwood.3-1.1.3

--- a/releases/dogwood/3/bare/CHANGELOG.md
+++ b/releases/dogwood/3/bare/CHANGELOG.md
@@ -11,7 +11,8 @@ release.
 
 ### Added
 
-- Make Gunicorn timeout configurable via an environment variable
+- Make Gunicorn timeout, workers and threads configurable via 
+  an environment variable
 - Configure all cache backends
 
 ### Changed

--- a/releases/dogwood/3/bare/Dockerfile
+++ b/releases/dogwood/3/bare/Dockerfile
@@ -165,10 +165,14 @@ RUN pip install -r requirements/edx/local.txt
 # prevent SSL certificate validation failure (we should use pyOpenSSL instead
 # of the local openssl library). For reference, see:
 # https://urllib3.readthedocs.io/en/latest/user-guide.html#ssl-py2
+#
+# The version of gunicorn shipped with Open edX is too old. We want to use a
+# recent version to be able to configure threads with gthread worker class.
 RUN pip install --upgrade \
       redis==3.3.7 \
       requests==2.22.0 \
-      urllib3[secure]==1.25.7
+      urllib3[secure]==1.25.7 \
+      gunicorn==19.9.0
 # Update assets skipping collectstatic (it should be done during deployment)
 RUN NO_PREREQ_INSTALL=1 \
     paver update_assets --settings=fun.docker_build --skip-collect
@@ -274,6 +278,13 @@ ENV SERVICE_VARIANT=lms
 # increased without having to make a new release of this image
 ENV GUNICORN_TIMEOUT 300
 
+# In docker we must increase the number of workers and threads created
+# by gunicorn.
+# This blogpost explains why and how to do that https://pythonspeed.com/articles/gunicorn-in-docker/
+ENV GUNICORN_WORKERS 3
+ENV GUNICORN_THREADS 6
+
+
 # Use Gunicorn in production as web server
 CMD DJANGO_SETTINGS_MODULE=${SERVICE_VARIANT}.envs.fun.docker_run \
     gunicorn \
@@ -281,4 +292,6 @@ CMD DJANGO_SETTINGS_MODULE=${SERVICE_VARIANT}.envs.fun.docker_run \
       --bind=0.0.0.0:8000 \
       --max-requests=1000 \
       --timeout=${GUNICORN_TIMEOUT} \
+      --workers=${GUNICORN_WORKERS} \
+      --threads=${GUNICORN_THREADS} \
       ${SERVICE_VARIANT}.wsgi:application

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Added
+
+- Make Gunicorn workers and threads configurable via an environment variable
+
 ### Fixed
 
 - Ensure all required directories exists inside each volume

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,13 +9,15 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-1.8.0] - 2020-01-10
+
 ### Added
 
 - Make Gunicorn workers and threads configurable via an environment variable
 
 ### Fixed
 
-- Ensure all required directories exists inside each volume
+- Ensure all required directories exist inside each volume
 
 ## [dogwood.3-fun-1.7.0] - 2020-01-08
 
@@ -173,7 +175,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.7.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.8.0...HEAD
+[dogwood.3-fun-1.8.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.7.0...dogwood.3-fun-1.8.0
 [dogwood.3-fun-1.7.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.6.0...dogwood.3-fun-1.7.0
 [dogwood.3-fun-1.6.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.5.1...dogwood.3-fun-1.6.0
 [dogwood.3-fun-1.5.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.5.0...dogwood.3-fun-1.5.1

--- a/releases/dogwood/3/fun/Dockerfile
+++ b/releases/dogwood/3/fun/Dockerfile
@@ -276,6 +276,12 @@ ENV SERVICE_VARIANT=lms
 #
 ENV GUNICORN_TIMEOUT 300
 
+# In docker we must increase the number of workers and threads created
+# by gunicorn.
+# This blogpost explains why and how to do that https://pythonspeed.com/articles/gunicorn-in-docker/
+ENV GUNICORN_WORKERS 3
+ENV GUNICORN_THREADS 6
+
 # Use Gunicorn in production as web server
 CMD DJANGO_SETTINGS_MODULE=${SERVICE_VARIANT}.envs.fun.docker_run \
     gunicorn \
@@ -283,4 +289,6 @@ CMD DJANGO_SETTINGS_MODULE=${SERVICE_VARIANT}.envs.fun.docker_run \
       --bind=0.0.0.0:8000 \
       --max-requests=1000 \
       --timeout=${GUNICORN_TIMEOUT} \
+      --workers=${GUNICORN_WORKERS} \
+      --threads=${GUNICORN_THREADS} \
       ${SERVICE_VARIANT}.wsgi:application

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -27,3 +27,7 @@ redis==2.10.6
 # https://urllib3.readthedocs.io/en/latest/user-guide.html#ssl-py2
 requests==2.22.0
 urllib3[secure]==1.25.7
+
+# The version of gunicorn shipped with Open edX is too old. We want to use a
+# recent version to be able to configure threads with gthread worker class.
+gunicorn==19.9.0

--- a/releases/eucalyptus/3/bare/CHANGELOG.md
+++ b/releases/eucalyptus/3/bare/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [eucalyptus.3-1.1.0] - 2020-01-10
+
 ### Added
 
 - Make Gunicorn timeout, workers and threads configurable via an environment 
@@ -26,7 +28,7 @@ release.
 
 ### Fixed
 
-- Ensure all required directories exists inside each volume
+- Ensure all required directories exist inside each volume
 - Refactor settings to repair and clean what is cms versus lms, configurable
   versus defined by code.
 
@@ -65,7 +67,8 @@ release.
 
 - First experimental release of OpenEdx `eucalyptus.3` (bare flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.4...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.1.0...HEAD
+[eucalyptus.3-1.1.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.4...eucalyptus.3-1.1.0
 [eucalyptus.3-1.0.4]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.3...eucalyptus.3-1.0.4
 [eucalyptus.3-1.0.3]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.2...eucalyptus.3-1.0.3
 [eucalyptus.3-1.0.2]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.1...eucalyptus.3-1.0.2

--- a/releases/eucalyptus/3/bare/CHANGELOG.md
+++ b/releases/eucalyptus/3/bare/CHANGELOG.md
@@ -11,7 +11,8 @@ release.
 
 ### Added
 
-- Make Gunicorn timeout configurable via an environment variable
+- Make Gunicorn timeout, workers and threads configurable via an environment 
+  variable
 - Configure all cache backends
 
 ### Changed

--- a/releases/eucalyptus/3/bare/Dockerfile
+++ b/releases/eucalyptus/3/bare/Dockerfile
@@ -132,7 +132,9 @@ RUN pip install -r requirements/edx/post.txt
 RUN pip install -r requirements/edx/local.txt
 # Redis is an extra requirement of Celery, we need to install it explicitly so
 # that celery workers are effective
-RUN pip install redis==3.3.7
+RUN pip install \
+      redis==3.3.7 \
+      gunicorn==19.9.0
 
 # Install Javascript requirements
 RUN npm install
@@ -245,6 +247,12 @@ ENV SERVICE_VARIANT=lms
 # increased without having to make a new release of this image
 ENV GUNICORN_TIMEOUT 300
 
+# In docker we must increase the number of workers and threads created
+# by gunicorn.
+# This blogpost explains why and how to do that https://pythonspeed.com/articles/gunicorn-in-docker/
+ENV GUNICORN_WORKERS 3
+ENV GUNICORN_THREADS 6
+
 # Use Gunicorn in production as web server
 CMD DJANGO_SETTINGS_MODULE=${SERVICE_VARIANT}.envs.fun.docker_run \
     gunicorn \
@@ -252,4 +260,6 @@ CMD DJANGO_SETTINGS_MODULE=${SERVICE_VARIANT}.envs.fun.docker_run \
       --bind=0.0.0.0:8000 \
       --max-requests=1000 \
       --timeout=${GUNICORN_TIMEOUT} \
+      --workers=${GUNICORN_WORKERS} \
+      --threads=${GUNICORN_THREADS} \
       ${SERVICE_VARIANT}.wsgi:application

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Added
+
+- Make Gunicorn workers and threads configurable via an environment variable
+
 ### Fixed
 
 - Neutralize thumbnails creation as `eucalyptus.3-wb` is not using them

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [eucalyptus.3-wb-1.6.0] - 2020-01-10
+
 ### Added
 
 - Make Gunicorn workers and threads configurable via an environment variable
@@ -16,7 +18,7 @@ release.
 ### Fixed
 
 - Neutralize thumbnails creation as `eucalyptus.3-wb` is not using them
-- Ensure all required directories exists inside each volume
+- Ensure all required directories exist inside each volume
 
 ### Removed
 
@@ -137,7 +139,8 @@ release.
 - Set replicaSet and read_preference in mongodb connection
 - Add missing support for redis sentinel
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.5.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.6.0...HEAD
+[eucalyptus.3-wb-1.6.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.5.0...eucalyptus.3-wb-1.6.0
 [eucalyptus.3-wb-1.5.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.4.0...eucalyptus.3-wb-1.5.0
 [eucalyptus.3-wb-1.4.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.3.1...eucalyptus.3-wb-1.4.0
 [eucalyptus.3-wb-1.3.1]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.3.0...eucalyptus.3-wb-1.3.1

--- a/releases/eucalyptus/3/wb/Dockerfile
+++ b/releases/eucalyptus/3/wb/Dockerfile
@@ -245,6 +245,12 @@ ENV SERVICE_VARIANT=lms
 # increased without having to make a new release of this image
 ENV GUNICORN_TIMEOUT 300
 
+# In docker we must increase the number of workers and threads created
+# by gunicorn.
+# This blogpost explains why and how to do that https://pythonspeed.com/articles/gunicorn-in-docker/
+ENV GUNICORN_WORKERS 3
+ENV GUNICORN_THREADS 6
+
 # Use Gunicorn in production as web server
 CMD DJANGO_SETTINGS_MODULE=${SERVICE_VARIANT}.envs.fun.docker_run \
     gunicorn \
@@ -252,4 +258,6 @@ CMD DJANGO_SETTINGS_MODULE=${SERVICE_VARIANT}.envs.fun.docker_run \
       --bind=0.0.0.0:8000 \
       --max-requests=1000 \
       --timeout=${GUNICORN_TIMEOUT} \
+      --workers=${GUNICORN_WORKERS} \
+      --threads=${GUNICORN_THREADS} \
       ${SERVICE_VARIANT}.wsgi:application

--- a/releases/eucalyptus/3/wb/requirements.txt
+++ b/releases/eucalyptus/3/wb/requirements.txt
@@ -15,3 +15,4 @@ celery-redis-sentinel==0.3.0
 django-redis-sessions==0.6.1
 raven==6.9.0
 redis==2.10.6
+gunicorn==19.9.0

--- a/releases/hawthorn/1/bare/CHANGELOG.md
+++ b/releases/hawthorn/1/bare/CHANGELOG.md
@@ -12,6 +12,8 @@ release.
 ### Added
 
 - Configure all cache backends
+- Make Gunicorn timeout, workers and threads configurable via an environment 
+  variable
 
 ### Changed
 

--- a/releases/hawthorn/1/bare/CHANGELOG.md
+++ b/releases/hawthorn/1/bare/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [hawthorn.1-3.0.0] - 2020-01-10
+
 ### Added
 
 - Configure all cache backends
@@ -17,7 +19,7 @@ release.
 
 ### Changed
 
-- Move DATA_DIR to same location as for other flavors
+- Move DATA_DIR to same location as for other flavors (breaking change)
 - Make ORA2 configurable and use filesystem backend by default
 - Stop inheriting from MKTG_URL_LINK_MAP default setting
 
@@ -200,7 +202,8 @@ result of updating our OpenEdX images from `ginkgo` to `hawthorn.1`. It is not
 functional and is intended for development and debugging work in
 [Arnold](https://github.com/openfun/arnold).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-2.8.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-3.0.0...HEAD
+[hawthorn.1-3.0.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-2.8.0...hawthorn.1-3.0.0
 [hawthorn.1-2.8.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-2.7.1...hawthorn.1-2.8.0
 [hawthorn.1-2.7.1]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-2.7.0...hawthorn.1-2.7.1
 [hawthorn.1-2.7.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-2.6.0...hawthorn.1-2.7.0

--- a/releases/hawthorn/1/bare/Dockerfile
+++ b/releases/hawthorn/1/bare/Dockerfile
@@ -103,6 +103,7 @@ WORKDIR /edx/app/edxapp/edx-platform
 
 # Install python dependencies
 RUN pip install --src /usr/local/src -r requirements/edx/base.txt
+RUN pip install gunicorn==19.9.0
 
 # Install Javascript requirements
 RUN npm install
@@ -204,6 +205,24 @@ USER 10000
 # (defaults to "lms")
 ENV SERVICE_VARIANT=lms
 
+# Gunicorn configuration
+#
+# We want to be able to easily increase gunicorn in hawtorn if needed 
+ENV GUNICORN_TIMEOUT 300
+
+# In docker we must increase the number of workers and threads created
+# by gunicorn.
+# This blogpost explains why and how to do that https://pythonspeed.com/articles/gunicorn-in-docker/
+ENV GUNICORN_WORKERS 3
+ENV GUNICORN_THREADS 6
+
 # Use Gunicorn in production as web server
 CMD DJANGO_SETTINGS_MODULE=${SERVICE_VARIANT}.envs.fun.docker_run \
-    gunicorn --name=${SERVICE_VARIANT} --bind=0.0.0.0:8000 --max-requests=1000 ${SERVICE_VARIANT}.wsgi:application
+    gunicorn \
+      --name=${SERVICE_VARIANT} \
+      --bind=0.0.0.0:8000 \
+      --max-requests=1000 \
+      --timeout=${GUNICORN_TIMEOUT} \
+      --workers=${GUNICORN_WORKERS} \
+      --threads=${GUNICORN_THREADS} \
+      ${SERVICE_VARIANT}.wsgi:application

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [hawthorn.1-oee-3.0.0] - 2020-01-10
+
 ### Added
 
 - Configure all cache backends
@@ -17,13 +19,13 @@ release.
 
 ### Changed
 
-- Move DATA_DIR to same location as for other flavors
+- Move DATA_DIR to same location as for other flavors (breaking change)
 - Make ORA2 configurable and use filesystem backend by default
 - Stop inheriting from MKTG_URL_LINK_MAP default setting
 
 ### Fixed
 
-- Ensure all required directories exists inside each volume
+- Ensure all required directories exist inside each volume
 - Make Celery result backend configurable
 
 ## [hawthorn.1-oee-2.12.3] - 2019-12-10
@@ -236,7 +238,8 @@ First release of OpenEdx extended.
 
 - Add a configurable LTI consumer xblock
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-2.12.3...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-3.0.0...HEAD
+[hawthorn.1-oee-3.0.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-2.12.3...hawthorn.1-oee-3.0.0
 [hawthorn.1-oee-2.12.3]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-2.12.2...hawthorn.1-oee-2.12.3
 [hawthorn.1-oee-2.12.2]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-2.12.1...hawthorn.1-oee-2.12.2
 [hawthorn.1-oee-2.12.1]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-2.12.0...hawthorn.1-oee-2.12.1

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -12,6 +12,8 @@ release.
 ### Added
 
 - Configure all cache backends
+- Make Gunicorn timeout, workers and threads configurable via an environment 
+  variable
 
 ### Changed
 

--- a/releases/hawthorn/1/oee/Dockerfile
+++ b/releases/hawthorn/1/oee/Dockerfile
@@ -212,6 +212,24 @@ USER 10000
 # (defaults to "lms")
 ENV SERVICE_VARIANT=lms
 
+# Gunicorn configuration
+#
+# We want to be able to easily increase gunicorn in hawtorn if needed 
+ENV GUNICORN_TIMEOUT 300
+
+# In docker we must increase the number of workers and threads created
+# by gunicorn.
+# This blogpost explains why and how to do that https://pythonspeed.com/articles/gunicorn-in-docker/
+ENV GUNICORN_WORKERS 3
+ENV GUNICORN_THREADS 6
+
 # Use Gunicorn in production as web server
 CMD DJANGO_SETTINGS_MODULE=${SERVICE_VARIANT}.envs.fun.docker_run \
-    gunicorn --name=${SERVICE_VARIANT} --bind=0.0.0.0:8000 --max-requests=1000 ${SERVICE_VARIANT}.wsgi:application
+    gunicorn \
+      --name=${SERVICE_VARIANT} \
+      --bind=0.0.0.0:8000 \
+      --max-requests=1000 \
+      --timeout=${GUNICORN_TIMEOUT} \
+      --workers=${GUNICORN_WORKERS} \
+      --threads=${GUNICORN_THREADS} \
+      ${SERVICE_VARIANT}.wsgi:application

--- a/releases/hawthorn/1/oee/requirements.txt
+++ b/releases/hawthorn/1/oee/requirements.txt
@@ -11,3 +11,4 @@ celery-redis-sentinel==0.3.0
 django-redis-sessions==0.6.1
 raven==6.9.0
 redis==2.10.6
+gunicorn==19.9.0

--- a/releases/master/bare/Dockerfile
+++ b/releases/master/bare/Dockerfile
@@ -103,6 +103,7 @@ WORKDIR /edx/app/edxapp/edx-platform
 
 # Install python dependencies
 RUN pip install --src /usr/local/src -r requirements/edx/base.txt
+RUN pip install gunicorn==19.9.0
 
 # Install Javascript requirements
 RUN npm install
@@ -203,6 +204,24 @@ USER 10000
 # (defaults to "lms")
 ENV SERVICE_VARIANT=lms
 
+# Gunicorn configuration
+#
+# We want to be able to easily increase gunicorn if needed 
+ENV GUNICORN_TIMEOUT 300
+
+# In docker we must increase the number of workers and threads created
+# by gunicorn.
+# This blogpost explains why and how to do that https://pythonspeed.com/articles/gunicorn-in-docker/
+ENV GUNICORN_WORKERS 3
+ENV GUNICORN_THREADS 6
+
 # Use Gunicorn in production as web server
 CMD DJANGO_SETTINGS_MODULE=${SERVICE_VARIANT}.envs.fun.docker_run \
-    gunicorn --name=${SERVICE_VARIANT} --bind=0.0.0.0:8000 --max-requests=1000 ${SERVICE_VARIANT}.wsgi:application
+    gunicorn \
+      --name=${SERVICE_VARIANT} \
+      --bind=0.0.0.0:8000 \
+      --max-requests=1000 \
+      --timeout=${GUNICORN_TIMEOUT} \
+      --workers=${GUNICORN_WORKERS} \
+      --threads=${GUNICORN_THREADS} \
+      ${SERVICE_VARIANT}.wsgi:application


### PR DESCRIPTION
## Purpose

When running in a container it is interesting to increase number of
workers and threads run by gunicorn. We found an interresting blogpost
explaining why and how to do that
https://pythonspeed.com/articles/gunicorn-in-docker/

## Proposal

Add environment variable in each flavors allowing to configure gunicorn with a number of workers and threads
