### PR TITLE
Add edxapp-nginx extras

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ build_steps: &build_steps
           chmod +x ~/docker-compose
           sudo mv ~/docker-compose /usr/local/bin/docker-compose
 
-    # Production image build. It will be tagged as edxapp:latest
+    # Production image build
     - run:
         name: Build production image
         command: |
@@ -39,12 +39,19 @@ build_steps: &build_steps
           make build
 
     # Development image build. It uses the "development" Dockerfile target
-    # file and will be tagged as edxapp:dev
+    # file
     - run:
         name: Build development image
         command: |
           source $(bin/ci activate_path)
           make dev-build
+
+    # Extras build (nginx, etc.)
+    - run:
+        name: Build extras images
+        command: |
+          source $(bin/ci activate_path)
+          make extras-build
 
     # Bootstrap
     - run:
@@ -174,6 +181,12 @@ jobs:
             source $(bin/ci activate_path)
             make build
 
+      - run:
+          name: Rebuild extras production images
+          command: |
+            source $(bin/ci activate_path)
+            make extras-build
+
       # Tag images with our DockerHub namespace (fundocker/), and list images to
       # check that they have been properly tagged.
       - run:
@@ -183,17 +196,25 @@ jobs:
             docker tag edxapp:${EDX_RELEASE}-${FLAVOR} fundocker/edxapp:${CIRCLE_TAG}
             docker images fundocker/edxapp:${CIRCLE_TAG}
 
+      - run:
+          name: Tag extras production images
+          command: |
+            source $(bin/ci activate_path)
+            docker tag edxapp-nginx:${EDX_RELEASE}-${FLAVOR} fundocker/edxapp-nginx:${CIRCLE_TAG}
+            docker images fundocker/edxapp-nginx:${CIRCLE_TAG}
+
       # Login to DockerHub with encrypted credentials stored as secret
       # environment variables (set in CircleCI project settings)
       - run:
           name: Login to DockerHub
           command: echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
 
-      # Publish the production image to DockerHub
+      # Publish the production images to DockerHub
       - run:
           name: Publish production image
           command: |
             docker push fundocker/edxapp:${CIRCLE_TAG}
+            docker push fundocker/edxapp-nginx:${CIRCLE_TAG}
 
 # CI workflows
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ build_steps: &build_steps
     - run:
         name: Upgrade docker-compose
         command: |
-          curl -L "https://github.com/docker/compose/releases/download/1.24.1/docker-compose-$(uname -s)-$(uname -m)" -o ~/docker-compose
+          curl -L "https://github.com/docker/compose/releases/download/1.25.1/docker-compose-$(uname -s)-$(uname -m)" -o ~/docker-compose
           chmod +x ~/docker-compose
           sudo mv ~/docker-compose /usr/local/bin/docker-compose
 
@@ -169,7 +169,7 @@ jobs:
       - run:
           name: Upgrade docker-compose
           command: |
-            curl -L "https://github.com/docker/compose/releases/download/1.24.1/docker-compose-$(uname -s)-$(uname -m)" -o ~/docker-compose
+            curl -L "https://github.com/docker/compose/releases/download/1.25.1/docker-compose-$(uname -s)-$(uname -m)" -o ~/docker-compose
             chmod +x ~/docker-compose
             sudo mv ~/docker-compose /usr/local/bin/docker-compose
 

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,14 @@ EDX_RELEASE_REF           ?= release-2018-08-29-14.14
 EDX_DEMO_RELEASE_REF      ?= master
 EDX_DEMO_ARCHIVE_URL      ?= https://github.com/edx/edx-demo-course/archive/$(EDX_DEMO_RELEASE_REF).tar.gz
 
+# Docker images
+EDXAPP_IMAGE_NAME         ?= edxapp
+EDXAPP_IMAGE_TAG          ?= $(EDX_RELEASE)-$(FLAVOR)
+
+# Extras
+EXTRAS_NGINX_IMAGE_NAME   ?= edxapp-nginx
+EXTRAS_NGINX_IMAGE_TAG    ?= $(EDXAPP_IMAGE_TAG)
+
 # Redis service used
 REDIS_SERVICE             ?= redis
 
@@ -21,6 +29,7 @@ COMPOSE          = \
   DOCKER_UID=$(DOCKER_UID) \
   DOCKER_GID=$(DOCKER_GID) \
   FLAVORED_EDX_RELEASE_PATH="$(FLAVORED_EDX_RELEASE_PATH)" \
+  EDXAPP_IMAGE_TAG=$(EDXAPP_IMAGE_TAG) \
   docker-compose
 COMPOSE_RUN      = $(COMPOSE) run --rm -e HOME="/tmp"
 COMPOSE_EXEC     = $(COMPOSE) exec
@@ -229,6 +238,16 @@ dev-watch: tree  ## start assets watcher (front-end development)
 	  paver watch_assets --settings=fun.docker_build_development
 .PHONY: dev-watch
 
+extras-build:  ## build all project extras images for a flavored release
+	@echo -e "🐳 Building extras: $(COLOR_INFO)$(EXTRAS_NGINX_IMAGE_NAME):$(EXTRAS_NGINX_IMAGE_TAG)$(COLOR_RESET) image..."
+	cd extras/nginx && \
+	  docker build \
+	    --build-arg EDXAPP_IMAGE_NAME=$(EDXAPP_IMAGE_NAME) \
+	    --build-arg EDXAPP_IMAGE_TAG=$(EDXAPP_IMAGE_TAG) \
+	    -t $(EXTRAS_NGINX_IMAGE_NAME):$(EXTRAS_NGINX_IMAGE_TAG) \
+	    .
+.PHONY: extras-build
+
 # You can force archive download with the -B option:
 #
 #   $ make -B fetch-demo
@@ -258,6 +277,10 @@ info:  ## get activated release info
 	@echo -e "* EDX_DEMO_RELEASE_REF       : $(COLOR_INFO)$(EDX_DEMO_RELEASE_REF)$(COLOR_RESET)"
 	@echo -e "* EDX_DEMO_ARCHIVE_URL       : $(COLOR_INFO)$(EDX_DEMO_ARCHIVE_URL)$(COLOR_RESET)"
 	@echo -e "* REDIS_SERVICE              : $(COLOR_INFO)$(REDIS_SERVICE)$(COLOR_RESET)"
+	@echo -e "* EDXAPP_IMAGE_NAME          : $(COLOR_INFO)$(EDXAPP_IMAGE_NAME)$(COLOR_RESET)"
+	@echo -e "* EDXAPP_IMAGE_TAG           : $(COLOR_INFO)$(EDXAPP_IMAGE_TAG)$(COLOR_RESET)"
+	@echo -e "* EXTRAS_NGINX_IMAGE_NAME    : $(COLOR_INFO)$(EXTRAS_NGINX_IMAGE_NAME)$(COLOR_RESET)"
+	@echo -e "* EXTRAS_NGINX_IMAGE_TAG     : $(COLOR_INFO)$(EXTRAS_NGINX_IMAGE_TAG)$(COLOR_RESET)"
 	@echo -e ""
 .PHONY: info
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ including database services which in production are not run on Docker. See the
 - **mailcatcher** the email backend
 
 Concerning Redis, it is possible to run a single redis instance (the default choice)
-or to run redis with sentinel to simulate a HA instance. 
+or to run redis with sentinel to simulate a HA instance.
 To use Redis sentinel you have to set the `REDIS_SERVICE` environment variable
 to `redis-sentinel`:
 
@@ -204,6 +204,30 @@ Here are some valid examples:
 
 - `dogwood.3-1.0.3`
 - `hawthorn.1-oee-2.0.1`
+
+## Extras
+
+This project also provides extra, optional companion images that can be used
+along with `edxapp`.
+
+### `nginx`
+
+The classical way to handle and serve static files in a Django application is
+to collect them (using the `collectstatic` management command) and post-process
+them using an appropriate storage back end that uses cache-busting techniques
+to avoid old _versus_ new static files collisions (_e.g._
+`ManifestStaticFilesStorage`).
+
+Depending on the `edx-platform` release, some files may not benefit from a
+cache busting md5 hash, leading to unexpected side effects during deployment.
+
+To prevent such behavior, for each new `openedx-docker` release, we will also
+release an
+[`edxapp-nginx`](https://hub.docker.com/repository/docker/fundocker/edxapp-nginx/)
+image with the same Docker tag. This image is an [OpenShift-ready `nginx`
+image](https://github.com/openfun/openshift-docker#nginx) with embedded
+`edxapp`'s static files. You are supposed to use this image to serve your
+static files, media and reverse proxy to the version-matching `edxapp` instance.
 
 ## Alternative projects
 

--- a/bin/compose
+++ b/bin/compose
@@ -2,10 +2,12 @@
 
 DOCKER_UID=$(id -u)
 DOCKER_GID=$(id -g)
-FLAVORED_EDX_RELEASE_PATH="releases/$(echo ${EDX_RELEASE} | sed -E "s|\.|/|")/${FLAVOR}"
+EDXAPP_IMAGE_TAG="${EDX_RELEASE:-master}-${FLAVOR:-bare}"
+FLAVORED_EDX_RELEASE_PATH="releases/$(echo ${EDX_RELEASE:-master} | sed -E "s|\.|/|")/${FLAVOR:-bare}"
 
 export DOCKER_UID
 export DOCKER_GID
+export EDXAPP_IMAGE_TAG
 export FLAVORED_EDX_RELEASE_PATH
 
 docker-compose "${@}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,8 +60,8 @@ services:
       args:
         EDX_RELEASE_REF: ${EDX_RELEASE_REF:-release-2018-08-29-14.14}
         EDX_ARCHIVE_URL: ${EDX_ARCHIVE_URL:-https://github.com/edx/edx-platform/archive/release-2018-08-29-14.14.tar.gz}
-    image: edxapp:${EDX_RELEASE:-master}-${FLAVOR:-bare}
-    env_file: 
+    image: "${EDXAPP_IMAGE_NAME:-edxapp}:${EDXAPP_IMAGE_TAG:-master-bare}"
+    env_file:
       - env.d/development
       - env.d/${REDIS_SERVICE:-redis}
     environment:
@@ -90,8 +90,8 @@ services:
         DOCKER_GID: ${DOCKER_GID}
         EDX_RELEASE_REF: ${EDX_RELEASE_REF:-release-2018-08-29-14.14}
         EDX_ARCHIVE_URL: ${EDX_ARCHIVE_URL:-https://github.com/edx/edx-platform/archive/release-2018-08-29-14.14.tar.gz}
-    image: edxapp:${EDX_RELEASE:-master}-${FLAVOR:-bare}-dev
-    env_file: 
+    image: "${EDXAPP_IMAGE_NAME:-edxapp}:${EDXAPP_IMAGE_TAG:-master-bare}-dev"
+    env_file:
       - env.d/development
       - env.d/${REDIS_SERVICE:-redis}
     environment:
@@ -116,8 +116,8 @@ services:
       - ${REDIS_SERVICE:-redis}
 
   cms:
-    image: edxapp:${EDX_RELEASE:-master}-${FLAVOR:-bare}
-    env_file: 
+    image: "${EDXAPP_IMAGE_NAME:-edxapp}:${EDXAPP_IMAGE_TAG:-master-bare}"
+    env_file:
       - env.d/development
       - env.d/${REDIS_SERVICE:-redis}
     environment:
@@ -133,8 +133,8 @@ services:
     user: ${DOCKER_UID}:${DOCKER_GID}
 
   cms-dev:
-    image: edxapp:${EDX_RELEASE:-master}-${FLAVOR:-bare}-dev
-    env_file: 
+    image: "${EDXAPP_IMAGE_NAME:-edxapp}:${EDXAPP_IMAGE_TAG:-master-bare}-dev"
+    env_file:
       - env.d/development
       - env.d/${REDIS_SERVICE:-redis}
     ports:

--- a/extras/nginx/Dockerfile
+++ b/extras/nginx/Dockerfile
@@ -1,0 +1,44 @@
+# OpenEdx Docker extra: NGINX
+#
+# This image will bundle all static files from an openedx-docker release in the
+# /data/static directory.
+#
+# Usage:
+#
+#   docker build \
+#     --build-arg EDXAPP_IMAGE_TAG=dogwood.3-1.2.1 \
+#     -t edxapp-nginx:latest \
+#     .
+#
+ARG EDXAPP_IMAGE_NAME=fundocker/edxapp
+ARG EDXAPP_IMAGE_TAG
+ARG EDXAPP_STATIC_ROOT=/edx/app/edxapp/staticfiles
+ARG NGINX_IMAGE_NAME=fundocker/openshift-nginx
+ARG NGINX_IMAGE_TAG=1.13
+
+# === EDXAPP ===
+FROM ${EDXAPP_IMAGE_NAME}:${EDXAPP_IMAGE_TAG} as edxapp
+
+ARG EDXAPP_STATIC_ROOT
+
+USER root:root
+
+RUN apt-get update && \
+    apt-get install -y rdfind && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN python manage.py lms collectstatic --noinput --settings=fun.docker_run && \
+    python manage.py cms collectstatic --noinput --settings=fun.docker_run
+
+# Replace duplicated file by a symlink to decrease the overall size of the
+# final image
+RUN rdfind -makesymlinks true /edx/app/edxapp/staticfiles
+
+# === NGINX (final image) ===
+FROM ${NGINX_IMAGE_NAME}:${NGINX_IMAGE_TAG}
+
+ARG EDXAPP_STATIC_ROOT
+
+RUN mkdir -p ${EDXAPP_STATIC_ROOT}
+
+COPY --from=edxapp ${EDXAPP_STATIC_ROOT} ${EDXAPP_STATIC_ROOT}

--- a/releases/eucalyptus/3/wb/Dockerfile
+++ b/releases/eucalyptus/3/wb/Dockerfile
@@ -9,8 +9,8 @@
 #     .
 ARG DOCKER_UID=1000
 ARG DOCKER_GID=1000
-ARG EDX_RELEASE_REF=fun/whitebrand
-ARG EDX_ARCHIVE_URL=https://github.com/openfun/edx-platform/archive/fun/whitebrand.tar.gz
+ARG EDX_RELEASE_REF=eucalyptus.3-wb
+ARG EDX_ARCHIVE_URL=https://github.com/openfun/edx-platform/archive/eucalyptus.3-wb.tar.gz
 
 # === BASE ===
 FROM ubuntu:16.04 as base

--- a/releases/eucalyptus/3/wb/activate
+++ b/releases/eucalyptus/3/wb/activate
@@ -1,6 +1,6 @@
 export EDX_RELEASE="eucalyptus.3"
 export FLAVOR="wb"
-export EDX_RELEASE_REF="fun/whitebrand"
+export EDX_RELEASE_REF="eucalyptus.3-wb"
 export EDX_ARCHIVE_URL="https://github.com/openfun/edx-platform/archive/${EDX_RELEASE_REF}.tar.gz"
 export EDX_DEMO_RELEASE_REF="open-release/eucalyptus.3"
 export EDX_DEMO_ARCHIVE_URL="file://${PWD}/releases/eucalyptus/3/wb/demo-course.tar.gz"


### PR DESCRIPTION
## Purpose

We need a way to bundle an openedx release assets with the `nginx` image that will serve them to avoid side-effects in our deployment procedure (see the Arnold project).

## Proposal

Current work copy files collected in the edxapp release and replace duplicates by symlinks to save disk space and network bandwidth (up to 65%):

```
dogwood.3-1.2.1          	529MB
dogwood.3-1.2.1-slim     	198MB
eucalyptus.3-1.1.1       	573MB
eucalyptus.3-1.1.1-slim  	222MB
hawthorn.1-3.0.0         	959MB
hawthorn.1-3.0.0-slim    	320MB
hawthorn.1-oee-3.0.0     	960MB
hawthorn.1-oee-3.0.0-slim	320MB
```
*-slim images have been generated with the aforementioned optimization.

During this work, I've also:

- [x] upgrade the CI `docker-compose` release to `1.25.1`
- [x] fix `eucalyptus/3/wb` git branch reference