### PR TITLE
[dogwood/3/fun] fix fun edx platform release

### DIFF
--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,11 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Upgrade FUN's `edx-platform` release to `v5.3.0` (deactivate logging
+  anonymous user id error)
+
 ## [dogwood.3-fun-1.8.1] - 2020-01-11
 
 ### Removed

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-1.8.2] - 2020-01-17
+
 ### Fixed
 
 - Upgrade FUN's `edx-platform` release to `v5.3.0` (deactivate logging
@@ -186,7 +188,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.8.1...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.8.2...HEAD
+[dogwood.3-fun-1.8.2]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.8.1...dogwood.3-fun-1.8.2
 [dogwood.3-fun-1.8.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.8.0...dogwood.3-fun-1.8.1
 [dogwood.3-fun-1.8.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.7.0...dogwood.3-fun-1.8.0
 [dogwood.3-fun-1.7.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.6.0...dogwood.3-fun-1.7.0

--- a/releases/dogwood/3/fun/activate
+++ b/releases/dogwood/3/fun/activate
@@ -1,6 +1,6 @@
 export EDX_RELEASE="dogwood.3"
 export FLAVOR="fun"
-export EDX_RELEASE_REF="fun-5.2.0"
+export EDX_RELEASE_REF="v5.3.0"
 export EDX_ARCHIVE_URL="https://github.com/openfun/edx-platform/archive/${EDX_RELEASE_REF}.tar.gz"
 export EDX_DEMO_RELEASE_REF="open-release/eucalyptus.1"
 export EDX_DEMO_ARCHIVE_URL="file://${PWD}/releases/dogwood/3/fun/demo-course.tar.gz"


### PR DESCRIPTION
## Purpose

The "deactivate logging anonymous user id error" error is spamming our Sentry and doesn't help. This bug has been fixed in our 5.3.0 release of FUN's `edx-platform`.

## Proposal

- [x] upgrade `edx-platform` to `v5.3.0`
