### PR TITLE
Upgrade fun-apps in wb + fun flavors

### DIFF
--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-1.8.6] - 2020-01-23
+
 ### Fixed
 
 - Upgrade `fun-apps` to `5.2.2`
@@ -211,7 +213,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.8.5...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.8.6...HEAD
+[dogwood.3-fun-1.8.6]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.8.5...dogwood.3-fun-1.8.6
 [dogwood.3-fun-1.8.5]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.8.4...dogwood.3-fun-1.8.5
 [dogwood.3-fun-1.8.4]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.8.3...dogwood.3-fun-1.8.4
 [dogwood.3-fun-1.8.3]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.8.2...dogwood.3-fun-1.8.3

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Upgrade `fun-apps` to `5.2.2`
+
 ## [dogwood.3-fun-1.8.5] - 2020-01-22
 
 ### Fixed

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -4,7 +4,7 @@
 # ==== core ====
 edx-gea==0.2.0
 fonzie==0.2.0
-fun-apps==5.2.1
+fun-apps==5.2.2
 
 # ==== xblocks ====
 configurable_lti_consumer-xblock==1.3.0

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [eucalyptus.3-wb-1.6.3] - 2020-01-23
+
 ### Fixed
 
 - Upgrade `fun-apps` to `2.2.1+wb`
@@ -155,7 +157,8 @@ release.
 - Set replicaSet and read_preference in mongodb connection
 - Add missing support for redis sentinel
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.6.2...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.6.3...HEAD
+[eucalyptus.3-wb-1.6.3]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.6.2...eucalyptus.3-wb-1.6.3
 [eucalyptus.3-wb-1.6.2]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.6.1...eucalyptus.3-wb-1.6.2
 [eucalyptus.3-wb-1.6.1]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.6.0...eucalyptus.3-wb-1.6.1
 [eucalyptus.3-wb-1.6.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.5.0...eucalyptus.3-wb-1.6.0

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Upgrade `fun-apps` to `2.2.1+wb`
+
 ## [eucalyptus.3-wb-1.6.2] - 2020-01-22
 
 ### Changed

--- a/releases/eucalyptus/3/wb/requirements.txt
+++ b/releases/eucalyptus/3/wb/requirements.txt
@@ -4,7 +4,7 @@
 # ==== core ====
 configurable-lti-consumer-xblock==1.3.0
 edx-gea==0.2.0
-fun-apps==2.2.0+wb
+fun-apps==2.2.1+wb
 libcast-xblock==0.5.0
 password-container-xblock==0.3.0
 xblock-proctor-exam==0.9.0b0


### PR DESCRIPTION
## Purpose

We recently fixed a cache busting issue on fun-apps' static files:

- https://github.com/openfun/fun-apps/pull/677
- https://github.com/openfun/fun-apps/pull/678

## Proposal

- [x] upgrade fun-apps to `2.2.1+wb` for the `eucalyptus.3-wb` release
- [x] upgrade fun-apps to `5.2.2` for the `dogwood.3-fun` release

