### PR TITLE
✨(dogwood/3/fun) add django-redis-sentinel-redux

### DIFF
--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -18,6 +18,10 @@ release.
 
 - Configure most Django cache backends to Redis
 
+### Removed
+
+- Remove now useless Memcached settings
+
 
 ## [dogwood.3-fun-1.11.0] - 2020-04-01
 

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,16 @@ release.
 
 ## [Unreleased]
 
+### Added
+
+- Add `django-redis-sentinel-redux` to use make possible the use of
+  Redis Sentinel for Django cache
+
+### Changed
+
+- Configure most Django cache backends to Redis
+
+
 ## [dogwood.3-fun-1.11.0] - 2020-04-01
 
 ### Changed

--- a/releases/dogwood/3/fun/config/cms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/cms/docker_run_production.py
@@ -164,48 +164,67 @@ LOG_DIR = config("LOG_DIR", default=path("/edx/var/logs/edx"), formatter=path)
 MEMCACHED_HOST = config("MEMCACHED_HOST", default="memcached")
 MEMCACHED_PORT = config("MEMCACHED_PORT", default=11211, formatter=int)
 
+CACHE_REDIS_HOST = config("CACHE_REDIS_HOST", default="redis")
+CACHE_REDIS_PORT = config("CACHE_REDIS_PORT", default=6379, formatter=int)
+CACHE_REDIS_DB = config("CACHE_REDIS_DB", default=1, formatter=int)
+CACHE_REDIS_URI = "redis://{}:{}/{}".format(CACHE_REDIS_HOST, CACHE_REDIS_PORT, CACHE_REDIS_DB)
+CACHE_REDIS_BACKEND = config("CACHE_REDIS_BACKEND", default="django_redis.cache.RedisCache")
+CACHE_REDIS_CLIENT = config("CACHE_REDIS_CLIENT", default="django_redis.client.DefaultClient")
+
 CACHES = config(
     "CACHES",
     default={
         "default": {
-            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
-            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
-            "KEY_FUNCTION": "util.memcache.safe_key",
+            "BACKEND": CACHE_REDIS_BACKEND,
+            "LOCATION": CACHE_REDIS_URI,
             "KEY_PREFIX": "default",
+            "OPTIONS": {
+              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
+            },
         },
         "general": {
-            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
-            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
-            "KEY_FUNCTION": "util.memcache.safe_key",
+            "BACKEND": CACHE_REDIS_BACKEND,
+            "LOCATION": CACHE_REDIS_URI,
             "KEY_PREFIX": "general",
+            "OPTIONS": {
+              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
+            },
         },
         "loc_cache": {
             "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
             "LOCATION": "edx_location_mem_cache",
         },
         "celery": {
-            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
-            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
-            "KEY_FUNCTION": "util.memcache.safe_key",
+            "BACKEND": CACHE_REDIS_BACKEND,
+            "LOCATION": CACHE_REDIS_URI,
             "KEY_PREFIX": "celery",
+            "OPTIONS": {
+              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
+            },
         },
         "mongo_metadata_inheritance": {
-            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
-            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
-            "KEY_FUNCTION": "util.memcache.safe_key",
+            "BACKEND": CACHE_REDIS_BACKEND,
+            "LOCATION": CACHE_REDIS_URI,
             "KEY_PREFIX": "mongo_metadata_inheritance",
+            "OPTIONS": {
+              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
+            },
         },
         "openassessment_submissions": {
-            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
-            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
-            "KEY_FUNCTION": "util.memcache.safe_key",
+            "BACKEND": CACHE_REDIS_BACKEND,
+            "LOCATION": CACHE_REDIS_URI,
             "KEY_PREFIX": "openassessment_submissions",
+            "OPTIONS": {
+              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
+            },
         },
         "staticfiles": {
-            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
-            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
-            "KEY_FUNCTION": "util.memcache.safe_key",
+            "BACKEND": CACHE_REDIS_BACKEND,
+            "LOCATION":CACHE_REDIS_URI,
             "KEY_PREFIX": "staticfiles",
+            "OPTIONS": {
+              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
+            },
         },
     },
     formatter=json.loads,

--- a/releases/dogwood/3/fun/config/cms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/cms/docker_run_production.py
@@ -187,10 +187,6 @@ CACHES = config(
               "CLIENT_CLASS": CACHE_REDIS_CLIENT,
             },
         },
-        "loc_cache": {
-            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-            "LOCATION": "edx_location_mem_cache",
-        },
         "celery": {
             "BACKEND": CACHE_REDIS_BACKEND,
             "LOCATION": CACHE_REDIS_URI,
@@ -215,13 +211,14 @@ CACHES = config(
               "CLIENT_CLASS": CACHE_REDIS_CLIENT,
             },
         },
+        "loc_cache": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "edx_location_mem_cache",
+        },
+        # Cache backend used by Django 1.8 storage backend while processing static files
         "staticfiles": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION":CACHE_REDIS_URI,
-            "KEY_PREFIX": "staticfiles",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "edx_location_mem_cache",
         },
     },
     formatter=json.loads,

--- a/releases/dogwood/3/fun/config/cms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/cms/docker_run_production.py
@@ -161,9 +161,6 @@ ALLOWED_HOSTS = config(
 
 LOG_DIR = config("LOG_DIR", default=path("/edx/var/logs/edx"), formatter=path)
 
-MEMCACHED_HOST = config("MEMCACHED_HOST", default="memcached")
-MEMCACHED_PORT = config("MEMCACHED_PORT", default=11211, formatter=int)
-
 CACHE_REDIS_HOST = config("CACHE_REDIS_HOST", default="redis")
 CACHE_REDIS_PORT = config("CACHE_REDIS_PORT", default=6379, formatter=int)
 CACHE_REDIS_DB = config("CACHE_REDIS_DB", default=1, formatter=int)

--- a/releases/dogwood/3/fun/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/lms/docker_run_production.py
@@ -260,9 +260,6 @@ if config("SESSION_COOKIE_NAME", default=None):
     # being a str()
     SESSION_COOKIE_NAME = str(config("SESSION_COOKIE_NAME"))
 
-MEMCACHED_HOST = config("MEMCACHED_HOST", default="memcached")
-MEMCACHED_PORT = config("MEMCACHED_PORT", default=11211, formatter=int)
-
 CACHE_REDIS_HOST = config("CACHE_REDIS_HOST", default="redis")
 CACHE_REDIS_PORT = config("CACHE_REDIS_PORT", default=6379, formatter=int)
 CACHE_REDIS_DB = config("CACHE_REDIS_DB", default=1, formatter=int)

--- a/releases/dogwood/3/fun/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/lms/docker_run_production.py
@@ -263,48 +263,67 @@ if config("SESSION_COOKIE_NAME", default=None):
 MEMCACHED_HOST = config("MEMCACHED_HOST", default="memcached")
 MEMCACHED_PORT = config("MEMCACHED_PORT", default=11211, formatter=int)
 
+CACHE_REDIS_HOST = config("CACHE_REDIS_HOST", default="redis")
+CACHE_REDIS_PORT = config("CACHE_REDIS_PORT", default=6379, formatter=int)
+CACHE_REDIS_DB = config("CACHE_REDIS_DB", default=1, formatter=int)
+CACHE_REDIS_URI = "redis://{}:{}/{}".format(CACHE_REDIS_HOST, CACHE_REDIS_PORT, CACHE_REDIS_DB)
+CACHE_REDIS_BACKEND = config("CACHE_REDIS_BACKEND", default="django_redis.cache.RedisCache")
+CACHE_REDIS_CLIENT = config("CACHE_REDIS_CLIENT", default="django_redis.client.DefaultClient")
+
 CACHES = config(
     "CACHES",
     default={
         "default": {
-            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
-            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
-            "KEY_FUNCTION": "util.memcache.safe_key",
+            "BACKEND": CACHE_REDIS_BACKEND,
+            "LOCATION": CACHE_REDIS_URI,
             "KEY_PREFIX": "default",
+            "OPTIONS": {
+              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
+            },
         },
         "general": {
-            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
-            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
-            "KEY_FUNCTION": "util.memcache.safe_key",
+            "BACKEND": CACHE_REDIS_BACKEND,
+            "LOCATION": CACHE_REDIS_URI,
             "KEY_PREFIX": "general",
+            "OPTIONS": {
+              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
+            },
         },
         "loc_cache": {
             "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
             "LOCATION": "edx_location_mem_cache",
         },
         "celery": {
-            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
-            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
-            "KEY_FUNCTION": "util.memcache.safe_key",
+            "BACKEND": CACHE_REDIS_BACKEND,
+            "LOCATION": CACHE_REDIS_URI,
             "KEY_PREFIX": "celery",
+            "OPTIONS": {
+              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
+            },
         },
         "mongo_metadata_inheritance": {
-            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
-            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
-            "KEY_FUNCTION": "util.memcache.safe_key",
+            "BACKEND": CACHE_REDIS_BACKEND,
+            "LOCATION": CACHE_REDIS_URI,
             "KEY_PREFIX": "mongo_metadata_inheritance",
+            "OPTIONS": {
+              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
+            },
         },
         "openassessment_submissions": {
-            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
-            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
-            "KEY_FUNCTION": "util.memcache.safe_key",
+            "BACKEND": CACHE_REDIS_BACKEND,
+            "LOCATION": CACHE_REDIS_URI,
             "KEY_PREFIX": "openassessment_submissions",
+            "OPTIONS": {
+              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
+            },
         },
         "staticfiles": {
-            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
-            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
-            "KEY_FUNCTION": "util.memcache.safe_key",
+            "BACKEND": CACHE_REDIS_BACKEND,
+            "LOCATION":CACHE_REDIS_URI,
             "KEY_PREFIX": "staticfiles",
+            "OPTIONS": {
+              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
+            },
         },
     },
     formatter=json.loads,

--- a/releases/dogwood/3/fun/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/lms/docker_run_production.py
@@ -286,10 +286,6 @@ CACHES = config(
               "CLIENT_CLASS": CACHE_REDIS_CLIENT,
             },
         },
-        "loc_cache": {
-            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-            "LOCATION": "edx_location_mem_cache",
-        },
         "celery": {
             "BACKEND": CACHE_REDIS_BACKEND,
             "LOCATION": CACHE_REDIS_URI,
@@ -314,13 +310,14 @@ CACHES = config(
               "CLIENT_CLASS": CACHE_REDIS_CLIENT,
             },
         },
+        "loc_cache": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "edx_location_mem_cache",
+        },
+        # Cache backend used by Django 1.8 storage backend while processing static files
         "staticfiles": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION":CACHE_REDIS_URI,
-            "KEY_PREFIX": "staticfiles",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "edx_location_mem_cache",
         },
     },
     formatter=json.loads,

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -18,6 +18,8 @@ xblock-utils2==0.3.0
 
 # ==== third-party apps ====
 celery-redis-sentinel==0.3.0
+django-redis==4.8.0  # Force django-redis 4.8.0 to keep Django==1.8
+django-redis-sentinel-redux==0.2.0
 django-redis-sessions==0.6.1
 raven==6.9.0
 redis==2.10.6


### PR DESCRIPTION
We want to use Redis Sentinel to improve Django cache reliability,
here we add related dependencies and set default caches backend to Redis 
and MemLoc.