### PR TITLE
Fix certificates directory name and release a fix: dogwood.3-fun-1.8.4

### DIFF
--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-1.8.5] - 2020-01-22
+
 ### Fixed
 
 - Certificates are in a directory with a french name: "attestations"
@@ -205,7 +207,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.8.4...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.8.5...HEAD
+[dogwood.3-fun-1.8.5]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.8.4...dogwood.3-fun-1.8.5
 [dogwood.3-fun-1.8.4]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.8.3...dogwood.3-fun-1.8.4
 [dogwood.3-fun-1.8.3]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.8.2...dogwood.3-fun-1.8.3
 [dogwood.3-fun-1.8.2]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.8.1...dogwood.3-fun-1.8.2

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Certificates are in a directory with a french name: "attestations"
+
 ## [dogwood.3-fun-1.8.4] - 2020-01-21
 
 ### Fixed

--- a/releases/dogwood/3/fun/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/lms/docker_run_production.py
@@ -1358,7 +1358,7 @@ LOCALE_PATHS.append(REPO_ROOT / "conf/locale")  # edx-platform locales
 LOCALE_PATHS.append(path(pkgutil.get_loader("proctor_exam").filename) / "locale")
 
 # -- Certificates
-CERTIFICATES_DIRECTORY_NAME = "certificates"
+CERTIFICATES_DIRECTORY_NAME = "attestations"
 
 FUN_LOGO_PATH = FUN_BASE_ROOT / "funsite/static" / FUN_BIG_LOGO_RELATIVE_PATH
 FUN_ATTESTATION_LOGO_PATH = (


### PR DESCRIPTION
### Fixed

- Certificates are in a directory with a french name: "attestations"
