### PR TITLE
🐛(dogwood/3/fun) Fix known unpacking bug in xmodule

### DIFF
--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed known unpacking bug by upgrading to openfun/edx-platform version dogwood.3-fun-5.3.1
+
 ## [dogwood.3-fun-1.8.3] - 2020-01-17
 
 ### Fixed

--- a/releases/dogwood/3/fun/Dockerfile
+++ b/releases/dogwood/3/fun/Dockerfile
@@ -9,8 +9,8 @@
 #     .
 ARG DOCKER_UID=1000
 ARG DOCKER_GID=1000
-ARG EDX_RELEASE_REF=fun/dogwood
-ARG EDX_ARCHIVE_URL=https://github.com/openfun/edx-platform/archive/fun-4.35.0.tar.gz
+ARG EDX_RELEASE_REF=dogwood.3-fun
+ARG EDX_ARCHIVE_URL=https://github.com/openfun/edx-platform/archive/dogwood.3-fun-5.3.1.tar.gz
 
 # === BASE ===
 FROM ubuntu:12.04 as base

--- a/releases/dogwood/3/fun/activate
+++ b/releases/dogwood/3/fun/activate
@@ -1,6 +1,6 @@
 export EDX_RELEASE="dogwood.3"
 export FLAVOR="fun"
-export EDX_RELEASE_REF="v5.3.0"
+export EDX_RELEASE_REF="dogwood.3-fun"
 export EDX_ARCHIVE_URL="https://github.com/openfun/edx-platform/archive/${EDX_RELEASE_REF}.tar.gz"
 export EDX_DEMO_RELEASE_REF="open-release/eucalyptus.1"
 export EDX_DEMO_ARCHIVE_URL="file://${PWD}/releases/dogwood/3/fun/demo-course.tar.gz"


### PR DESCRIPTION
### Purpose

A long standing and known bug was fixed in [openfun/edx-platform](https://github.com/openfun/edx-platform/releases/tag/dogwood.3-fun-5.3.1).

### Proposal

Upgrade to openfun/edx-platform version dogwood.3-fun-5.3.1

:warning: The release process was refactored in openfun/edx-platform so the new tags are more explicit.
