### PR TITLE
WIP 🐛(flavors/*) set basic authentification backend for dev. environments

### DIFF
--- a/releases/dogwood/3/bare/CHANGELOG.md
+++ b/releases/dogwood/3/bare/CHANGELOG.md
@@ -16,6 +16,7 @@ release.
 ### Changed
 
 - Refactor the way authentication backends are configured to make it straightforward
+- Set basic authentification backend for development environment
 
 ## [dogwood.3-1.2.2] - 2020-03-13
 
@@ -35,7 +36,7 @@ release.
 
 ### Added
 
-- Make Gunicorn timeout, workers and threads configurable via 
+- Make Gunicorn timeout, workers and threads configurable via
   an environment variable
 - Configure all cache backends
 

--- a/releases/dogwood/3/bare/config/lms/docker_run_development.py
+++ b/releases/dogwood/3/bare/config/lms/docker_run_development.py
@@ -1,6 +1,8 @@
 # This file includes overrides to build the `development` environment for the LMS starting from the
 # settings of the `production` environment
 
+import json
+
 from docker_run_production import *
 from .utils import Configuration
 
@@ -21,3 +23,9 @@ PIPELINE_ENABLED = False
 STATICFILES_STORAGE = "openedx.core.storage.DevelopmentStorage"
 
 ALLOWED_HOSTS = ["*"]
+
+AUTHENTICATION_BACKENDS = config(
+    "AUTHENTICATION_BACKENDS",
+    default=["django.contrib.auth.backends.ModelBackend"],
+    formatter=json.loads
+)

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Changed
+
+- Set basic authentification backend for development environment
+
 ## [dogwood.3-fun-1.12.0] - 2020-04-07
 
 ### Added

--- a/releases/dogwood/3/fun/config/lms/docker_run_development.py
+++ b/releases/dogwood/3/fun/config/lms/docker_run_development.py
@@ -1,5 +1,8 @@
 # This file includes overrides to build the `development` environment for the LMS starting from the
 # settings of the `production` environment
+
+import json
+
 from docker_run_production import *
 from .utils import Configuration
 
@@ -28,4 +31,10 @@ ORA2_FILEUPLOAD_BACKEND = "filesystem"
 ORA2_FILEUPLOAD_ROOT = os.path.join(SHARED_ROOT, "openassessment_submissions")
 ORA2_FILEUPLOAD_CACHE_ROOT = os.path.join(
     SHARED_ROOT, "openassessment_submissions_cache"
+)
+
+AUTHENTICATION_BACKENDS = config(
+    "AUTHENTICATION_BACKENDS",
+    default=["django.contrib.auth.backends.ModelBackend"],
+    formatter=json.loads
 )

--- a/releases/eucalyptus/3/bare/CHANGELOG.md
+++ b/releases/eucalyptus/3/bare/CHANGELOG.md
@@ -16,6 +16,7 @@ release.
 ### Changed
 
 - Refactor the way authentication backends are configured to make it straightforward
+- Set basic authentification backend for development environment
 
 ## [eucalyptus.3-1.1.2] - 2020-03-13
 
@@ -34,7 +35,7 @@ release.
 
 ### Added
 
-- Make Gunicorn timeout, workers and threads configurable via an environment 
+- Make Gunicorn timeout, workers and threads configurable via an environment
   variable
 - Configure all cache backends
 

--- a/releases/eucalyptus/3/bare/config/lms/docker_run_development.py
+++ b/releases/eucalyptus/3/bare/config/lms/docker_run_development.py
@@ -1,6 +1,8 @@
 # This file includes overrides to build the `development` environment for the LMS starting from the
 # settings of the `production` environment
 
+import json
+
 from docker_run_production import *
 from .utils import Configuration
 
@@ -21,3 +23,9 @@ PIPELINE_ENABLED = False
 STATICFILES_STORAGE = "openedx.core.storage.DevelopmentStorage"
 
 ALLOWED_HOSTS = ["*"]
+
+AUTHENTICATION_BACKENDS = config(
+    "AUTHENTICATION_BACKENDS",
+    default=["django.contrib.auth.backends.ModelBackend"],
+    formatter=json.loads
+)

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Changed
+
+- Set basic authentification backend for development environment
+
 ## [eucalyptus.3-wb-1.8.0] - 2020-04-03
 
 ### Added

--- a/releases/eucalyptus/3/wb/config/lms/docker_run_development.py
+++ b/releases/eucalyptus/3/wb/config/lms/docker_run_development.py
@@ -1,6 +1,8 @@
 # This file includes overrides to build the `development` environment for the LMS starting from the
 # settings of the `production` environment
 
+import json
+
 from docker_run_production import *
 from .utils import Configuration
 
@@ -22,3 +24,9 @@ STATICFILES_STORAGE = "openedx.core.storage.DevelopmentStorage"
 
 ALLOWED_HOSTS = ["*"]
 FEATURES["AUTOMATIC_AUTH_FOR_TESTING"] = True
+
+AUTHENTICATION_BACKENDS = config(
+    "AUTHENTICATION_BACKENDS",
+    default=["django.contrib.auth.backends.ModelBackend"],
+    formatter=json.loads
+)

--- a/releases/hawthorn/1/bare/CHANGELOG.md
+++ b/releases/hawthorn/1/bare/CHANGELOG.md
@@ -16,6 +16,7 @@ release.
 ### Changed
 
 - Refactor the way authentication backends are configured to make it straightforward
+- Set basic authentification backend for development environment
 
 ### Fixed
 

--- a/releases/hawthorn/1/bare/config/lms/docker_run_development.py
+++ b/releases/hawthorn/1/bare/config/lms/docker_run_development.py
@@ -1,6 +1,8 @@
 # This file includes overrides to build the `development` environment for the LMS starting from the
 # settings of the `production` environment
 
+import json
+
 from docker_run_production import *
 from .utils import Configuration
 
@@ -23,3 +25,9 @@ STATICFILES_STORAGE = "openedx.core.storage.DevelopmentStorage"
 ALLOWED_HOSTS = ["*"]
 
 WEBPACK_CONFIG_PATH = "webpack.dev.config.js"
+
+AUTHENTICATION_BACKENDS = config(
+    "AUTHENTICATION_BACKENDS",
+    default=["django.contrib.auth.backends.ModelBackend"],
+    formatter=json.loads
+)

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -16,6 +16,7 @@ release.
 ### Changed
 
 - Refactor the way authentication backends are configured to make it straightforward
+- Set basic authentification backend for development environment
 
 ### Fixed
 

--- a/releases/hawthorn/1/oee/config/lms/docker_run_development.py
+++ b/releases/hawthorn/1/oee/config/lms/docker_run_development.py
@@ -1,6 +1,8 @@
 # This file includes overrides to build the `development` environment for the LMS starting from the
 # settings of the `production` environment
 
+import json
+
 from docker_run_production import *
 from .utils import Configuration
 
@@ -23,3 +25,9 @@ STATICFILES_STORAGE = "openedx.core.storage.DevelopmentStorage"
 ALLOWED_HOSTS = ["*"]
 
 WEBPACK_CONFIG_PATH = "webpack.dev.config.js"
+
+AUTHENTICATION_BACKENDS = config(
+    "AUTHENTICATION_BACKENDS",
+    default=["django.contrib.auth.backends.ModelBackend"],
+    formatter=json.loads
+)

--- a/releases/master/bare/config/lms/docker_run_development.py
+++ b/releases/master/bare/config/lms/docker_run_development.py
@@ -1,6 +1,8 @@
 # This file includes overrides to build the `development` environment for the LMS starting from the
 # settings of the `production` environment
 
+import json
+
 from docker_run_production import *
 from .utils import Configuration
 
@@ -23,3 +25,9 @@ STATICFILES_STORAGE = "openedx.core.storage.DevelopmentStorage"
 ALLOWED_HOSTS = ["*"]
 
 WEBPACK_CONFIG_PATH = "webpack.dev.config.js"
+
+AUTHENTICATION_BACKENDS = config(
+    "AUTHENTICATION_BACKENDS",
+    default=["django.contrib.auth.backends.ModelBackend"],
+    formatter=json.loads
+)


### PR DESCRIPTION
In a previous modification we changed rate limit authentification
backend to work behind proxies and it brokes development images because
it can't work with Django development server as it does not set
HTTP_X_FORWARDED_FOR header.
