### PR TITLE
(dogwood/3/fun) Add cache to home page for authenticated users and release dogwood.3-fun-1.9.0

### DIFF
--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade `fun-apps` to `5.3.0` to cache home page for authenticated users
+
 ## [dogwood.3-fun-1.8.6] - 2020-01-23
 
 ### Fixed

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-1.9.0] - 2020-01-29
+
 ### Changed
 
 - Upgrade `fun-apps` to `5.3.0` to cache home page for authenticated users
@@ -217,7 +219,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.8.6...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.9.0...HEAD
+[dogwood.3-fun-1.9.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.8.6...dogwood.3-fun-1.9.0
 [dogwood.3-fun-1.8.6]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.8.5...dogwood.3-fun-1.8.6
 [dogwood.3-fun-1.8.5]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.8.4...dogwood.3-fun-1.8.5
 [dogwood.3-fun-1.8.4]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.8.3...dogwood.3-fun-1.8.4

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -4,7 +4,7 @@
 # ==== core ====
 edx-gea==0.2.0
 fonzie==0.2.0
-fun-apps==5.2.2
+fun-apps==5.3.0
 
 # ==== xblocks ====
 configurable_lti_consumer-xblock==1.3.0


### PR DESCRIPTION
### Changed

- Upgrade `fun-apps` to `5.3.0` to cache home page for authenticated users
