### PR TITLE
🔧([dogwood|eucalyptus]/3/[fun|wb]) add AT_INTERNET_SMARTTAG settings

### DIFF
--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Added
+
+- Add `AT_INTERNET_SMARTTAG` setting to configure web analytics tracking
+
 ## [dogwood.3-fun-1.9.2] - 2020-03-13
 
 ### Fixed

--- a/releases/dogwood/3/fun/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/lms/docker_run_production.py
@@ -1514,3 +1514,6 @@ PAYMENT_ADMIN = "paybox@fun-mooc.fr"
 # Force Edx to use `libcast_xblock` as default video player
 # in the studio (big green button) and if any xblock is called `video`
 XBLOCK_SELECT_FUNCTION = prefer_fun_video
+
+# AT Internet web analytics tracking
+AT_INTERNET_SMARTTAG = config("AT_INTERNET_SMARTTAG", default=None)

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Added
+
+- Add `AT_INTERNET_SMARTTAG` setting to configure web analytics tracking
+
 ## [eucalyptus.3-wb-1.7.3] - 2020-03-13
 
 ### Fixed

--- a/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
@@ -1426,3 +1426,6 @@ DEFAULT_VIDEO_CLIENT_MODULE = config(
 )
 BOKECC_FAKE_VIDEO_ID = config("BOKECC_FAKE_VIDEO_ID", default="")
 BOKECC_URL = config("BOKECC_URL", default="https://spark.bokecc.com/api/")
+
+# AT Internet web analytics tracking
+AT_INTERNET_SMARTTAG = config("AT_INTERNET_SMARTTAG", default=None)


### PR DESCRIPTION
This settings will be used in templates to configure
AT Internet web analytics tracking.
