### PR TITLE
Add bokecc video provider settings in LMS config

### DIFF
--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Add missing settings related to bokecc video provider backend in LMS config
+
 ## [eucalyptus.3-wb-1.7.1] - 2020-02-18
 
 ### Fixed

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [eucalyptus.3-wb-1.7.2] - 2020-02-19
+
 ### Fixed
 
 - Add missing settings related to bokecc video provider backend in LMS config
@@ -177,7 +179,8 @@ release.
 - Set replicaSet and read_preference in mongodb connection
 - Add missing support for redis sentinel
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.7.1...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.7.2...HEAD
+[eucalyptus.3-wb-1.7.2]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.7.1...eucalyptus.3-wb-1.7.2
 [eucalyptus.3-wb-1.7.1]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.7.0...eucalyptus.3-wb-1.7.1
 [eucalyptus.3-wb-1.7.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.6.3...eucalyptus.3-wb-1.7.0
 [eucalyptus.3-wb-1.6.3]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.6.2...eucalyptus.3-wb-1.6.3

--- a/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
@@ -1416,3 +1416,13 @@ NUMBER_DAYS_TOO_LATE = 31
 # Force Edx to use `libcast_xblock` as default video player
 # in the studio (big green button) and if any xblock is called `video`
 XBLOCK_SELECT_FUNCTION = prefer_fun_video
+
+# BOKECC video provider settings
+
+BOKECC_APIKEY = config("BOKECC_APIKEY", default="")
+BOKECC_USERID = config("BOKECC_USERID", default="")
+DEFAULT_VIDEO_CLIENT_MODULE = config(
+    "DEFAULT_VIDEO_CLIENT_MODULE", default="videoproviders.api.bokecc"
+)
+BOKECC_FAKE_VIDEO_ID = config("BOKECC_FAKE_VIDEO_ID", default="")
+BOKECC_URL = config("BOKECC_URL", default="https://spark.bokecc.com/api/")


### PR DESCRIPTION
## Purpose

Bokecc settings were added only in CMS config but we also need them in
the LMS config.


## Proposal

- [x] Add bokecc video provider settings in LMS config
