### PR TITLE
Release hawthorn.1 oee 3.2.0

### DIFF
--- a/releases/hawthorn/1/bare/CHANGELOG.md
+++ b/releases/hawthorn/1/bare/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [hawthorn.1-3.2.0] - 2020-04-08
+
 ### Added
 
 - Rate limiting authentication backend that works behind proxies
@@ -232,7 +234,8 @@ result of updating our OpenEdX images from `ginkgo` to `hawthorn.1`. It is not
 functional and is intended for development and debugging work in
 [Arnold](https://github.com/openfun/arnold).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-3.1.1...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-3.2.0...HEAD
+[hawthorn.1-3.2.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-3.1.1...hawthorn.1-3.2.0
 [hawthorn.1-3.1.1]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-3.1.0...hawthorn.1-3.1.1
 [hawthorn.1-3.1.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-3.0.0...hawthorn.1-3.1.0
 [hawthorn.1-3.0.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-2.8.0...hawthorn.1-3.0.0

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [hawthorn.1-oee-3.2.0] - 2020-04-08
+
 ### Added
 
 - Rate limiting authentication backend that works behind proxies
@@ -274,7 +276,8 @@ First release of OpenEdx extended.
 
 - Add a configurable LTI consumer xblock
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-3.1.2...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-3.2.0..HEAD
+[hawthorn.1-oee-3.2.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.1.2...hawthorn.1-oee-3.2.0
 [hawthorn.1-oee-3.1.2]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.1.1...hawthorn.1-oee-3.1.2
 [hawthorn.1-oee-3.1.1]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.1.0...hawthorn.1-oee-3.1.1
 [hawthorn.1-oee-3.1.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.0.0...hawthorn.1-oee-3.1.0


### PR DESCRIPTION
## hawthorn.1-3.2.0 - 2020-04-08

### Added

- Rate limiting authentication backend that works behind proxies

### Changed

- Refactor the way authentication backends are configured to make it straightforward
- Set basic authentification backend for development environment

### Fixed

- Remove hardcoded FILE_UPLOAD_STORAGE_BUCKET_NAME value to make sure it is configurable

## hawthorn.1-oee-3.2.0 - 2020-04-08

### Added

- Rate limiting authentication backend that works behind proxies

### Changed

- Refactor the way authentication backends are configured to make it straightforward
- Set basic authentification backend for development environment

### Fixed

- Remove hardcoded FILE_UPLOAD_STORAGE_BUCKET_NAME value to make sure it is configurable