### PR TITLE
Remove method to ensure directories exist

### DIFF
--- a/releases/dogwood/3/bare/CHANGELOG.md
+++ b/releases/dogwood/3/bare/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Removed
+
+- Checks that ensure required directories exist in volumes
+
 ## [dogwood.3-1.2.0] - 2020-01-10
 
 ### Added

--- a/releases/dogwood/3/bare/CHANGELOG.md
+++ b/releases/dogwood/3/bare/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-1.2.1] - 2020-01-11
+
 ### Removed
 
 - Checks that ensure required directories exist in volumes
@@ -79,7 +81,8 @@ release.
 
 First experimental release of OpenEdx `dogwood.3` (bare flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-1.2.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-1.2.1...HEAD
+[dogwood.3-1.2.1]: https://github.com/openfun/openedx-docker/compare/tag/dogwood.3-1.2.0...dogwood.3-1.2.1
 [dogwood.3-1.2.0]: https://github.com/openfun/openedx-docker/compare/tag/dogwood.3-1.1.5...dogwood.3-1.2.0
 [dogwood.3-1.1.5]: https://github.com/openfun/openedx-docker/compare/tag/dogwood.3-1.1.4...dogwood.3-1.1.5
 [dogwood.3-1.1.4]: https://github.com/openfun/openedx-docker/compare/tag/dogwood.3-1.1.3...dogwood.3-1.1.4

--- a/releases/dogwood/3/bare/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/bare/config/lms/docker_run_production.py
@@ -30,7 +30,8 @@ from xmodule.modulestore.modulestore_settings import (
 )
 
 from ..common import *
-from .utils import Configuration, ensure_directory_exists
+from .utils import Configuration
+
 
 # Load custom configuration parameters from yaml files
 config = Configuration(os.path.dirname(__file__))
@@ -807,10 +808,6 @@ ORA2_FILE_PREFIX = config("ORA2_FILE_PREFIX", default=ORA2_FILE_PREFIX)
 
 # If backend is "filesystem"
 ORA2_FILEUPLOAD_ROOT = DATA_DIR / "openassessment_submissions"
-# The code in edX ORA2 is missing appropriate checks so we must ensure here that this
-# directory exists:
-ensure_directory_exists(ORA2_FILEUPLOAD_ROOT)
-
 ORA2_FILEUPLOAD_CACHE_NAME = config(
     "ORA2_FILEUPLOAD_CACHE_NAME", default="openassessment_submissions"
 )

--- a/releases/dogwood/3/bare/config/lms/utils.py
+++ b/releases/dogwood/3/bare/config/lms/utils.py
@@ -108,9 +108,3 @@ class Configuration(dict):
             #    - make a PR to Open edX to provide a better default for this setting.
             default = None
         return self(name, default=default)
-
-
-def ensure_directory_exists(directory):
-    """This function creates a directory if it does not exist on the filesystem."""
-    if not os.path.exists(directory):
-        os.mkdir(directory)

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-1.8.1] - 2020-01-11
+
 ### Removed
 
 - Checks that ensure required directories exist in volumes
@@ -179,7 +181,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.8.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.8.1...HEAD
+[dogwood.3-fun-1.8.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.8.0...dogwood.3-fun-1.8.1
 [dogwood.3-fun-1.8.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.7.0...dogwood.3-fun-1.8.0
 [dogwood.3-fun-1.7.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.6.0...dogwood.3-fun-1.7.0
 [dogwood.3-fun-1.6.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.5.1...dogwood.3-fun-1.6.0

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Removed
+
+- Checks that ensure required directories exist in volumes
+
 ## [dogwood.3-fun-1.8.0] - 2020-01-10
 
 ### Added

--- a/releases/dogwood/3/fun/config/cms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/cms/docker_run_production.py
@@ -29,7 +29,7 @@ from xmodule.modulestore.modulestore_settings import (
     update_module_store_settings,
 )
 
-from lms.envs.fun.utils import Configuration, ensure_directory_exists, prefer_fun_video
+from lms.envs.fun.utils import Configuration, prefer_fun_video
 from ..common import *
 
 # Load custom configuration parameters from yaml files
@@ -739,15 +739,11 @@ SUBTITLE_SUPPORTED_LANGUAGES = LazyChoicesSorter(
 )
 
 # Videofront subtitles cache
-VIDEOFRONT_SUBTITLE_CACHE_ROOT = DATA_DIR / "video_subtitles_cache"
 CACHES["video_subtitles"] = {
     "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",
     "KEY_PREFIX": "video_subtitles",
-    "LOCATION": VIDEOFRONT_SUBTITLE_CACHE_ROOT,
+    "LOCATION": DATA_DIR / "video_subtitles_cache",
 }
-# The code in edX ORA2 is missing appropriate checks so we must ensure here that this
-# directory exists:
-ensure_directory_exists(VIDEOFRONT_SUBTITLE_CACHE_ROOT)
 
 # Course image thumbnails
 FUN_THUMBNAIL_OPTIONS = {

--- a/releases/dogwood/3/fun/config/lms/docker_run_development.py
+++ b/releases/dogwood/3/fun/config/lms/docker_run_development.py
@@ -1,8 +1,7 @@
 # This file includes overrides to build the `development` environment for the LMS starting from the
 # settings of the `production` environment
-
 from docker_run_production import *
-from .utils import Configuration, ensure_directory_exists
+from .utils import Configuration
 
 # Load custom configuration parameters from yaml files
 config = Configuration(os.path.dirname(__file__))
@@ -27,10 +26,6 @@ FEATURES["AUTOMATIC_AUTH_FOR_TESTING"] = True
 # ORA2 fileupload
 ORA2_FILEUPLOAD_BACKEND = "filesystem"
 ORA2_FILEUPLOAD_ROOT = os.path.join(SHARED_ROOT, "openassessment_submissions")
-# The code in edX ORA2 is missing appropriate checks so we must ensure here that this
-# directory exists:
-ensure_directory_exists(ORA2_FILEUPLOAD_ROOT)
-
 ORA2_FILEUPLOAD_CACHE_ROOT = os.path.join(
     SHARED_ROOT, "openassessment_submissions_cache"
 )

--- a/releases/dogwood/3/fun/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/lms/docker_run_production.py
@@ -37,7 +37,7 @@ from xmodule.modulestore.modulestore_settings import (
 )
 
 from ..common import *
-from .utils import Configuration, ensure_directory_exists, prefer_fun_video
+from .utils import Configuration, prefer_fun_video
 
 # Load custom configuration parameters from yaml files
 config = Configuration(os.path.dirname(__file__))
@@ -1360,9 +1360,6 @@ LOCALE_PATHS.append(path(pkgutil.get_loader("proctor_exam").filename) / "locale"
 # -- Certificates
 CERTIFICATE_BASE_URL = MEDIA_URL + "attestations/"
 CERTIFICATES_DIRECTORY = MEDIA_ROOT / "certificates"
-# The code in fun-apps is missing appropriate checks so we must ensure here that this
-# directory exists:
-ensure_directory_exists(CERTIFICATES_DIRECTORY)
 
 FUN_LOGO_PATH = FUN_BASE_ROOT / "funsite/static" / FUN_BIG_LOGO_RELATIVE_PATH
 FUN_ATTESTATION_LOGO_PATH = (
@@ -1371,15 +1368,11 @@ FUN_ATTESTATION_LOGO_PATH = (
 STUDENT_NAME_FOR_TEST_CERTIFICATE = "Test User"
 
 # Videofront subtitles cache
-VIDEOFRONT_SUBTITLE_CACHE_ROOT = DATA_DIR / "video_subtitles_cache"
 CACHES["video_subtitles"] = {
     "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",
     "KEY_PREFIX": "video_subtitles",
-    "LOCATION": VIDEOFRONT_SUBTITLE_CACHE_ROOT,
+    "LOCATION": DATA_DIR / "video_subtitles_cache",
 }
-# The code in edX ORA2 is missing appropriate checks so we must ensure here that this
-# directory exists:
-ensure_directory_exists(VIDEOFRONT_SUBTITLE_CACHE_ROOT)
 
 # Course image thumbnails
 FUN_THUMBNAIL_OPTIONS = {

--- a/releases/dogwood/3/fun/config/lms/utils.py
+++ b/releases/dogwood/3/fun/config/lms/utils.py
@@ -109,12 +109,6 @@ class Configuration(dict):
         return self(name, default=default)
 
 
-def ensure_directory_exists(directory):
-    """This function creates a directory if it does not exist on the filesystem."""
-    if not os.path.exists(directory):
-        os.mkdir(directory)
-
-
 def prefer_fun_video(identifier, entry_points):
     """
     This function will be affected to XBLOCK_SELECT_FUNCTION which is used to
@@ -123,9 +117,11 @@ def prefer_fun_video(identifier, entry_points):
     """
     from django.conf import settings
     from xmodule.modulestore import prefer_xmodules
+
     if identifier == "video":
         import pkg_resources
         from xblock.core import XBlock
+
         # These entry points are listed in the setup.py of the libcast module
         # Inspired by the XBlock.load_class method
         entry_points = list(

--- a/releases/eucalyptus/3/bare/CHANGELOG.md
+++ b/releases/eucalyptus/3/bare/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [eucalyptus.3-1.1.1] - 2020-01-11
+
 ### Removed
 
 - Checks that ensure required directories exist in volumes
@@ -71,7 +73,8 @@ release.
 
 - First experimental release of OpenEdx `eucalyptus.3` (bare flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.1.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.1.1...HEAD
+[eucalyptus.3-1.1.1]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.1.0...eucalyptus.3-1.1.1
 [eucalyptus.3-1.1.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.4...eucalyptus.3-1.1.0
 [eucalyptus.3-1.0.4]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.3...eucalyptus.3-1.0.4
 [eucalyptus.3-1.0.3]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.2...eucalyptus.3-1.0.3

--- a/releases/eucalyptus/3/bare/CHANGELOG.md
+++ b/releases/eucalyptus/3/bare/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Removed
+
+- Checks that ensure required directories exist in volumes
+
 ## [eucalyptus.3-1.1.0] - 2020-01-10
 
 ### Added

--- a/releases/eucalyptus/3/bare/config/lms/docker_run_production.py
+++ b/releases/eucalyptus/3/bare/config/lms/docker_run_production.py
@@ -31,7 +31,7 @@ from xmodule.modulestore.modulestore_settings import (
 )
 
 from ..common import *
-from .utils import Configuration, ensure_directory_exists
+from .utils import Configuration
 
 # Load custom configuration parameters from yaml files
 config = Configuration(os.path.dirname(__file__))
@@ -884,9 +884,6 @@ ORA2_FILE_PREFIX = config("ORA2_FILE_PREFIX", default=ORA2_FILE_PREFIX)
 
 # If backend is "filesystem"
 ORA2_FILEUPLOAD_ROOT = DATA_DIR / "openassessment_submissions"
-# The code in edX ORA2 is missing appropriate checks so we must ensure here that this
-# directory exists:
-ensure_directory_exists(ORA2_FILEUPLOAD_ROOT)
 
 ORA2_FILEUPLOAD_CACHE_NAME = config(
     "ORA2_FILEUPLOAD_CACHE_NAME", default="openassessment_submissions"

--- a/releases/eucalyptus/3/bare/config/lms/utils.py
+++ b/releases/eucalyptus/3/bare/config/lms/utils.py
@@ -108,9 +108,3 @@ class Configuration(dict):
             #    - make a PR to Open edX to provide a better default for this setting.
             default = None
         return self(name, default=default)
-
-
-def ensure_directory_exists(directory):
-    """This function creates a directory if it does not exist on the filesystem."""
-    if not os.path.exists(directory):
-        os.mkdir(directory)

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [eucalyptus.3-wb-1.6.1] - 2020-01-11
+
 ### Removed
 
 - Checks that ensure required directories exist in volumes
@@ -143,7 +145,8 @@ release.
 - Set replicaSet and read_preference in mongodb connection
 - Add missing support for redis sentinel
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.6.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.6.1...HEAD
+[eucalyptus.3-wb-1.6.1]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.6.0...eucalyptus.3-wb-1.6.1
 [eucalyptus.3-wb-1.6.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.5.0...eucalyptus.3-wb-1.6.0
 [eucalyptus.3-wb-1.5.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.4.0...eucalyptus.3-wb-1.5.0
 [eucalyptus.3-wb-1.4.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.3.1...eucalyptus.3-wb-1.4.0

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Removed
+
+- Checks that ensure required directories exist in volumes
+
 ## [eucalyptus.3-wb-1.6.0] - 2020-01-10
 
 ### Added

--- a/releases/eucalyptus/3/wb/config/cms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/cms/docker_run_production.py
@@ -24,7 +24,7 @@ from xmodule.modulestore.modulestore_settings import (
 )
 
 from ..common import *
-from lms.envs.fun.utils import Configuration, ensure_directory_exists, prefer_fun_video
+from lms.envs.fun.utils import Configuration, prefer_fun_video
 
 # Load custom configuration parameters from yaml files
 config = Configuration(os.path.dirname(__file__))
@@ -812,15 +812,11 @@ FUN_DEFAULT_VIDEO_PLAYER = config(
 )
 
 # Videofront subtitles cache
-VIDEOFRONT_SUBTITLE_CACHE_ROOT = DATA_DIR / "video_subtitles_cache"
 CACHES["video_subtitles"] = {
     "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",
     "KEY_PREFIX": "video_subtitles",
-    "LOCATION": VIDEOFRONT_SUBTITLE_CACHE_ROOT,
+    "LOCATION": DATA_DIR / "video_subtitles_cache",
 }
-# The code in edX ORA2 is missing appropriate checks so we must ensure here that this
-# directory exists:
-ensure_directory_exists(VIDEOFRONT_SUBTITLE_CACHE_ROOT)
 
 # Max size of asset uploads to GridFS
 MAX_ASSET_UPLOAD_FILE_SIZE_IN_MB = config(

--- a/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
@@ -33,7 +33,7 @@ from xmodule.modulestore.modulestore_settings import (
 )
 
 from ..common import *
-from .utils import Configuration, ensure_directory_exists, prefer_fun_video
+from .utils import Configuration, prefer_fun_video
 
 # Load custom configuration parameters from yaml files
 config = Configuration(os.path.dirname(__file__))
@@ -927,10 +927,6 @@ ORA2_FILE_PREFIX = config("ORA2_FILE_PREFIX", default=ORA2_FILE_PREFIX)
 
 # If backend is "filesystem"
 ORA2_FILEUPLOAD_ROOT = DATA_DIR / "openassessment_submissions"
-# The code in edX ORA2 is missing appropriate checks so we must ensure here that this
-# directory exists:
-ensure_directory_exists(ORA2_FILEUPLOAD_ROOT)
-
 ORA2_FILEUPLOAD_CACHE_NAME = config(
     "ORA2_FILEUPLOAD_CACHE_NAME", default="openassessment_submissions"
 )
@@ -1395,22 +1391,15 @@ FUN_THUMBNAIL_OPTIONS = {}
 # -- Certificates
 CERTIFICATE_BASE_URL = MEDIA_URL + "attestations/"
 CERTIFICATES_DIRECTORY = MEDIA_ROOT / "certificates"
-# The code in fun-apps is missing appropriate checks so we must ensure here that this
-# directory exists:
-ensure_directory_exists(CERTIFICATES_DIRECTORY)
 
 STUDENT_NAME_FOR_TEST_CERTIFICATE = "Test User"
 
 # Videofront subtitles cache
-VIDEOFRONT_SUBTITLE_CACHE_ROOT = DATA_DIR / "video_subtitles_cache"
 CACHES["video_subtitles"] = {
     "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",
     "KEY_PREFIX": "video_subtitles",
-    "LOCATION": VIDEOFRONT_SUBTITLE_CACHE_ROOT,
+    "LOCATION": DATA_DIR / "video_subtitles_cache",
 }
-# The code in edX ORA2 is missing appropriate checks so we must ensure here that this
-# directory exists:
-ensure_directory_exists(VIDEOFRONT_SUBTITLE_CACHE_ROOT)
 
 # Used by pure-pagination app,
 # https://github.com/jamespacileo/django-pure-pagination for information about

--- a/releases/eucalyptus/3/wb/config/lms/utils.py
+++ b/releases/eucalyptus/3/wb/config/lms/utils.py
@@ -105,12 +105,6 @@ class Configuration(dict):
         return self(name, default=default)
 
 
-def ensure_directory_exists(directory):
-    """This function creates a directory if it does not exist on the filesystem."""
-    if not os.path.exists(directory):
-        os.mkdir(directory)
-
-
 def prefer_fun_video(identifier, entry_points):
     """
     This function will be affected to XBLOCK_SELECT_FUNCTION which is used to


### PR DESCRIPTION
## Purpose

These checks are creating more problems than they solve because of all the commands that we run with volumes not mounted in jobs. In these cases, running the method `ensure_directories_exists` is throwing errors that are hard to solve. In conclusion, this was counterproductive and should be removed.

## Proposal

Remove checks on required directories in volumes (we added [a job in Arnold](https://github.com/openfun/arnold/pull/432) to take care of this).
   