### PR TITLE
🔧(dogwood/3/fun) rewrite constants related to fun's PDF certificates urls

### DIFF
--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Changed
+
+- Rewrite settings related to FUN's certificates download URLs
+
 ### Fixed
 
 - Fixed known unpacking bug by upgrading to openfun/edx-platform version dogwood.3-fun-5.3.1

--- a/releases/dogwood/3/fun/Dockerfile
+++ b/releases/dogwood/3/fun/Dockerfile
@@ -9,8 +9,8 @@
 #     .
 ARG DOCKER_UID=1000
 ARG DOCKER_GID=1000
-ARG EDX_RELEASE_REF=dogwood.3-fun
-ARG EDX_ARCHIVE_URL=https://github.com/openfun/edx-platform/archive/dogwood.3-fun-5.3.1.tar.gz
+ARG EDX_RELEASE_REF=dogwood.3-fun-5.3.2
+ARG EDX_ARCHIVE_URL=https://github.com/openfun/edx-platform/archive/dogwood.3-fun-5.3.2.tar.gz
 
 # === BASE ===
 FROM ubuntu:12.04 as base

--- a/releases/dogwood/3/fun/activate
+++ b/releases/dogwood/3/fun/activate
@@ -1,6 +1,6 @@
 export EDX_RELEASE="dogwood.3"
 export FLAVOR="fun"
-export EDX_RELEASE_REF="dogwood.3-fun"
+export EDX_RELEASE_REF="dogwood.3-fun-5.3.2"
 export EDX_ARCHIVE_URL="https://github.com/openfun/edx-platform/archive/${EDX_RELEASE_REF}.tar.gz"
 export EDX_DEMO_RELEASE_REF="open-release/eucalyptus.1"
 export EDX_DEMO_ARCHIVE_URL="file://${PWD}/releases/dogwood/3/fun/demo-course.tar.gz"

--- a/releases/dogwood/3/fun/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/lms/docker_run_production.py
@@ -1358,8 +1358,7 @@ LOCALE_PATHS.append(REPO_ROOT / "conf/locale")  # edx-platform locales
 LOCALE_PATHS.append(path(pkgutil.get_loader("proctor_exam").filename) / "locale")
 
 # -- Certificates
-CERTIFICATE_BASE_URL = MEDIA_URL + "attestations/"
-CERTIFICATES_DIRECTORY = MEDIA_ROOT / "certificates"
+CERTIFICATES_DIRECTORY_NAME = "certificates"
 
 FUN_LOGO_PATH = FUN_BASE_ROOT / "funsite/static" / FUN_BIG_LOGO_RELATIVE_PATH
 FUN_ATTESTATION_LOGO_PATH = (

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -4,7 +4,7 @@
 # ==== core ====
 edx-gea==0.2.0
 fonzie==0.2.0
-fun-apps==5.2.0
+fun-apps==5.2.1
 
 # ==== xblocks ====
 configurable_lti_consumer-xblock==1.3.0


### PR DESCRIPTION
This modification follows change of location of certificates files which
were previously stored in there own volume and have now been moved to
`media` volume in `certificate` directory.

Simplify constants needed to build url and use a different name for safety.
