### PR TITLE
add bokecc video provider settings

### DIFF
--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,12 @@ release.
 
 ## [Unreleased]
 
+## [eucalyptus.3-wb-1.7.1] - 2020-02-18
+
+### Fixed
+
+- Add missing settings related to bokecc video provider backend
+
 ## [eucalyptus.3-wb-1.7.0] - 2020-02-17
 
 ### Added
@@ -167,7 +173,8 @@ release.
 - Set replicaSet and read_preference in mongodb connection
 - Add missing support for redis sentinel
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.7.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.7.1...HEAD
+[eucalyptus.3-wb-1.7.1]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.7.0...eucalyptus.3-wb-1.7.1
 [eucalyptus.3-wb-1.7.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.6.3...eucalyptus.3-wb-1.7.0
 [eucalyptus.3-wb-1.6.3]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.6.2...eucalyptus.3-wb-1.6.3
 [eucalyptus.3-wb-1.6.2]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.6.1...eucalyptus.3-wb-1.6.2

--- a/releases/eucalyptus/3/wb/config/cms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/cms/docker_run_production.py
@@ -826,3 +826,13 @@ MAX_ASSET_UPLOAD_FILE_SIZE_IN_MB = config(
 # Force Edx to use `libcast_xblock` as default video player
 # in the studio (big green button) and if any xblock is called `video`
 XBLOCK_SELECT_FUNCTION = prefer_fun_video
+
+# BOKECC video provider settings
+
+BOKECC_APIKEY = config("BOKECC_APIKEY", default="")
+BOKECC_USERID = config("BOKECC_USERID", default="")
+DEFAULT_VIDEO_CLIENT_MODULE = config(
+    "DEFAULT_VIDEO_CLIENT_MODULE", default="videoproviders.api.bokecc"
+)
+BOKECC_FAKE_VIDEO_ID = config("BOKECC_FAKE_VIDEO_ID", default="")
+BOKECC_URL = config("BOKECC_URL", default="https://spark.bokecc.com/api/")


### PR DESCRIPTION
## Purpose

In order to configure bokecc video provider we have to add settings
related to this provider in the docker_run_production file

## Proposal

- [x] add missing bokecc settings in `docker_run_production.py` file
