### PR TITLE
Dogwood.3 fun upgrade funapps to 5.4.0

### DIFF
--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade `fun-apps` to `5.4.0` to add a "browsable" status for courses in the catalog
+
 ## [dogwood.3-fun-1.10.0] - 2020-03-25
 
 ### Added

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-1.11.0] - 2020-04-01
+
 ### Changed
 
 - Upgrade `fun-apps` to `5.4.0` to add a "browsable" status for courses in the catalog
@@ -247,7 +249,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.10.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.11.0...HEAD
+[dogwood.3-fun-1.11.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.10.0...dogwood.3-fun-1.11.0
 [dogwood.3-fun-1.10.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.9.2...dogwood.3-fun-1.10.0
 [dogwood.3-fun-1.9.2]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.9.1...dogwood.3-fun-1.9.2
 [dogwood.3-fun-1.9.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.9.0...dogwood.3-fun-1.9.1

--- a/releases/dogwood/3/fun/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/lms/docker_run_production.py
@@ -1191,7 +1191,6 @@ INSTALLED_APPS += (
     "backoffice",
     "bootstrapform",
     "ckeditor",
-    "contact",
     "course_dashboard",
     "course_pages",
     "courses_api",
@@ -1334,7 +1333,6 @@ FAVICON_PATH = "fun/images/favicon.ico"
 # See Xblock i18n: http://www.libremente.eu/2017/12/06/edx-translation/
 LOCALIZED_FUN_APPS = [
     "backoffice",
-    "contact",
     "course_dashboard",
     "course_pages",
     "courses",

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -4,7 +4,7 @@
 # ==== core ====
 edx-gea==0.2.0
 fonzie==0.2.0
-fun-apps==5.3.1
+fun-apps==5.4.0
 
 # ==== xblocks ====
 configurable_lti_consumer-xblock==1.3.0


### PR DESCRIPTION
## Purpose

On [fun-mooc.fr](https://www.fun-mooc.fr), we want to introduce a new status for courses in the catalog that are finished but still open for enrollment. They can be accessed by students even though there is no more activity and follow-up by a teacher.

We can call this new state : "browsable". 

## Proposal

The feature was implemented in [fun-apps v5.4.0](https://github.com/openfun/fun-apps/releases/tag/v5.4.0). This PR upgrades `openedx-docker` to this version of [fun-apps](https://github.com/openfun/fun-apps) and publishes it as a minor release.
