### PR TITLE
🐛([dogwood|eucalyptus]/3/[fun|wb]) fix videofront subtitles cache

### DIFF
--- a/releases/dogwood/3/fun/config/cms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/cms/docker_run_production.py
@@ -29,7 +29,7 @@ from xmodule.modulestore.modulestore_settings import (
     update_module_store_settings,
 )
 
-from lms.envs.fun.utils import Configuration, prefer_fun_video
+from lms.envs.fun.utils import Configuration, ensure_directory_exists, prefer_fun_video
 from ..common import *
 
 # Load custom configuration parameters from yaml files
@@ -203,11 +203,6 @@ CACHES = config(
             "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
             "KEY_FUNCTION": "util.memcache.safe_key",
             "KEY_PREFIX": "staticfiles",
-        },
-        "video_subtitles": {
-            "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",
-            "KEY_PREFIX": "video_subtitles",
-            "LOCATION": "/edx/var/edxapp/shared/video_subtitles_cache"
         },
     },
     formatter=json.loads,
@@ -743,7 +738,18 @@ SUBTITLE_SUPPORTED_LANGUAGES = LazyChoicesSorter(
     if code not in ("zh-cn", "zh-tw")
 )
 
-# Course image thumbnail sizes
+# Videofront subtitles cache
+VIDEOFRONT_SUBTITLE_CACHE_ROOT = DATA_DIR / "video_subtitles_cache"
+CACHES["video_subtitles"] = {
+    "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",
+    "KEY_PREFIX": "video_subtitles",
+    "LOCATION": VIDEOFRONT_SUBTITLE_CACHE_ROOT,
+}
+# The code in edX ORA2 is missing appropriate checks so we must ensure here that this
+# directory exists:
+ensure_directory_exists(VIDEOFRONT_SUBTITLE_CACHE_ROOT)
+
+# Course image thumbnails
 FUN_THUMBNAIL_OPTIONS = {
     "small": {"size": (270, 152), "crop": "smart"},
     "big": {"size": (337, 191), "crop": "smart"},

--- a/releases/dogwood/3/fun/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/lms/docker_run_production.py
@@ -306,11 +306,6 @@ CACHES = config(
             "KEY_FUNCTION": "util.memcache.safe_key",
             "KEY_PREFIX": "staticfiles",
         },
-        "video_subtitles": {
-            "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",
-            "KEY_PREFIX": "video_subtitles",
-            "LOCATION": "/edx/var/edxapp/shared/video_subtitles_cache"
-        },
     },
     formatter=json.loads,
 )
@@ -1375,7 +1370,18 @@ FUN_ATTESTATION_LOGO_PATH = (
 )
 STUDENT_NAME_FOR_TEST_CERTIFICATE = "Test User"
 
-# Course image thumbnail sizes
+# Videofront subtitles cache
+VIDEOFRONT_SUBTITLE_CACHE_ROOT = DATA_DIR / "video_subtitles_cache"
+CACHES["video_subtitles"] = {
+    "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",
+    "KEY_PREFIX": "video_subtitles",
+    "LOCATION": VIDEOFRONT_SUBTITLE_CACHE_ROOT,
+}
+# The code in edX ORA2 is missing appropriate checks so we must ensure here that this
+# directory exists:
+ensure_directory_exists(VIDEOFRONT_SUBTITLE_CACHE_ROOT)
+
+# Course image thumbnails
 FUN_THUMBNAIL_OPTIONS = {
     "small": {"size": (270, 152), "crop": "smart"},
     "big": {"size": (337, 191), "crop": "smart"},

--- a/releases/eucalyptus/3/wb/config/cms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/cms/docker_run_production.py
@@ -24,7 +24,7 @@ from xmodule.modulestore.modulestore_settings import (
 )
 
 from ..common import *
-from lms.envs.fun.utils import Configuration, prefer_fun_video
+from lms.envs.fun.utils import Configuration, ensure_directory_exists, prefer_fun_video
 
 # Load custom configuration parameters from yaml files
 config = Configuration(os.path.dirname(__file__))
@@ -197,11 +197,6 @@ CACHES = config(
             "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
             "KEY_FUNCTION": "util.memcache.safe_key",
             "KEY_PREFIX": "staticfiles",
-        },
-        "video_subtitles": {
-            "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",
-            "KEY_PREFIX": "video_subtitles",
-            "LOCATION": "/edx/var/edxapp/shared/video_subtitles_cache"
         },
     },
     formatter=json.loads,
@@ -812,7 +807,20 @@ DEFAULT_TEMPLATE_ENGINE["DIRS"].append(FUN_BASE_ROOT / "fun/templates/cms")
 
 # In `eucalyptus/wb` flavor, this constant has to be set to True (not None)
 # for `videofront` upload dashboard to show up in studio menues.
-FUN_DEFAULT_VIDEO_PLAYER = config("FUN_DEFAULT_VIDEO_PLAYER", default=True, formatter=bool)
+FUN_DEFAULT_VIDEO_PLAYER = config(
+    "FUN_DEFAULT_VIDEO_PLAYER", default=True, formatter=bool
+)
+
+# Videofront subtitles cache
+VIDEOFRONT_SUBTITLE_CACHE_ROOT = DATA_DIR / "video_subtitles_cache"
+CACHES["video_subtitles"] = {
+    "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",
+    "KEY_PREFIX": "video_subtitles",
+    "LOCATION": VIDEOFRONT_SUBTITLE_CACHE_ROOT,
+}
+# The code in edX ORA2 is missing appropriate checks so we must ensure here that this
+# directory exists:
+ensure_directory_exists(VIDEOFRONT_SUBTITLE_CACHE_ROOT)
 
 # Max size of asset uploads to GridFS
 MAX_ASSET_UPLOAD_FILE_SIZE_IN_MB = config(

--- a/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
@@ -324,11 +324,6 @@ CACHES = config(
             "KEY_FUNCTION": "util.memcache.safe_key",
             "KEY_PREFIX": "staticfiles",
         },
-        "video_subtitles": {
-            "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",
-            "KEY_PREFIX": "video_subtitles",
-            "LOCATION": "/edx/var/edxapp/shared/video_subtitles_cache",
-        },
     },
     formatter=json.loads,
 )
@@ -1405,6 +1400,17 @@ CERTIFICATES_DIRECTORY = MEDIA_ROOT / "certificates"
 ensure_directory_exists(CERTIFICATES_DIRECTORY)
 
 STUDENT_NAME_FOR_TEST_CERTIFICATE = "Test User"
+
+# Videofront subtitles cache
+VIDEOFRONT_SUBTITLE_CACHE_ROOT = DATA_DIR / "video_subtitles_cache"
+CACHES["video_subtitles"] = {
+    "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",
+    "KEY_PREFIX": "video_subtitles",
+    "LOCATION": VIDEOFRONT_SUBTITLE_CACHE_ROOT,
+}
+# The code in edX ORA2 is missing appropriate checks so we must ensure here that this
+# directory exists:
+ensure_directory_exists(VIDEOFRONT_SUBTITLE_CACHE_ROOT)
 
 # Used by pure-pagination app,
 # https://github.com/jamespacileo/django-pure-pagination for information about


### PR DESCRIPTION
## Purpose

The location declared for videofront subtitles cache did not exist which raised 500 errors when trying to access it.

## Proposal

- [x] add our now beloved anti-pattern to ensure the required directory is created in the volume
- [x] move videofront cache declaration to the "FUN stuff" section of the settings so that we don't forget to remove it when we soon decommission videofront.

