### PR TITLE
Fix media root in cms and make a fix release

### DIFF
--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-1.8.3] - 2020-01-17
+
 ### Fixed
 
 - Set MEDIA_ROOT in cms config as it is used to generate thumbnails in `fun-apps`
@@ -192,7 +194,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.8.2...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.8.3...HEAD
+[dogwood.3-fun-1.8.3]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.8.2...dogwood.3-fun-1.8.3
 [dogwood.3-fun-1.8.2]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.8.1...dogwood.3-fun-1.8.2
 [dogwood.3-fun-1.8.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.8.0...dogwood.3-fun-1.8.1
 [dogwood.3-fun-1.8.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.7.0...dogwood.3-fun-1.8.0

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Set MEDIA_ROOT in cms config as it is used to generate thumbnails in `fun-apps`
+
 ## [dogwood.3-fun-1.8.2] - 2020-01-17
 
 ### Fixed

--- a/releases/dogwood/3/fun/config/cms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/cms/docker_run_production.py
@@ -135,6 +135,9 @@ STATIC_ROOT = path("/edx/app/edxapp/staticfiles/studio")
 STATICFILES_STORAGE = "pipeline.storage.PipelineCachedStorage"
 PIPELINE = True
 
+MEDIA_ROOT = path("/edx/var/edxapp/media/")
+MEDIA_URL = "/media/"
+
 EMAIL_BACKEND = config(
     "EMAIL_BACKEND", default="django.core.mail.backends.smtp.EmailBackend"
 )


### PR DESCRIPTION
## Purpose

Generating thumbnails in the cms was broken because the `MEDIA_ROOT` setting was not set properly in the config of the cms.

## Proposal

Set MEDIA_ROOT to the same value as in the lms
