### PR TITLE
(dogwood.3 fun) Fix ora2 bucket name, further accelerate home page and release dogwood.3-fun-1.9.1 fix

### DIFF
--- a/releases/dogwood/3/bare/CHANGELOG.md
+++ b/releases/dogwood/3/bare/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove hardcoded FILE_UPLOAD_STORAGE_BUCKET_NAME value to make sure it is configurable
+
 ## [dogwood.3-1.2.1] - 2020-01-11
 
 ### Removed

--- a/releases/dogwood/3/bare/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/bare/config/lms/docker_run_production.py
@@ -612,7 +612,7 @@ DEFAULT_FILE_STORAGE = config(
 
 # Specific setting for the File Upload Service to store media in a bucket.
 FILE_UPLOAD_STORAGE_BUCKET_NAME = config(
-    "FILE_UPLOAD_STORAGE_BUCKET_NAME", default=FILE_UPLOAD_STORAGE_BUCKET_NAME
+    "FILE_UPLOAD_STORAGE_BUCKET_NAME", default="uploads"
 )
 FILE_UPLOAD_STORAGE_PREFIX = config(
     "FILE_UPLOAD_STORAGE_PREFIX", default=FILE_UPLOAD_STORAGE_PREFIX
@@ -801,7 +801,7 @@ FINANCIAL_REPORTS = config(
 
 ##### ORA2 ######
 ORA2_FILEUPLOAD_BACKEND = config("ORA2_FILEUPLOAD_BACKEND", default="filesystem")
-FILE_UPLOAD_STORAGE_BUCKET_NAME = "uploads"
+
 # Prefix for uploads of example-based assessment AI classifiers
 # This can be used to separate uploads for different environments
 ORA2_FILE_PREFIX = config("ORA2_FILE_PREFIX", default=ORA2_FILE_PREFIX)

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -11,6 +11,7 @@ release.
 
 ### Fixed
 
+- Upgrade `fun-apps` to `5.3.1` to further accelerate the home page for authenticated users
 - Remove hardcoded FILE_UPLOAD_STORAGE_BUCKET_NAME value to make sure it is configurable
 
 ## [dogwood.3-fun-1.9.0] - 2020-01-29

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove hardcoded FILE_UPLOAD_STORAGE_BUCKET_NAME value to make sure it is configurable
+
 ## [dogwood.3-fun-1.9.0] - 2020-01-29
 
 ### Changed

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-1.9.1] - 2020-01-29
+
 ### Fixed
 
 - Upgrade `fun-apps` to `5.3.1` to further accelerate the home page for authenticated users
@@ -224,7 +226,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.9.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.9.1...HEAD
+[dogwood.3-fun-1.9.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.9.0...dogwood.3-fun-1.9.1
 [dogwood.3-fun-1.9.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.8.6...dogwood.3-fun-1.9.0
 [dogwood.3-fun-1.8.6]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.8.5...dogwood.3-fun-1.8.6
 [dogwood.3-fun-1.8.5]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.8.4...dogwood.3-fun-1.8.5

--- a/releases/dogwood/3/fun/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/lms/docker_run_production.py
@@ -649,7 +649,7 @@ DEFAULT_FILE_STORAGE = config(
 
 # Specific setting for the File Upload Service to store media in a bucket.
 FILE_UPLOAD_STORAGE_BUCKET_NAME = config(
-    "FILE_UPLOAD_STORAGE_BUCKET_NAME", default=FILE_UPLOAD_STORAGE_BUCKET_NAME
+    "FILE_UPLOAD_STORAGE_BUCKET_NAME", default="uploads"
 )
 FILE_UPLOAD_STORAGE_PREFIX = config(
     "FILE_UPLOAD_STORAGE_PREFIX", default=FILE_UPLOAD_STORAGE_PREFIX
@@ -1390,8 +1390,6 @@ THUMBNAIL_EXTENSION = "png"
 ORA2_FILEUPLOAD_BACKEND = "swift"
 ORA2_SWIFT_KEY = config("ORA2_SWIFT_KEY", default="")
 ORA2_SWIFT_URL = config("ORA2_SWIFT_URL", default="")
-
-FILE_UPLOAD_STORAGE_BUCKET_NAME = "uploads"
 
 # Prefix for uploads of example-based assessment AI classifiers
 # This can be used to separate uploads for different environments

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -4,7 +4,7 @@
 # ==== core ====
 edx-gea==0.2.0
 fonzie==0.2.0
-fun-apps==5.3.0
+fun-apps==5.3.1
 
 # ==== xblocks ====
 configurable_lti_consumer-xblock==1.3.0

--- a/releases/eucalyptus/3/bare/CHANGELOG.md
+++ b/releases/eucalyptus/3/bare/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove hardcoded FILE_UPLOAD_STORAGE_BUCKET_NAME value to make sure it is configurable
+
 ## [eucalyptus.3-1.1.1] - 2020-01-11
 
 ### Removed

--- a/releases/eucalyptus/3/bare/config/lms/docker_run_production.py
+++ b/releases/eucalyptus/3/bare/config/lms/docker_run_production.py
@@ -678,7 +678,7 @@ DEFAULT_FILE_STORAGE = config(
 
 # Specific setting for the File Upload Service to store media in a bucket.
 FILE_UPLOAD_STORAGE_BUCKET_NAME = config(
-    "FILE_UPLOAD_STORAGE_BUCKET_NAME", default=FILE_UPLOAD_STORAGE_BUCKET_NAME
+    "FILE_UPLOAD_STORAGE_BUCKET_NAME", default="uploads"
 )
 FILE_UPLOAD_STORAGE_PREFIX = config(
     "FILE_UPLOAD_STORAGE_PREFIX", default=FILE_UPLOAD_STORAGE_PREFIX
@@ -877,7 +877,7 @@ FINANCIAL_REPORTS = config(
 
 ##### ORA2 ######
 ORA2_FILEUPLOAD_BACKEND = config("ORA2_FILEUPLOAD_BACKEND", default="filesystem")
-FILE_UPLOAD_STORAGE_BUCKET_NAME = "uploads"
+
 # Prefix for uploads of example-based assessment AI classifiers
 # This can be used to separate uploads for different environments
 ORA2_FILE_PREFIX = config("ORA2_FILE_PREFIX", default=ORA2_FILE_PREFIX)

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove hardcoded FILE_UPLOAD_STORAGE_BUCKET_NAME value to make sure it is configurable
+
 ## [eucalyptus.3-wb-1.6.3] - 2020-01-23
 
 ### Fixed

--- a/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
@@ -706,7 +706,7 @@ DEFAULT_FILE_STORAGE = config(
 
 # Specific setting for the File Upload Service to store media in a bucket.
 FILE_UPLOAD_STORAGE_BUCKET_NAME = config(
-    "FILE_UPLOAD_STORAGE_BUCKET_NAME", default=FILE_UPLOAD_STORAGE_BUCKET_NAME
+    "FILE_UPLOAD_STORAGE_BUCKET_NAME", default="uploads"
 )
 FILE_UPLOAD_STORAGE_PREFIX = config(
     "FILE_UPLOAD_STORAGE_PREFIX", default=FILE_UPLOAD_STORAGE_PREFIX
@@ -920,7 +920,7 @@ FINANCIAL_REPORTS = config(
 
 ##### ORA2 ######
 ORA2_FILEUPLOAD_BACKEND = config("ORA2_FILEUPLOAD_BACKEND", default="filesystem")
-FILE_UPLOAD_STORAGE_BUCKET_NAME = "uploads"
+
 # Prefix for uploads of example-based assessment AI classifiers
 # This can be used to separate uploads for different environments
 ORA2_FILE_PREFIX = config("ORA2_FILE_PREFIX", default=ORA2_FILE_PREFIX)

--- a/releases/hawthorn/1/bare/CHANGELOG.md
+++ b/releases/hawthorn/1/bare/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove hardcoded FILE_UPLOAD_STORAGE_BUCKET_NAME value to make sure it is configurable
+
 ## [hawthorn.1-3.1.1] - 2020-01-23
 
 ### Fixed

--- a/releases/hawthorn/1/bare/config/cms/docker_run_production.py
+++ b/releases/hawthorn/1/bare/config/cms/docker_run_production.py
@@ -415,7 +415,7 @@ if FEATURES.get("AUTH_USE_CAS"):
 
 # Specific setting for the File Upload Service to store media in a bucket.
 FILE_UPLOAD_STORAGE_BUCKET_NAME = config(
-    "FILE_UPLOAD_STORAGE_BUCKET_NAME", default=FILE_UPLOAD_STORAGE_BUCKET_NAME
+    "FILE_UPLOAD_STORAGE_BUCKET_NAME", default="uploads"
 )
 FILE_UPLOAD_STORAGE_PREFIX = config(
     "FILE_UPLOAD_STORAGE_PREFIX", default=FILE_UPLOAD_STORAGE_PREFIX

--- a/releases/hawthorn/1/bare/config/lms/docker_run_production.py
+++ b/releases/hawthorn/1/bare/config/lms/docker_run_production.py
@@ -675,7 +675,7 @@ DEFAULT_FILE_STORAGE = config(
 
 # Specific setting for the File Upload Service to store media in a bucket.
 FILE_UPLOAD_STORAGE_BUCKET_NAME = config(
-    "FILE_UPLOAD_STORAGE_BUCKET_NAME", default=FILE_UPLOAD_STORAGE_BUCKET_NAME
+    "FILE_UPLOAD_STORAGE_BUCKET_NAME", default="uploads"
 )
 FILE_UPLOAD_STORAGE_PREFIX = config(
     "FILE_UPLOAD_STORAGE_PREFIX", default=FILE_UPLOAD_STORAGE_PREFIX
@@ -881,7 +881,7 @@ FINANCIAL_REPORTS = config(
 
 ##### ORA2 ######
 ORA2_FILEUPLOAD_BACKEND = config("ORA2_FILEUPLOAD_BACKEND", default="filesystem")
-FILE_UPLOAD_STORAGE_BUCKET_NAME = "uploads"
+
 # Prefix for uploads of example-based assessment AI classifiers
 # This can be used to separate uploads for different environments
 ORA2_FILE_PREFIX = config("ORA2_FILE_PREFIX", default=ORA2_FILE_PREFIX)

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove hardcoded FILE_UPLOAD_STORAGE_BUCKET_NAME value to make sure it is configurable
+
 ## [hawthorn.1-oee-3.1.2] - 2020-01-23
 
 ### Fixed

--- a/releases/hawthorn/1/oee/config/cms/docker_run_production.py
+++ b/releases/hawthorn/1/oee/config/cms/docker_run_production.py
@@ -439,7 +439,7 @@ if FEATURES.get("AUTH_USE_CAS"):
 
 # Specific setting for the File Upload Service to store media in a bucket.
 FILE_UPLOAD_STORAGE_BUCKET_NAME = config(
-    "FILE_UPLOAD_STORAGE_BUCKET_NAME", default=FILE_UPLOAD_STORAGE_BUCKET_NAME
+    "FILE_UPLOAD_STORAGE_BUCKET_NAME", default="uploads"
 )
 FILE_UPLOAD_STORAGE_PREFIX = config(
     "FILE_UPLOAD_STORAGE_PREFIX", default=FILE_UPLOAD_STORAGE_PREFIX

--- a/releases/hawthorn/1/oee/config/lms/docker_run_production.py
+++ b/releases/hawthorn/1/oee/config/lms/docker_run_production.py
@@ -709,7 +709,7 @@ DEFAULT_FILE_STORAGE = config(
 
 # Specific setting for the File Upload Service to store media in a bucket.
 FILE_UPLOAD_STORAGE_BUCKET_NAME = config(
-    "FILE_UPLOAD_STORAGE_BUCKET_NAME", default=FILE_UPLOAD_STORAGE_BUCKET_NAME
+    "FILE_UPLOAD_STORAGE_BUCKET_NAME", default="uploads"
 )
 FILE_UPLOAD_STORAGE_PREFIX = config(
     "FILE_UPLOAD_STORAGE_PREFIX", default=FILE_UPLOAD_STORAGE_PREFIX
@@ -946,7 +946,7 @@ FINANCIAL_REPORTS = config(
 
 ##### ORA2 ######
 ORA2_FILEUPLOAD_BACKEND = config("ORA2_FILEUPLOAD_BACKEND", default="filesystem")
-FILE_UPLOAD_STORAGE_BUCKET_NAME = "uploads"
+
 # Prefix for uploads of example-based assessment AI classifiers
 # This can be used to separate uploads for different environments
 ORA2_FILE_PREFIX = config("ORA2_FILE_PREFIX", default=ORA2_FILE_PREFIX)

--- a/releases/master/bare/config/cms/docker_run_production.py
+++ b/releases/master/bare/config/cms/docker_run_production.py
@@ -416,7 +416,7 @@ if FEATURES.get("AUTH_USE_CAS"):
 
 # Specific setting for the File Upload Service to store media in a bucket.
 FILE_UPLOAD_STORAGE_BUCKET_NAME = config(
-    "FILE_UPLOAD_STORAGE_BUCKET_NAME", default=FILE_UPLOAD_STORAGE_BUCKET_NAME
+    "FILE_UPLOAD_STORAGE_BUCKET_NAME", default="uploads"
 )
 FILE_UPLOAD_STORAGE_PREFIX = config(
     "FILE_UPLOAD_STORAGE_PREFIX", default=FILE_UPLOAD_STORAGE_PREFIX

--- a/releases/master/bare/config/lms/docker_run_production.py
+++ b/releases/master/bare/config/lms/docker_run_production.py
@@ -676,7 +676,7 @@ DEFAULT_FILE_STORAGE = config(
 
 # Specific setting for the File Upload Service to store media in a bucket.
 FILE_UPLOAD_STORAGE_BUCKET_NAME = config(
-    "FILE_UPLOAD_STORAGE_BUCKET_NAME", default=FILE_UPLOAD_STORAGE_BUCKET_NAME
+    "FILE_UPLOAD_STORAGE_BUCKET_NAME", default="uploads"
 )
 FILE_UPLOAD_STORAGE_PREFIX = config(
     "FILE_UPLOAD_STORAGE_PREFIX", default=FILE_UPLOAD_STORAGE_PREFIX
@@ -882,7 +882,7 @@ FINANCIAL_REPORTS = config(
 
 ##### ORA2 ######
 ORA2_FILEUPLOAD_BACKEND = config("ORA2_FILEUPLOAD_BACKEND", default="filesystem")
-FILE_UPLOAD_STORAGE_BUCKET_NAME = "uploads"
+
 # Prefix for uploads of example-based assessment AI classifiers
 # This can be used to separate uploads for different environments
 ORA2_FILE_PREFIX = config("ORA2_FILE_PREFIX", default=ORA2_FILE_PREFIX)


### PR DESCRIPTION
## Purpose

We noticed the `FILE_UPLOAD_STORAGE_BUCKET_NAME` setting was not configurable anymore because it was overriden by a hardcoded value.

In parallel, the previous release was attempting to accelerate the dogwood.3-fun home page but we found out that most of the time was in fact spent in the view.

## Proposal

- [x] Fix the `FILE_UPLOAD_STORAGE_BUCKET_NAME` setting by declaring the hardcoded value as a default to the configurable value.
- [x] Upgrade to [fun-apps v5.3.1](https://github.com/openfun/fun-apps/releases/tag/v5.3.1) which overrides the home page view to further accelerate it.