### PR TITLE
Upgrade fun-apps for eucalyptus white brands

### DIFF
--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [eucalyptus.3-wb-1.7.0] - 2020-02-17
+
 ### Added
 
 - Upgrade fun-apps to `2.3.1+wb` to add bokecc video provider backend
@@ -165,7 +167,8 @@ release.
 - Set replicaSet and read_preference in mongodb connection
 - Add missing support for redis sentinel
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.6.3...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.7.0...HEAD
+[eucalyptus.3-wb-1.7.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.6.3...eucalyptus.3-wb-1.7.0
 [eucalyptus.3-wb-1.6.3]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.6.2...eucalyptus.3-wb-1.6.3
 [eucalyptus.3-wb-1.6.2]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.6.1...eucalyptus.3-wb-1.6.2
 [eucalyptus.3-wb-1.6.1]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.6.0...eucalyptus.3-wb-1.6.1

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Added
+
+- Upgrade fun-apps to `2.3.1+wb` to add bokecc video provider backend
+
 ### Fixed
 
 - Remove hardcoded FILE_UPLOAD_STORAGE_BUCKET_NAME value to make sure it is configurable

--- a/releases/eucalyptus/3/wb/requirements.txt
+++ b/releases/eucalyptus/3/wb/requirements.txt
@@ -4,8 +4,8 @@
 # ==== core ====
 configurable-lti-consumer-xblock==1.3.0
 edx-gea==0.2.0
-fun-apps==2.2.1+wb
-libcast-xblock==0.5.0
+fun-apps==2.3.1+wb
+libcast-xblock==0.6.0
 password-container-xblock==0.3.0
 xblock-proctor-exam==0.9.0b0
 xblock-utils2==0.3.0


### PR DESCRIPTION
## Purpose

One of our white brands requires support for the `bokecc` video provider backend.

## Proposal

- [x] upgrade fun-apps to `2.3.0+wb`
