### PR TITLE
Remove method to ensure directories exist hawthorn and master

### DIFF
--- a/releases/hawthorn/1/bare/CHANGELOG.md
+++ b/releases/hawthorn/1/bare/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade to a recent release of nodejs as the one packaged in Ubuntu was breaking the build
+
 ### Removed
 
 - Checks that ensure required directories exist in volumes

--- a/releases/hawthorn/1/bare/CHANGELOG.md
+++ b/releases/hawthorn/1/bare/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [hawthorn.1-3.1.0] - 2020-01-15
+
 ### Changed
 
 - Upgrade to a recent release of nodejs as the one packaged in Ubuntu was breaking the build
@@ -210,7 +212,8 @@ result of updating our OpenEdX images from `ginkgo` to `hawthorn.1`. It is not
 functional and is intended for development and debugging work in
 [Arnold](https://github.com/openfun/arnold).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-3.0.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-3.1.0...HEAD
+[hawthorn.1-3.1.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-3.0.0...hawthorn.1-3.1.0
 [hawthorn.1-3.0.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-2.8.0...hawthorn.1-3.0.0
 [hawthorn.1-2.8.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-2.7.1...hawthorn.1-2.8.0
 [hawthorn.1-2.7.1]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-2.7.0...hawthorn.1-2.7.1

--- a/releases/hawthorn/1/bare/CHANGELOG.md
+++ b/releases/hawthorn/1/bare/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Removed
+
+- Checks that ensure required directories exist in volumes
+
 ## [hawthorn.1-3.0.0] - 2020-01-10
 
 ### Added

--- a/releases/hawthorn/1/bare/Dockerfile
+++ b/releases/hawthorn/1/bare/Dockerfile
@@ -49,10 +49,23 @@ RUN curl -sLo edxapp.tgz https://github.com/edx/edx-platform/archive/$EDX_RELEAS
 # === EDXAPP ===
 FROM base as edxapp
 
-# Install base system dependencies
+# Install apt https support (required to use node sources repository)
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y python && \
+    apt-get install -y \
+      apt-transport-https
+
+# Add a recent release of nodejs to apt sources (ubuntu package for precise is
+# broken)
+RUN echo "deb https://deb.nodesource.com/node_10.x trusty main" \
+	> /etc/apt/sources.list.d/nodesource.list && \
+    curl -s 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key' | apt-key add -
+
+# Install base system dependencies
+RUN apt-get update && \
+    apt-get install -y \
+      nodejs \
+      python && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /edx/app/edxapp/edx-platform
@@ -89,9 +102,6 @@ RUN apt-get update && \
     libmysqlclient-dev \
     libxml2-dev \
     libxmlsec1-dev \
-    nodejs \
-    nodejs-legacy \
-    npm \
     python-dev && \
     rm -rf /var/lib/apt/lists/*
 
@@ -186,8 +196,6 @@ RUN apt-get update && \
     libxml2 \
     libxmlsec1-dev \
     lynx \
-    nodejs \
-    nodejs-legacy \
     tzdata && \
     rm -rf /var/lib/apt/lists/*
 

--- a/releases/hawthorn/1/bare/config/lms/docker_run_production.py
+++ b/releases/hawthorn/1/bare/config/lms/docker_run_production.py
@@ -17,7 +17,7 @@ from xmodule.modulestore.modulestore_settings import (
 )
 
 from ..common import *
-from .utils import Configuration, ensure_directory_exists
+from .utils import Configuration
 
 # Load custom configuration parameters from yaml files
 config = Configuration(os.path.dirname(__file__))
@@ -888,10 +888,6 @@ ORA2_FILE_PREFIX = config("ORA2_FILE_PREFIX", default=ORA2_FILE_PREFIX)
 
 # If backend is "filesystem"
 ORA2_FILEUPLOAD_ROOT = DATA_DIR / "openassessment_submissions"
-# The code in edX ORA2 is missing appropriate checks so we must ensure here that this
-# directory exists:
-ensure_directory_exists(ORA2_FILEUPLOAD_ROOT)
-
 ORA2_FILEUPLOAD_CACHE_NAME = config(
     "ORA2_FILEUPLOAD_CACHE_NAME", default="openassessment_submissions"
 )

--- a/releases/hawthorn/1/bare/config/lms/utils.py
+++ b/releases/hawthorn/1/bare/config/lms/utils.py
@@ -108,9 +108,3 @@ class Configuration(dict):
             #    - make a PR to Open edX to provide a better default for this setting.
             default = None
         return self(name, default=default)
-
-
-def ensure_directory_exists(directory):
-    """This function creates a directory if it does not exist on the filesystem."""
-    if not os.path.exists(directory):
-        os.mkdir(directory)

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade to a recent release of nodejs as the one packaged in Ubuntu was breaking the build
+
 ### Removed
 
 - Checks that ensure required directories exist in volumes

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Removed
+
+- Checks that ensure required directories exist in volumes
+
 ## [hawthorn.1-oee-3.0.0] - 2020-01-10
 
 ### Added

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [hawthorn.1-oee-3.1.0] - 2020-01-15
+
 ### Changed
 
 - Upgrade to a recent release of nodejs as the one packaged in Ubuntu was breaking the build
@@ -246,7 +248,8 @@ First release of OpenEdx extended.
 
 - Add a configurable LTI consumer xblock
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-3.0.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-3.1.0...HEAD
+[hawthorn.1-oee-3.1.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.0.0...hawthorn.1-oee-3.1.0
 [hawthorn.1-oee-3.0.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-2.12.3...hawthorn.1-oee-3.0.0
 [hawthorn.1-oee-2.12.3]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-2.12.2...hawthorn.1-oee-2.12.3
 [hawthorn.1-oee-2.12.2]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-2.12.1...hawthorn.1-oee-2.12.2

--- a/releases/hawthorn/1/oee/Dockerfile
+++ b/releases/hawthorn/1/oee/Dockerfile
@@ -49,10 +49,23 @@ RUN curl -sLo edxapp.tgz https://github.com/edx/edx-platform/archive/$EDX_RELEAS
 # === EDXAPP ===
 FROM base as edxapp
 
-# Install base system dependencies
+# Install apt https support (required to use node sources repository)
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y python && \
+    apt-get install -y \
+      apt-transport-https
+
+# Add a recent release of nodejs to apt sources (ubuntu package for precise is
+# broken)
+RUN echo "deb https://deb.nodesource.com/node_10.x trusty main" \
+	> /etc/apt/sources.list.d/nodesource.list && \
+    curl -s 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key' | apt-key add -
+
+# Install base system dependencies
+RUN apt-get update && \
+    apt-get install -y \
+      nodejs \
+      python && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /edx/app/edxapp/edx-platform
@@ -92,9 +105,6 @@ RUN apt-get update && \
     libmysqlclient-dev \
     libxml2-dev \
     libxmlsec1-dev \
-    nodejs \
-    nodejs-legacy \
-    npm \
     python-dev && \
     rm -rf /var/lib/apt/lists/*
 
@@ -193,8 +203,6 @@ RUN apt-get update && \
     libxml2 \
     libxmlsec1-dev \
     lynx \
-    nodejs \
-    nodejs-legacy \
     tzdata && \
     rm -rf /var/lib/apt/lists/*
 

--- a/releases/hawthorn/1/oee/config/lms/docker_run_production.py
+++ b/releases/hawthorn/1/oee/config/lms/docker_run_production.py
@@ -18,7 +18,7 @@ from xmodule.modulestore.modulestore_settings import (
 )
 
 from ..common import *
-from .utils import Configuration, ensure_directory_exists
+from .utils import Configuration
 
 # Load custom configuration parameters from yaml files
 config = Configuration(os.path.dirname(__file__))
@@ -953,10 +953,6 @@ ORA2_FILE_PREFIX = config("ORA2_FILE_PREFIX", default=ORA2_FILE_PREFIX)
 
 # If backend is "filesystem"
 ORA2_FILEUPLOAD_ROOT = DATA_DIR / "openassessment_submissions"
-# The code in edX ORA2 is missing appropriate checks so we must ensure here that this
-# directory exists:
-ensure_directory_exists(ORA2_FILEUPLOAD_ROOT)
-
 ORA2_FILEUPLOAD_CACHE_NAME = config(
     "ORA2_FILEUPLOAD_CACHE_NAME", default="openassessment_submissions"
 )

--- a/releases/hawthorn/1/oee/config/lms/utils.py
+++ b/releases/hawthorn/1/oee/config/lms/utils.py
@@ -108,9 +108,3 @@ class Configuration(dict):
             #    - make a PR to Open edX to provide a better default for this setting.
             default = None
         return self(name, default=default)
-
-
-def ensure_directory_exists(directory):
-    """This function creates a directory if it does not exist on the filesystem."""
-    if not os.path.exists(directory):
-        os.mkdir(directory)

--- a/releases/master/bare/Dockerfile
+++ b/releases/master/bare/Dockerfile
@@ -49,10 +49,23 @@ RUN curl -sLo edxapp.tgz https://github.com/edx/edx-platform/archive/$EDX_RELEAS
 # === EDXAPP ===
 FROM base as edxapp
 
-# Install base system dependencies
+# Install apt https support (required to use node sources repository)
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y python && \
+    apt-get install -y \
+      apt-transport-https
+
+# Add a recent release of nodejs to apt sources (ubuntu package for precise is
+# broken)
+RUN echo "deb https://deb.nodesource.com/node_10.x trusty main" \
+	> /etc/apt/sources.list.d/nodesource.list && \
+    curl -s 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key' | apt-key add -
+
+# Install base system dependencies
+RUN apt-get update && \
+    apt-get install -y \
+      nodejs \
+      python && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /edx/app/edxapp/edx-platform
@@ -89,9 +102,6 @@ RUN apt-get update && \
     libmysqlclient-dev \
     libxml2-dev \
     libxmlsec1-dev \
-    nodejs \
-    nodejs-legacy \
-    npm \
     python-dev && \
     rm -rf /var/lib/apt/lists/*
 
@@ -185,8 +195,7 @@ RUN apt-get update && \
     libmysqlclient20 \
     libxml2 \
     libxmlsec1-dev \
-    nodejs \
-    nodejs-legacy \
+    lynx \
     tzdata && \
     rm -rf /var/lib/apt/lists/*
 

--- a/releases/master/bare/config/lms/docker_run_production.py
+++ b/releases/master/bare/config/lms/docker_run_production.py
@@ -17,7 +17,7 @@ from xmodule.modulestore.modulestore_settings import (
 )
 
 from ..common import *
-from .utils import Configuration, ensure_directory_exists
+from .utils import Configuration
 
 # Load custom configuration parameters from yaml files
 config = Configuration(os.path.dirname(__file__))
@@ -889,10 +889,6 @@ ORA2_FILE_PREFIX = config("ORA2_FILE_PREFIX", default=ORA2_FILE_PREFIX)
 
 # If backend is "filesystem"
 ORA2_FILEUPLOAD_ROOT = DATA_DIR / "openassessment_submissions"
-# The code in edX ORA2 is missing appropriate checks so we must ensure here that this
-# directory exists:
-ensure_directory_exists(ORA2_FILEUPLOAD_ROOT)
-
 ORA2_FILEUPLOAD_CACHE_NAME = config(
     "ORA2_FILEUPLOAD_CACHE_NAME", default="openassessment_submissions"
 )

--- a/releases/master/bare/config/lms/utils.py
+++ b/releases/master/bare/config/lms/utils.py
@@ -108,9 +108,3 @@ class Configuration(dict):
             #    - make a PR to Open edX to provide a better default for this setting.
             default = None
         return self(name, default=default)
-
-
-def ensure_directory_exists(directory):
-    """This function creates a directory if it does not exist on the filesystem."""
-    if not os.path.exists(directory):
-        os.mkdir(directory)


### PR DESCRIPTION
## Purpose

These checks are creating more problems than they solve because of all the commands that we run with volumes not mounted in jobs. In these cases, running the method `ensure_directories_exists` is throwing errors that are hard to solve. In conclusion, this was counterproductive and should be removed.

## Proposal

Remove checks on required directories in volumes (we added [a job in Arnold](https://github.com/openfun/arnold/pull/432) to take care of this).
   
:warning:  This was cut out of PR https://github.com/openfun/openedx-docker/pull/182 because builds on hawthorn and master were failing and we could not afford to delay dogwood and eucalyptus.
