### PR TITLE
🐛(eucalyptus/3/wb) neutralize thumbnails creation as they are not used

### DIFF
--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Neutralize thumbnails creation as `eucalyptus.3-wb` is not using them
+
 ### Removed
 
 - Alternate queues settings to extend CELERY_QUEUES for cross-process workers

--- a/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
@@ -1386,11 +1386,14 @@ MAKO_TEMPLATES["main"] = [
 
 FUN_SMALL_LOGO_RELATIVE_PATH = "funsite/images/logos/fun61.png"
 FUN_BIG_LOGO_RELATIVE_PATH = "funsite/images/logos/fun195.png"
+FUN_LOGO_PATH = FUN_BASE_ROOT / "funsite/static" / FUN_BIG_LOGO_RELATIVE_PATH
+
+# Set thumbnail options to nothing otherwise they will be computed
+FUN_THUMBNAIL_OPTIONS = {}
 
 # -- Certificates
 CERTIFICATE_BASE_URL = MEDIA_URL + "attestations/"
 CERTIFICATES_DIRECTORY = MEDIA_ROOT / "certificates"
-FUN_LOGO_PATH = FUN_BASE_ROOT / "funsite/static" / FUN_BIG_LOGO_RELATIVE_PATH
 STUDENT_NAME_FOR_TEST_CERTIFICATE = "Test User"
 
 # Used by pure-pagination app,


### PR DESCRIPTION
## Purpose

The fun-apps are interdependant. Some thumbnails are calculated for the catalog search page that we are not using in eucalyptus.3. 

## Proposal

We can neutralize the creation of useless thumbnails by setting desired `FUN_THUMBNAIL_OPTIONS` to nothing.

