### PR TITLE
Fix hawthorn.1 expected webpack-stats.json files

### DIFF
--- a/releases/hawthorn/1/bare/CHANGELOG.md
+++ b/releases/hawthorn/1/bare/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [hawthorn.1-3.1.1] - 2020-01-23
+
 ### Fixed
 
 - Copy `webpack-stats.json` files to expected static files root path in case no
@@ -217,7 +219,8 @@ result of updating our OpenEdX images from `ginkgo` to `hawthorn.1`. It is not
 functional and is intended for development and debugging work in
 [Arnold](https://github.com/openfun/arnold).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-3.1.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-3.1.1...HEAD
+[hawthorn.1-3.1.1]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-3.1.0...hawthorn.1-3.1.1
 [hawthorn.1-3.1.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-3.0.0...hawthorn.1-3.1.0
 [hawthorn.1-3.0.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-2.8.0...hawthorn.1-3.0.0
 [hawthorn.1-2.8.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-2.7.1...hawthorn.1-2.8.0

--- a/releases/hawthorn/1/bare/CHANGELOG.md
+++ b/releases/hawthorn/1/bare/CHANGELOG.md
@@ -9,6 +9,11 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Copy `webpack-stats.json` files to expected static files root path in case no
+  static files volume is mounted
+
 ## [hawthorn.1-3.1.0] - 2020-01-15
 
 ### Changed
@@ -24,7 +29,7 @@ release.
 ### Added
 
 - Configure all cache backends
-- Make Gunicorn timeout, workers and threads configurable via an environment 
+- Make Gunicorn timeout, workers and threads configurable via an environment
   variable
 
 ### Changed

--- a/releases/hawthorn/1/bare/Dockerfile
+++ b/releases/hawthorn/1/bare/Dockerfile
@@ -205,6 +205,14 @@ COPY --from=builder /usr/local /usr/local
 # Copy modified sources (sic!)
 COPY --from=builder /edx/app/edxapp/edx-platform  /edx/app/edxapp/edx-platform
 
+# ... and webpack-stats.json files (sic! ...again)
+COPY --from=builder \
+  /edx/app/edxapp/edx-platform/common/static/webpack-stats.json \
+  /edx/app/edxapp/staticfiles/webpack-stats.json
+COPY --from=builder \
+  /edx/app/edxapp/edx-platform/common/static/studio/webpack-stats.json \
+  /edx/app/edxapp/staticfiles/studio/webpack-stats.json
+
 # Now that dependencies are installed and configuration has been set, the above
 # statements will run with a un-privileged user.
 USER 10000
@@ -215,7 +223,7 @@ ENV SERVICE_VARIANT=lms
 
 # Gunicorn configuration
 #
-# We want to be able to easily increase gunicorn in hawtorn if needed 
+# We want to be able to easily increase gunicorn in hawtorn if needed
 ENV GUNICORN_TIMEOUT 300
 
 # In docker we must increase the number of workers and threads created

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [hawthorn.1-oee-3.1.2] - 2020-01-23
+
 ### Fixed
 
 - Copy `webpack-stats.json` files to expected static files root path in case no
@@ -259,7 +261,8 @@ First release of OpenEdx extended.
 
 - Add a configurable LTI consumer xblock
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-3.1.1...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-3.1.2...HEAD
+[hawthorn.1-oee-3.1.2]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.1.1...hawthorn.1-oee-3.1.2
 [hawthorn.1-oee-3.1.1]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.1.0...hawthorn.1-oee-3.1.1
 [hawthorn.1-oee-3.1.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.0.0...hawthorn.1-oee-3.1.0
 [hawthorn.1-oee-3.0.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-2.12.3...hawthorn.1-oee-3.0.0
@@ -287,5 +290,4 @@ First release of OpenEdx extended.
 [hawthorn.1-oee-2.1.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-2.0.3...hawthorn.1-oee-2.1.0
 [hawthorn.1-oee-2.0.3]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-2.0.2...hawthorn.1-oee-2.0.3
 [hawthorn.1-oee-2.0.2]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-2.0.1...hawthorn.1-oee-2.0.2
-[hawthorn.1-oee-2.0.1]: https://github.com/openfun/openedx-docker/releases/tag/hawthorn.1-oee-2.0.1
 [hawthorn.1-oee-2.0.1]: https://github.com/openfun/openedx-docker/releases/tag/hawthorn.1-oee-2.0.1

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -9,6 +9,11 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Copy `webpack-stats.json` files to expected static files root path in case no
+  static files volume is mounted
+
 ## [hawthorn.1-oee-3.1.1] - 2020-01-22
 
 ### Fixed
@@ -282,4 +287,5 @@ First release of OpenEdx extended.
 [hawthorn.1-oee-2.1.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-2.0.3...hawthorn.1-oee-2.1.0
 [hawthorn.1-oee-2.0.3]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-2.0.2...hawthorn.1-oee-2.0.3
 [hawthorn.1-oee-2.0.2]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-2.0.1...hawthorn.1-oee-2.0.2
+[hawthorn.1-oee-2.0.1]: https://github.com/openfun/openedx-docker/releases/tag/hawthorn.1-oee-2.0.1
 [hawthorn.1-oee-2.0.1]: https://github.com/openfun/openedx-docker/releases/tag/hawthorn.1-oee-2.0.1

--- a/releases/hawthorn/1/oee/Dockerfile
+++ b/releases/hawthorn/1/oee/Dockerfile
@@ -212,6 +212,14 @@ COPY --from=builder /usr/local /usr/local
 # Copy modified sources (sic!)
 COPY --from=builder /edx/app/edxapp/edx-platform  /edx/app/edxapp/edx-platform
 
+# ... and webpack-stats.json files (sic! ...again)
+COPY --from=builder \
+  /edx/app/edxapp/edx-platform/common/static/webpack-stats.json \
+  /edx/app/edxapp/staticfiles/webpack-stats.json
+COPY --from=builder \
+  /edx/app/edxapp/edx-platform/common/static/studio/webpack-stats.json \
+  /edx/app/edxapp/staticfiles/studio/webpack-stats.json
+
 # Now that dependencies are installed and configuration has been set, the above
 # statements will run with a un-privileged user.
 USER 10000
@@ -222,7 +230,7 @@ ENV SERVICE_VARIANT=lms
 
 # Gunicorn configuration
 #
-# We want to be able to easily increase gunicorn in hawtorn if needed 
+# We want to be able to easily increase gunicorn in hawtorn if needed
 ENV GUNICORN_TIMEOUT 300
 
 # In docker we must increase the number of workers and threads created


### PR DESCRIPTION
## Purpose

Now that we may use `hawthorn` images without mounting a dedicated volume for static files (see the edxapp-nginx extra), the backend still requires `webpack-stats.json` files generated via the `update_assets` `paver` command.

## Proposal

- [x] copy `webpack-stats.json` files where expected in the production image
