### PR TITLE
🐛(dogwood/3/fun) pin `django-redis` version to 4.5.0

### DIFF
--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -13,6 +13,10 @@ release.
 
 - Set basic authentification backend for development environment
 
+### Fixed
+
+- Pin `django-redis` to version 4.5.0
+
 ## [dogwood.3-fun-1.12.0] - 2020-04-07
 
 ### Added

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -18,7 +18,7 @@ xblock-utils2==0.3.0
 
 # ==== third-party apps ====
 celery-redis-sentinel==0.3.0
-django-redis==4.8.0  # Force django-redis 4.8.0 to keep Django==1.8
+django-redis==4.5.0  # Force django-redis 4.5.0 to keep Django==1.8
 django-redis-sentinel-redux==0.2.0
 django-redis-sessions==0.6.1
 raven==6.9.0


### PR DESCRIPTION
In `dogwood.3-fun-1.12.0` we wrongly pined `django-redis` version to 4.8.0
to maintain `django-redis-sentinel-redux` compatible with Django 1.8