### PR TITLE
Fix third party auth settings

### DIFF
--- a/releases/dogwood/3/bare/CHANGELOG.md
+++ b/releases/dogwood/3/bare/CHANGELOG.md
@@ -11,6 +11,7 @@ release.
 
 ### Fixed
 
+- Fix setting AUTHENTICATION_BACKENDS to allow activating third party authentication
 - Remove hardcoded FILE_UPLOAD_STORAGE_BUCKET_NAME value to make sure it is configurable
 - Downgrade and pin `virtualenv` to version 16.7.9
 

--- a/releases/dogwood/3/bare/CHANGELOG.md
+++ b/releases/dogwood/3/bare/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-1.2.2] - 2020-03-13
+
 ### Fixed
 
 - Fix setting AUTHENTICATION_BACKENDS to allow activating third party authentication
@@ -87,7 +89,8 @@ release.
 
 First experimental release of OpenEdx `dogwood.3` (bare flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-1.2.1...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-1.2.2...HEAD
+[dogwood.3-1.2.2]: https://github.com/openfun/openedx-docker/compare/tag/dogwood.3-1.2.1...dogwood.3-1.2.2
 [dogwood.3-1.2.1]: https://github.com/openfun/openedx-docker/compare/tag/dogwood.3-1.2.0...dogwood.3-1.2.1
 [dogwood.3-1.2.0]: https://github.com/openfun/openedx-docker/compare/tag/dogwood.3-1.1.5...dogwood.3-1.2.0
 [dogwood.3-1.1.5]: https://github.com/openfun/openedx-docker/compare/tag/dogwood.3-1.1.4...dogwood.3-1.1.5

--- a/releases/dogwood/3/bare/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/bare/config/lms/docker_run_production.py
@@ -862,7 +862,7 @@ X_FRAME_OPTIONS = config("X_FRAME_OPTIONS", default=X_FRAME_OPTIONS)
 if FEATURES.get("ENABLE_THIRD_PARTY_AUTH"):
     AUTHENTICATION_BACKENDS = config(
         "THIRD_PARTY_AUTH_BACKENDS",
-        [
+        default=[
             "social.backends.google.GoogleOAuth2",
             "social.backends.linkedin.LinkedinOAuth2",
             "social.backends.facebook.FacebookOAuth2",

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-1.9.2] - 2020-03-13
+
 ### Fixed
 
 - Fix setting AUTHENTICATION_BACKENDS to allow activating third party authentication
@@ -231,7 +233,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.9.1...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.9.2...HEAD
+[dogwood.3-fun-1.9.2]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.9.1...dogwood.3-fun-1.9.2
 [dogwood.3-fun-1.9.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.9.0...dogwood.3-fun-1.9.1
 [dogwood.3-fun-1.9.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.8.6...dogwood.3-fun-1.9.0
 [dogwood.3-fun-1.8.6]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.8.5...dogwood.3-fun-1.8.6

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -11,6 +11,7 @@ release.
 
 ### Fixed
 
+- Fix setting AUTHENTICATION_BACKENDS to allow activating third party authentication
 - Downgrade and pin `virtualenv` to version 16.7.9
 
 ## [dogwood.3-fun-1.9.1] - 2020-01-29

--- a/releases/dogwood/3/fun/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/lms/docker_run_production.py
@@ -899,7 +899,7 @@ X_FRAME_OPTIONS = config("X_FRAME_OPTIONS", default=X_FRAME_OPTIONS)
 if FEATURES.get("ENABLE_THIRD_PARTY_AUTH"):
     AUTHENTICATION_BACKENDS = config(
         "THIRD_PARTY_AUTH_BACKENDS",
-        [
+        default=[
             "social.backends.google.GoogleOAuth2",
             "social.backends.linkedin.LinkedinOAuth2",
             "social.backends.facebook.FacebookOAuth2",

--- a/releases/eucalyptus/3/bare/CHANGELOG.md
+++ b/releases/eucalyptus/3/bare/CHANGELOG.md
@@ -11,6 +11,7 @@ release.
 
 ### Fixed
 
+- Fix setting `AUTHENTICATION_BACKENDS` to allow activating third party authentication
 - Remove hardcoded FILE_UPLOAD_STORAGE_BUCKET_NAME value to make sure it is configurable
 
 ## [eucalyptus.3-1.1.1] - 2020-01-11

--- a/releases/eucalyptus/3/bare/CHANGELOG.md
+++ b/releases/eucalyptus/3/bare/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [eucalyptus.3-1.1.2] - 2020-03-13
+
 ### Fixed
 
 - Fix setting `AUTHENTICATION_BACKENDS` to allow activating third party authentication
@@ -78,7 +80,8 @@ release.
 
 - First experimental release of OpenEdx `eucalyptus.3` (bare flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.1.1...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.1.2...HEAD
+[eucalyptus.3-1.1.2]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.1.1...eucalyptus.3-1.1.2
 [eucalyptus.3-1.1.1]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.1.0...eucalyptus.3-1.1.1
 [eucalyptus.3-1.1.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.4...eucalyptus.3-1.1.0
 [eucalyptus.3-1.0.4]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.3...eucalyptus.3-1.0.4

--- a/releases/eucalyptus/3/bare/config/lms/docker_run_production.py
+++ b/releases/eucalyptus/3/bare/config/lms/docker_run_production.py
@@ -934,7 +934,7 @@ X_FRAME_OPTIONS = config("X_FRAME_OPTIONS", default=X_FRAME_OPTIONS)
 if FEATURES.get("ENABLE_THIRD_PARTY_AUTH"):
     AUTHENTICATION_BACKENDS = config(
         "THIRD_PARTY_AUTH_BACKENDS",
-        [
+        default=[
             "social.backends.google.GoogleOAuth2",
             "social.backends.linkedin.LinkedinOAuth2",
             "social.backends.facebook.FacebookOAuth2",

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix setting `AUTHENTICATION_BACKENDS` to allow activating third party authentication
+
 ## [eucalyptus.3-wb-1.7.2] - 2020-02-19
 
 ### Fixed

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [eucalyptus.3-wb-1.7.3] - 2020-03-13
+
 ### Fixed
 
 - Fix setting `AUTHENTICATION_BACKENDS` to allow activating third party authentication
@@ -183,7 +185,8 @@ release.
 - Set replicaSet and read_preference in mongodb connection
 - Add missing support for redis sentinel
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.7.2...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.7.3...HEAD
+[eucalyptus.3-wb-1.7.3]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.7.2...eucalyptus.3-wb-1.7.3
 [eucalyptus.3-wb-1.7.2]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.7.1...eucalyptus.3-wb-1.7.2
 [eucalyptus.3-wb-1.7.1]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.7.0...eucalyptus.3-wb-1.7.1
 [eucalyptus.3-wb-1.7.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.6.3...eucalyptus.3-wb-1.7.0

--- a/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
@@ -976,7 +976,7 @@ X_FRAME_OPTIONS = config("X_FRAME_OPTIONS", default=X_FRAME_OPTIONS)
 if FEATURES.get("ENABLE_THIRD_PARTY_AUTH"):
     AUTHENTICATION_BACKENDS = config(
         "THIRD_PARTY_AUTH_BACKENDS",
-        [
+        default=[
             "social.backends.google.GoogleOAuth2",
             "social.backends.linkedin.LinkedinOAuth2",
             "social.backends.facebook.FacebookOAuth2",


### PR DESCRIPTION
## Purpose

The `AUTHENTICATION_BACKENDS` setting default value was wrongly declared.

## Proposal

Pass the default value for the `AUTHENTICATION_BACKENDS` setting as a keyword argument.