### PR TITLE
Add rate limit backend for proxy

### DIFF
--- a/releases/dogwood/3/bare/CHANGELOG.md
+++ b/releases/dogwood/3/bare/CHANGELOG.md
@@ -13,6 +13,10 @@ release.
 
 - Rate limiting authentication backend that works behind proxies
 
+### Changed
+
+- Refactor the way authentication backends are configured to make it straightforward
+
 ## [dogwood.3-1.2.2] - 2020-03-13
 
 ### Fixed

--- a/releases/dogwood/3/bare/CHANGELOG.md
+++ b/releases/dogwood/3/bare/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Added
+
+- Rate limiting authentication backend that works behind proxies
+
 ## [dogwood.3-1.2.2] - 2020-03-13
 
 ### Fixed

--- a/releases/dogwood/3/bare/config/lms/backends.py
+++ b/releases/dogwood/3/bare/config/lms/backends.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+from ratelimitbackend.backends import RateLimitModelBackend
+
+
+class ProxyRateLimitModelBackend(RateLimitModelBackend):
+    """A rate limiting Backend that works behind a proxy."""
+
+    def get_ip(self, request):
+        """Return the end user address string as set by proxies."""
+        return request.META["HTTP_X_FORWARDED_FOR"]

--- a/releases/dogwood/3/bare/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/bare/config/lms/docker_run_production.py
@@ -476,10 +476,6 @@ CAS_EXTRA_LOGIN_PARAMS = config(
 )
 if FEATURES.get("AUTH_USE_CAS"):
     CAS_SERVER_URL = config("CAS_SERVER_URL", default=None)
-    AUTHENTICATION_BACKENDS = [
-        "django.contrib.auth.backends.ModelBackend",
-        "django_cas.backends.CASBackend",
-    ]
     INSTALLED_APPS.append("django_cas")
     MIDDLEWARE_CLASSES.append("django_cas.middleware.CASMiddleware")
     CAS_ATTRIBUTE_CALLBACK = config(
@@ -605,6 +601,14 @@ CC_PROCESSOR_NAME = config("CC_PROCESSOR_NAME", default=CC_PROCESSOR_NAME)
 CC_PROCESSOR = config("CC_PROCESSOR", default=CC_PROCESSOR)
 
 SECRET_KEY = config("SECRET_KEY", default="ThisisAnExampleKeyForDevPurposeOnly")
+
+# Authentication backends
+# - behind a proxy, use: "lms.envs.fun.backends.ProxyRateLimitModelBackend"
+# - for LTI provider, add: "lti_provider.users.LtiBackend"
+# - for CAS, add: "django_cas.backends.CASBackend"
+AUTHENTICATION_BACKENDS = config(
+    "AUTHENTICATION_BACKENDS", default=AUTHENTICATION_BACKENDS
+)
 
 DEFAULT_FILE_STORAGE = config(
     "DEFAULT_FILE_STORAGE", default="django.core.files.storage.FileSystemStorage"
@@ -860,17 +864,6 @@ X_FRAME_OPTIONS = config("X_FRAME_OPTIONS", default=X_FRAME_OPTIONS)
 
 ##### Third-party auth options ################################################
 if FEATURES.get("ENABLE_THIRD_PARTY_AUTH"):
-    AUTHENTICATION_BACKENDS = config(
-        "THIRD_PARTY_AUTH_BACKENDS",
-        default=[
-            "social.backends.google.GoogleOAuth2",
-            "social.backends.linkedin.LinkedinOAuth2",
-            "social.backends.facebook.FacebookOAuth2",
-            "third_party_auth.saml.SAMLAuthBackend",
-            "third_party_auth.lti.LTIAuthBackend",
-        ],
-    ) + list(AUTHENTICATION_BACKENDS)
-
     # The reduced session expiry time during the third party login pipeline. (Value in seconds)
     SOCIAL_AUTH_PIPELINE_TIMEOUT = config("SOCIAL_AUTH_PIPELINE_TIMEOUT", default=600)
 
@@ -1082,7 +1075,6 @@ CREDIT_PROVIDER_SECRET_KEYS = config(
 ##################### LTI Provider #####################
 if FEATURES.get("ENABLE_LTI_PROVIDER"):
     INSTALLED_APPS += ("lti_provider",)
-    AUTHENTICATION_BACKENDS += ("lti_provider.users.LtiBackend",)
 
 LTI_USER_EMAIL_DOMAIN = config("LTI_USER_EMAIL_DOMAIN", default="lti.example.com")
 

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -13,6 +13,10 @@ release.
 
 - Rate limiting authentication backend that works behind proxies
 
+### Changed
+
+- Refactor the way authentication backends are configured to make it straightforward
+
 ## [dogwood.3-fun-1.9.2] - 2020-03-13
 
 ### Fixed

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Added
+
+- Rate limiting authentication backend that works behind proxies
+
 ## [dogwood.3-fun-1.9.2] - 2020-03-13
 
 ### Fixed

--- a/releases/dogwood/3/fun/config/lms/backends.py
+++ b/releases/dogwood/3/fun/config/lms/backends.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+from ratelimitbackend.backends import RateLimitModelBackend
+
+
+class ProxyRateLimitModelBackend(RateLimitModelBackend):
+    """A rate limiting Backend that works behind a proxy."""
+
+    def get_ip(self, request):
+        """Return the end user address string as set by proxies."""
+        return request.META['HTTP_X_FORWARDED_FOR']

--- a/releases/dogwood/3/fun/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/lms/docker_run_production.py
@@ -513,10 +513,6 @@ CAS_EXTRA_LOGIN_PARAMS = config(
 )
 if FEATURES.get("AUTH_USE_CAS"):
     CAS_SERVER_URL = config("CAS_SERVER_URL", default=None)
-    AUTHENTICATION_BACKENDS = [
-        "django.contrib.auth.backends.ModelBackend",
-        "django_cas.backends.CASBackend",
-    ]
     INSTALLED_APPS.append("django_cas")
     MIDDLEWARE_CLASSES.append("django_cas.middleware.CASMiddleware")
     CAS_ATTRIBUTE_CALLBACK = config(
@@ -642,6 +638,15 @@ CC_PROCESSOR_NAME = config("CC_PROCESSOR_NAME", default=CC_PROCESSOR_NAME)
 CC_PROCESSOR = config("CC_PROCESSOR", default=CC_PROCESSOR)
 
 SECRET_KEY = config("SECRET_KEY", default="ThisisAnExampleKeyForDevPurposeOnly")
+
+# Authentication backends
+# - behind a proxy, use: "lms.envs.fun.backends.ProxyRateLimitModelBackend"
+# - for LTI provider, add: "lti_provider.users.LtiBackend"
+# - for CAS, add: "django_cas.backends.CASBackend"
+AUTHENTICATION_BACKENDS = config(
+    "AUTHENTICATION_BACKENDS",
+    default=("lms.envs.fun.backends.ProxyRateLimitModelBackend",),
+)
 
 DEFAULT_FILE_STORAGE = config(
     "DEFAULT_FILE_STORAGE", default="django.core.files.storage.FileSystemStorage"
@@ -897,17 +902,6 @@ X_FRAME_OPTIONS = config("X_FRAME_OPTIONS", default=X_FRAME_OPTIONS)
 
 ##### Third-party auth options ################################################
 if FEATURES.get("ENABLE_THIRD_PARTY_AUTH"):
-    AUTHENTICATION_BACKENDS = config(
-        "THIRD_PARTY_AUTH_BACKENDS",
-        default=[
-            "social.backends.google.GoogleOAuth2",
-            "social.backends.linkedin.LinkedinOAuth2",
-            "social.backends.facebook.FacebookOAuth2",
-            "third_party_auth.saml.SAMLAuthBackend",
-            "third_party_auth.lti.LTIAuthBackend",
-        ],
-    ) + list(AUTHENTICATION_BACKENDS)
-
     # The reduced session expiry time during the third party login pipeline. (Value in seconds)
     SOCIAL_AUTH_PIPELINE_TIMEOUT = config("SOCIAL_AUTH_PIPELINE_TIMEOUT", default=600)
 
@@ -1121,7 +1115,6 @@ CREDIT_PROVIDER_SECRET_KEYS = config(
 ##################### LTI Provider #####################
 if FEATURES.get("ENABLE_LTI_PROVIDER"):
     INSTALLED_APPS += ("lti_provider",)
-    AUTHENTICATION_BACKENDS += ("lti_provider.users.LtiBackend",)
 
 LTI_USER_EMAIL_DOMAIN = config("LTI_USER_EMAIL_DOMAIN", default="lti.example.com")
 

--- a/releases/eucalyptus/3/bare/CHANGELOG.md
+++ b/releases/eucalyptus/3/bare/CHANGELOG.md
@@ -13,6 +13,10 @@ release.
 
 - Rate limiting authentication backend that works behind proxies
 
+### Changed
+
+- Refactor the way authentication backends are configured to make it straightforward
+
 ## [eucalyptus.3-1.1.2] - 2020-03-13
 
 ### Fixed

--- a/releases/eucalyptus/3/bare/CHANGELOG.md
+++ b/releases/eucalyptus/3/bare/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Added
+
+- Rate limiting authentication backend that works behind proxies
+
 ## [eucalyptus.3-1.1.2] - 2020-03-13
 
 ### Fixed

--- a/releases/eucalyptus/3/bare/config/lms/backends.py
+++ b/releases/eucalyptus/3/bare/config/lms/backends.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+from ratelimitbackend.backends import RateLimitModelBackend
+
+
+class ProxyRateLimitModelBackend(RateLimitModelBackend):
+    """A rate limiting Backend that works behind a proxy."""
+
+    def get_ip(self, request):
+        """Return the end user address string as set by proxies."""
+        return request.META['HTTP_X_FORWARDED_FOR']

--- a/releases/eucalyptus/3/bare/config/lms/docker_run_production.py
+++ b/releases/eucalyptus/3/bare/config/lms/docker_run_production.py
@@ -201,7 +201,6 @@ REGISTRATION_EMAIL_PATTERNS_ALLOWED = config(
     "REGISTRATION_EMAIL_PATTERNS_ALLOWED", default=None
 )
 
-
 # Set the names of cookies shared with the marketing site
 # These have the same cookie domain as the session, which in production
 # usually includes subdomains.
@@ -518,10 +517,6 @@ CAS_EXTRA_LOGIN_PARAMS = config(
 )
 if FEATURES.get("AUTH_USE_CAS"):
     CAS_SERVER_URL = config("CAS_SERVER_URL", default=None)
-    AUTHENTICATION_BACKENDS = [
-        "django.contrib.auth.backends.ModelBackend",
-        "django_cas.backends.CASBackend",
-    ]
     INSTALLED_APPS.append("django_cas")
     MIDDLEWARE_CLASSES.append("django_cas.middleware.CASMiddleware")
     CAS_ATTRIBUTE_CALLBACK = config(
@@ -671,6 +666,14 @@ CC_PROCESSOR_NAME = config("CC_PROCESSOR_NAME", default=CC_PROCESSOR_NAME)
 CC_PROCESSOR = config("CC_PROCESSOR", default=CC_PROCESSOR)
 
 SECRET_KEY = config("SECRET_KEY", default="ThisisAnExampleKeyForDevPurposeOnly")
+
+# Authentication backends
+# - behind a proxy, use: "lms.envs.fun.backends.ProxyRateLimitModelBackend"
+# - for LTI provider, add: "lti_provider.users.LtiBackend"
+# - for CAS, add: "django_cas.backends.CASBackend"
+AUTHENTICATION_BACKENDS = config(
+    "AUTHENTICATION_BACKENDS", default=AUTHENTICATION_BACKENDS
+)
 
 DEFAULT_FILE_STORAGE = config(
     "DEFAULT_FILE_STORAGE", default="django.core.files.storage.FileSystemStorage"
@@ -932,18 +935,6 @@ X_FRAME_OPTIONS = config("X_FRAME_OPTIONS", default=X_FRAME_OPTIONS)
 
 ##### Third-party auth options ################################################
 if FEATURES.get("ENABLE_THIRD_PARTY_AUTH"):
-    AUTHENTICATION_BACKENDS = config(
-        "THIRD_PARTY_AUTH_BACKENDS",
-        default=[
-            "social.backends.google.GoogleOAuth2",
-            "social.backends.linkedin.LinkedinOAuth2",
-            "social.backends.facebook.FacebookOAuth2",
-            "social.backends.azuread.AzureADOAuth2",
-            "third_party_auth.saml.SAMLAuthBackend",
-            "third_party_auth.lti.LTIAuthBackend",
-        ],
-    ) + list(AUTHENTICATION_BACKENDS)
-
     # The reduced session expiry time during the third party login pipeline. (Value in seconds)
     SOCIAL_AUTH_PIPELINE_TIMEOUT = config("SOCIAL_AUTH_PIPELINE_TIMEOUT", default=600)
 
@@ -1188,7 +1179,6 @@ CREDIT_PROVIDER_SECRET_KEYS = config(
 ##################### LTI Provider #####################
 if FEATURES.get("ENABLE_LTI_PROVIDER"):
     INSTALLED_APPS += ("lti_provider",)
-    AUTHENTICATION_BACKENDS += ("lti_provider.users.LtiBackend",)
 
 LTI_USER_EMAIL_DOMAIN = config("LTI_USER_EMAIL_DOMAIN", default="lti.example.com")
 

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -13,6 +13,10 @@ release.
 
 - Rate limiting authentication backend that works behind proxies
 
+### Changed
+
+- Refactor the way authentication backends are configured to make it straightforward
+
 ## [eucalyptus.3-wb-1.7.4] - 2020-03-24
 
 ### Changed

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Added
+
+- Rate limiting authentication backend that works behind proxies
+
 ## [eucalyptus.3-wb-1.7.4] - 2020-03-24
 
 ### Changed

--- a/releases/eucalyptus/3/wb/config/lms/backends.py
+++ b/releases/eucalyptus/3/wb/config/lms/backends.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+from ratelimitbackend.backends import RateLimitModelBackend
+
+
+class ProxyRateLimitModelBackend(RateLimitModelBackend):
+    """A rate limiting Backend that works behind a proxy."""
+
+    def get_ip(self, request):
+        """Return the end user address string as set by proxies."""
+        return request.META['HTTP_X_FORWARDED_FOR']

--- a/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
@@ -235,7 +235,6 @@ REGISTRATION_EMAIL_PATTERNS_ALLOWED = config(
     "REGISTRATION_EMAIL_PATTERNS_ALLOWED", default=None
 )
 
-
 # Set the names of cookies shared with the marketing site
 # These have the same cookie domain as the session, which in production
 # usually includes subdomains.
@@ -546,10 +545,6 @@ CAS_EXTRA_LOGIN_PARAMS = config(
 )
 if FEATURES.get("AUTH_USE_CAS"):
     CAS_SERVER_URL = config("CAS_SERVER_URL", default=None)
-    AUTHENTICATION_BACKENDS = [
-        "django.contrib.auth.backends.ModelBackend",
-        "django_cas.backends.CASBackend",
-    ]
     INSTALLED_APPS += ("django_cas",)
     MIDDLEWARE_CLASSES.append("django_cas.middleware.CASMiddleware")
     CAS_ATTRIBUTE_CALLBACK = config(
@@ -699,6 +694,15 @@ CC_PROCESSOR_NAME = config("CC_PROCESSOR_NAME", default=CC_PROCESSOR_NAME)
 CC_PROCESSOR = config("CC_PROCESSOR", default=CC_PROCESSOR)
 
 SECRET_KEY = config("SECRET_KEY", default="ThisisAnExampleKeyForDevPurposeOnly")
+
+# Authentication backends
+# - behind a proxy, use: "lms.envs.fun.backends.ProxyRateLimitModelBackend"
+# - for LTI provider, add: "lti_provider.users.LtiBackend"
+# - for CAS, add: "django_cas.backends.CASBackend"
+AUTHENTICATION_BACKENDS = config(
+    "AUTHENTICATION_BACKENDS",
+    default=("lms.envs.fun.backends.ProxyRateLimitModelBackend",),
+)
 
 DEFAULT_FILE_STORAGE = config(
     "DEFAULT_FILE_STORAGE", default="django.core.files.storage.FileSystemStorage"
@@ -974,18 +978,6 @@ X_FRAME_OPTIONS = config("X_FRAME_OPTIONS", default=X_FRAME_OPTIONS)
 
 ##### Third-party auth options ################################################
 if FEATURES.get("ENABLE_THIRD_PARTY_AUTH"):
-    AUTHENTICATION_BACKENDS = config(
-        "THIRD_PARTY_AUTH_BACKENDS",
-        default=[
-            "social.backends.google.GoogleOAuth2",
-            "social.backends.linkedin.LinkedinOAuth2",
-            "social.backends.facebook.FacebookOAuth2",
-            "social.backends.azuread.AzureADOAuth2",
-            "third_party_auth.saml.SAMLAuthBackend",
-            "third_party_auth.lti.LTIAuthBackend",
-        ],
-    ) + list(AUTHENTICATION_BACKENDS)
-
     # The reduced session expiry time during the third party login pipeline. (Value in seconds)
     SOCIAL_AUTH_PIPELINE_TIMEOUT = config("SOCIAL_AUTH_PIPELINE_TIMEOUT", default=600)
 
@@ -1230,7 +1222,6 @@ CREDIT_PROVIDER_SECRET_KEYS = config(
 ##################### LTI Provider #####################
 if FEATURES.get("ENABLE_LTI_PROVIDER"):
     INSTALLED_APPS += ("lti_provider",)
-    AUTHENTICATION_BACKENDS += ("lti_provider.users.LtiBackend",)
 
 LTI_USER_EMAIL_DOMAIN = config("LTI_USER_EMAIL_DOMAIN", default="lti.example.com")
 

--- a/releases/hawthorn/1/bare/CHANGELOG.md
+++ b/releases/hawthorn/1/bare/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Added
+
+- Rate limiting authentication backend that works behind proxies
+
 ### Fixed
 
 - Remove hardcoded FILE_UPLOAD_STORAGE_BUCKET_NAME value to make sure it is configurable

--- a/releases/hawthorn/1/bare/CHANGELOG.md
+++ b/releases/hawthorn/1/bare/CHANGELOG.md
@@ -13,6 +13,10 @@ release.
 
 - Rate limiting authentication backend that works behind proxies
 
+### Changed
+
+- Refactor the way authentication backends are configured to make it straightforward
+
 ### Fixed
 
 - Remove hardcoded FILE_UPLOAD_STORAGE_BUCKET_NAME value to make sure it is configurable

--- a/releases/hawthorn/1/bare/config/lms/backends.py
+++ b/releases/hawthorn/1/bare/config/lms/backends.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+from ratelimitbackend.backends import RateLimitModelBackend
+
+
+class ProxyRateLimitModelBackend(RateLimitModelBackend):
+    """A rate limiting Backend that works behind a proxy."""
+
+    def get_ip(self, request):
+        """Return the end user address string as set by proxies."""
+        return request.META['HTTP_X_FORWARDED_FOR']

--- a/releases/hawthorn/1/bare/config/lms/docker_run_production.py
+++ b/releases/hawthorn/1/bare/config/lms/docker_run_production.py
@@ -530,10 +530,6 @@ CAS_EXTRA_LOGIN_PARAMS = config(
 )
 if FEATURES.get("AUTH_USE_CAS"):
     CAS_SERVER_URL = config("CAS_SERVER_URL", default=None)
-    AUTHENTICATION_BACKENDS = [
-        "django.contrib.auth.backends.ModelBackend",
-        "django_cas.backends.CASBackend",
-    ]
     INSTALLED_APPS.append("django_cas")
     MIDDLEWARE_CLASSES.append("django_cas.middleware.CASMiddleware")
     CAS_ATTRIBUTE_CALLBACK = config(
@@ -574,6 +570,14 @@ NOTIFICATION_EMAIL_EDX_LOGO = config(
     "NOTIFICATION_EMAIL_EDX_LOGO", default=NOTIFICATION_EMAIL_EDX_LOGO
 )
 SECRET_KEY = config("SECRET_KEY", default="ThisIsAnExampleKeyForDevPurposeOnly")
+
+# Authentication backends
+# - behind a proxy, use: "lms.envs.fun.backends.ProxyRateLimitModelBackend"
+# - for LTI provider, add: "lti_provider.users.LtiBackend"
+# - for CAS, add: "django_cas.backends.CASBackend"
+AUTHENTICATION_BACKENDS = config(
+    "AUTHENTICATION_BACKENDS", default=AUTHENTICATION_BACKENDS
+)
 
 # Determines whether the CSRF token can be transported on
 # unencrypted channels. It is set to False here for backward compatibility,
@@ -935,19 +939,6 @@ X_FRAME_OPTIONS = config("X_FRAME_OPTIONS", default=X_FRAME_OPTIONS)
 
 ##### Third-party auth options ################################################
 if FEATURES.get("ENABLE_THIRD_PARTY_AUTH"):
-    AUTHENTICATION_BACKENDS = config(
-        "THIRD_PARTY_AUTH_BACKENDS",
-        default=[
-            "social_core.backends.google.GoogleOAuth2",
-            "social_core.backends.linkedin.LinkedinOAuth2",
-            "social_core.backends.facebook.FacebookOAuth2",
-            "social_core.backends.azuread.AzureADOAuth2",
-            "third_party_auth.saml.SAMLAuthBackend",
-            "third_party_auth.lti.LTIAuthBackend",
-        ],
-        formatter=json.loads,
-    ) + list(AUTHENTICATION_BACKENDS)
-
     # The reduced session expiry time during the third party login pipeline. (Value in seconds)
     SOCIAL_AUTH_PIPELINE_TIMEOUT = config(
         "SOCIAL_AUTH_PIPELINE_TIMEOUT", default=600, formatter=int
@@ -1221,7 +1212,6 @@ CREDIT_PROVIDER_SECRET_KEYS = config(
 ##################### LTI Provider #####################
 if FEATURES.get("ENABLE_LTI_PROVIDER"):
     INSTALLED_APPS.append("lti_provider.apps.LtiProviderConfig")
-    AUTHENTICATION_BACKENDS.append("lti_provider.users.LtiBackend")
 
 LTI_USER_EMAIL_DOMAIN = config("LTI_USER_EMAIL_DOMAIN", default="lti.example.com")
 

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Added
+
+- Rate limiting authentication backend that works behind proxies
+
 ### Fixed
 
 - Remove hardcoded FILE_UPLOAD_STORAGE_BUCKET_NAME value to make sure it is configurable

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -13,6 +13,10 @@ release.
 
 - Rate limiting authentication backend that works behind proxies
 
+### Changed
+
+- Refactor the way authentication backends are configured to make it straightforward
+
 ### Fixed
 
 - Remove hardcoded FILE_UPLOAD_STORAGE_BUCKET_NAME value to make sure it is configurable

--- a/releases/hawthorn/1/oee/config/lms/backends.py
+++ b/releases/hawthorn/1/oee/config/lms/backends.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+from ratelimitbackend.backends import RateLimitModelBackend
+
+
+class ProxyRateLimitModelBackend(RateLimitModelBackend):
+    """A rate limiting Backend that works behind a proxy."""
+
+    def get_ip(self, request):
+        """Return the end user address string as set by proxies."""
+        return request.META['HTTP_X_FORWARDED_FOR']

--- a/releases/hawthorn/1/oee/config/lms/docker_run_production.py
+++ b/releases/hawthorn/1/oee/config/lms/docker_run_production.py
@@ -564,10 +564,6 @@ CAS_EXTRA_LOGIN_PARAMS = config(
 )
 if FEATURES.get("AUTH_USE_CAS"):
     CAS_SERVER_URL = config("CAS_SERVER_URL", default=None)
-    AUTHENTICATION_BACKENDS = [
-        "django.contrib.auth.backends.ModelBackend",
-        "django_cas.backends.CASBackend",
-    ]
     INSTALLED_APPS.append("django_cas")
     MIDDLEWARE_CLASSES.append("django_cas.middleware.CASMiddleware")
     CAS_ATTRIBUTE_CALLBACK = config(
@@ -608,6 +604,15 @@ NOTIFICATION_EMAIL_EDX_LOGO = config(
     "NOTIFICATION_EMAIL_EDX_LOGO", default=NOTIFICATION_EMAIL_EDX_LOGO
 )
 SECRET_KEY = config("SECRET_KEY", default="ThisIsAnExampleKeyForDevPurposeOnly")
+
+# Authentication backends
+# - behind a proxy, use: "lms.envs.fun.backends.ProxyRateLimitModelBackend"
+# - for LTI provider, add: "lti_provider.users.LtiBackend"
+# - for CAS, add: "django_cas.backends.CASBackend"
+AUTHENTICATION_BACKENDS = config(
+    "AUTHENTICATION_BACKENDS",
+    default=("lms.envs.fun.backends.ProxyRateLimitModelBackend",),
+)
 
 # Determines whether the CSRF token can be transported on
 # unencrypted channels. It is set to False here for backward compatibility,
@@ -1000,19 +1005,6 @@ X_FRAME_OPTIONS = config("X_FRAME_OPTIONS", default=X_FRAME_OPTIONS)
 
 ##### Third-party auth options ################################################
 if FEATURES.get("ENABLE_THIRD_PARTY_AUTH"):
-    AUTHENTICATION_BACKENDS = config(
-        "THIRD_PARTY_AUTH_BACKENDS",
-        default=[
-            "social_core.backends.google.GoogleOAuth2",
-            "social_core.backends.linkedin.LinkedinOAuth2",
-            "social_core.backends.facebook.FacebookOAuth2",
-            "social_core.backends.azuread.AzureADOAuth2",
-            "third_party_auth.saml.SAMLAuthBackend",
-            "third_party_auth.lti.LTIAuthBackend",
-        ],
-        formatter=json.loads,
-    ) + list(AUTHENTICATION_BACKENDS)
-
     # The reduced session expiry time during the third party login pipeline. (Value in seconds)
     SOCIAL_AUTH_PIPELINE_TIMEOUT = config(
         "SOCIAL_AUTH_PIPELINE_TIMEOUT", default=600, formatter=int
@@ -1286,7 +1278,6 @@ CREDIT_PROVIDER_SECRET_KEYS = config(
 ##################### LTI Provider #####################
 if FEATURES.get("ENABLE_LTI_PROVIDER"):
     INSTALLED_APPS.append("lti_provider.apps.LtiProviderConfig")
-    AUTHENTICATION_BACKENDS.append("lti_provider.users.LtiBackend")
 
 LTI_USER_EMAIL_DOMAIN = config("LTI_USER_EMAIL_DOMAIN", default="lti.example.com")
 

--- a/releases/master/bare/config/lms/backends.py
+++ b/releases/master/bare/config/lms/backends.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+from ratelimitbackend.backends import RateLimitModelBackend
+
+
+class ProxyRateLimitModelBackend(RateLimitModelBackend):
+    """A rate limiting Backend that works behind a proxy."""
+
+    def get_ip(self, request):
+        """Return the end user address string as set by proxies."""
+        return request.META['HTTP_X_FORWARDED_FOR']

--- a/releases/master/bare/config/lms/docker_run_production.py
+++ b/releases/master/bare/config/lms/docker_run_production.py
@@ -531,10 +531,6 @@ CAS_EXTRA_LOGIN_PARAMS = config(
 )
 if FEATURES.get("AUTH_USE_CAS"):
     CAS_SERVER_URL = config("CAS_SERVER_URL", default=None)
-    AUTHENTICATION_BACKENDS = [
-        "django.contrib.auth.backends.ModelBackend",
-        "django_cas.backends.CASBackend",
-    ]
     INSTALLED_APPS.append("django_cas")
     MIDDLEWARE_CLASSES.append("django_cas.middleware.CASMiddleware")
     CAS_ATTRIBUTE_CALLBACK = config(
@@ -575,6 +571,14 @@ NOTIFICATION_EMAIL_EDX_LOGO = config(
     "NOTIFICATION_EMAIL_EDX_LOGO", default=NOTIFICATION_EMAIL_EDX_LOGO
 )
 SECRET_KEY = config("SECRET_KEY", default="ThisIsAnExampleKeyForDevPurposeOnly")
+
+# Authentication backends
+# - behind a proxy, use: "lms.envs.fun.backends.ProxyRateLimitModelBackend"
+# - for LTI provider, add: "lti_provider.users.LtiBackend"
+# - for CAS, add: "django_cas.backends.CASBackend"
+AUTHENTICATION_BACKENDS = config(
+    "AUTHENTICATION_BACKENDS", default=AUTHENTICATION_BACKENDS
+)
 
 # Determines whether the CSRF token can be transported on
 # unencrypted channels. It is set to False here for backward compatibility,
@@ -936,19 +940,6 @@ X_FRAME_OPTIONS = config("X_FRAME_OPTIONS", default=X_FRAME_OPTIONS)
 
 ##### Third-party auth options ################################################
 if FEATURES.get("ENABLE_THIRD_PARTY_AUTH"):
-    AUTHENTICATION_BACKENDS = config(
-        "THIRD_PARTY_AUTH_BACKENDS",
-        default=[
-            "social_core.backends.google.GoogleOAuth2",
-            "social_core.backends.linkedin.LinkedinOAuth2",
-            "social_core.backends.facebook.FacebookOAuth2",
-            "social_core.backends.azuread.AzureADOAuth2",
-            "third_party_auth.saml.SAMLAuthBackend",
-            "third_party_auth.lti.LTIAuthBackend",
-        ],
-        formatter=json.loads,
-    ) + list(AUTHENTICATION_BACKENDS)
-
     # The reduced session expiry time during the third party login pipeline. (Value in seconds)
     SOCIAL_AUTH_PIPELINE_TIMEOUT = config(
         "SOCIAL_AUTH_PIPELINE_TIMEOUT", default=600, formatter=int
@@ -1222,7 +1213,6 @@ CREDIT_PROVIDER_SECRET_KEYS = config(
 ##################### LTI Provider #####################
 if FEATURES.get("ENABLE_LTI_PROVIDER"):
     INSTALLED_APPS.append("lti_provider.apps.LtiProviderConfig")
-    AUTHENTICATION_BACKENDS.append("lti_provider.users.LtiBackend")
 
 LTI_USER_EMAIL_DOMAIN = config("LTI_USER_EMAIL_DOMAIN", default="lti.example.com")
 


### PR DESCRIPTION
## Purpose

Due to very heavy traffic during Coronavirus confinement , we found out that Open edX rate limiting authentication backend does not work properly behind a proxy. Indeed, it is using the `REMOTE_ADDR` header to determine a request's end user IP address. 

When placed behind a proxy, the actual end user IP address is found in the `X-Forwarded-For` header.

## Proposal

- Add a custom rate limiting authentication backend based on the X-Forwarded-For header,
- Refactor the way authentication backends are defined to make it more straightforward.
