### PR TITLE
Fix dogwood build

### DIFF
--- a/releases/dogwood/3/bare/CHANGELOG.md
+++ b/releases/dogwood/3/bare/CHANGELOG.md
@@ -12,6 +12,7 @@ release.
 ### Fixed
 
 - Remove hardcoded FILE_UPLOAD_STORAGE_BUCKET_NAME value to make sure it is configurable
+- Downgrade and pin `virtualenv` to version 16.7.9
 
 ## [dogwood.3-1.2.1] - 2020-01-11
 

--- a/releases/dogwood/3/bare/Dockerfile
+++ b/releases/dogwood/3/bare/Dockerfile
@@ -207,7 +207,7 @@ RUN groupadd --gid ${DOCKER_GID} edx || \
 # To prevent permission issues related to the non-priviledged user running in
 # development, we will install development dependencies in a python virtual
 # environment belonging to that user
-RUN pip install virtualenv
+RUN pip install virtualenv==16.7.9
 
 # Create the virtualenv directory where we will install python development
 # dependencies

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Downgrade and pin `virtualenv` to version 16.7.9
+
 ## [dogwood.3-fun-1.9.1] - 2020-01-29
 
 ### Fixed

--- a/releases/dogwood/3/fun/Dockerfile
+++ b/releases/dogwood/3/fun/Dockerfile
@@ -199,7 +199,7 @@ RUN groupadd --gid ${DOCKER_GID} edx || \
 # To prevent permission issues related to the non-priviledged user running in
 # development, we will install development dependencies in a python virtual
 # environment belonging to that user
-RUN pip install virtualenv
+RUN pip install virtualenv==16.7.9
 
 # Create the virtualenv directory where we will install python development
 # dependencies

--- a/releases/dogwood/3/fun/Dockerfile
+++ b/releases/dogwood/3/fun/Dockerfile
@@ -9,8 +9,8 @@
 #     .
 ARG DOCKER_UID=1000
 ARG DOCKER_GID=1000
-ARG EDX_RELEASE_REF=dogwood.3-fun-5.3.2
-ARG EDX_ARCHIVE_URL=https://github.com/openfun/edx-platform/archive/dogwood.3-fun-5.3.2.tar.gz
+ARG EDX_RELEASE_REF=dogwood.3-fun-5.3.3
+ARG EDX_ARCHIVE_URL=https://github.com/openfun/edx-platform/archive/dogwood.3-fun-5.3.3.tar.gz
 
 # === BASE ===
 FROM ubuntu:12.04 as base

--- a/releases/dogwood/3/fun/activate
+++ b/releases/dogwood/3/fun/activate
@@ -1,6 +1,6 @@
 export EDX_RELEASE="dogwood.3"
 export FLAVOR="fun"
-export EDX_RELEASE_REF="dogwood.3-fun-5.3.2"
+export EDX_RELEASE_REF="dogwood.3-fun-5.3.3"
 export EDX_ARCHIVE_URL="https://github.com/openfun/edx-platform/archive/${EDX_RELEASE_REF}.tar.gz"
 export EDX_DEMO_RELEASE_REF="open-release/eucalyptus.1"
 export EDX_DEMO_ARCHIVE_URL="file://${PWD}/releases/dogwood/3/fun/demo-course.tar.gz"


### PR DESCRIPTION
## Purpose

It wasn't possible anymore to build dogwood images. A new version of virtualenv is incompatible with dogwood. We need to downgrade and pin it to a specific version


## Proposal
- [x] downgrade virtualenv and pin it to version 16.7.9
- [x] use dogwood fun version 5.3.3
