### PR TITLE
Refactor static files generation to avoid collectstatic during deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,8 +155,8 @@ collectstatic: \
   tree \
   run
 collectstatic:  ## copy static assets to static root directory
-	$(MANAGE_LMS) collectstatic --noinput --settings=fun.docker_run
-	$(MANAGE_CMS) collectstatic --noinput --settings=fun.docker_run
+	$(COMPOSE_RUN) -v $(PWD)/$(FLAVORED_EDX_RELEASE_PATH)/data/static/production:/edx/app/edxapp/staticfiles lms python manage.py lms collectstatic --noinput --settings=fun.docker_run
+	$(COMPOSE_RUN) -v $(PWD)/$(FLAVORED_EDX_RELEASE_PATH)/data/static/production:/edx/app/edxapp/staticfiles cms python manage.py cms collectstatic --noinput --settings=fun.docker_run
 .PHONY: collectstatic
 
 create-symlinks:  ## create symlinks to local configuration (mounted via a volume)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,6 @@ services:
       SERVICE_VARIANT: lms
       DJANGO_SETTINGS_MODULE: lms.envs.fun.docker_run
     volumes:
-      - ./${FLAVORED_EDX_RELEASE_PATH:-releases/master/bare}/data/static/production:/edx/app/edxapp/staticfiles
       - ./${FLAVORED_EDX_RELEASE_PATH:-releases/master/bare}/data/media:/edx/var/edxapp/media
       - ./${FLAVORED_EDX_RELEASE_PATH:-releases/master/bare}/data/store:/edx/app/edxapp/data
       - ./${FLAVORED_EDX_RELEASE_PATH:-releases/master/bare}/data/export:/edx/var/edxapp/export
@@ -124,7 +123,6 @@ services:
       SERVICE_VARIANT: cms
       DJANGO_SETTINGS_MODULE: cms.envs.fun.docker_run
     volumes:
-      - ./${FLAVORED_EDX_RELEASE_PATH:-releases/master/bare}/data/static/production:/edx/app/edxapp/staticfiles
       - ./${FLAVORED_EDX_RELEASE_PATH:-releases/master/bare}/data/media:/edx/var/edxapp/media
       - ./${FLAVORED_EDX_RELEASE_PATH:-releases/master/bare}/data/store:/edx/app/edxapp/data
       - ./${FLAVORED_EDX_RELEASE_PATH:-releases/master/bare}/config:/config

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,12 @@ release.
 
 ## [Unreleased]
 
+### Added
+
+- Allow serving static files via a CDN
+- A static files storage backend based on a manifest file instead of cache so
+  that `edxapp` can run without any access to its static files at runtime
+
 ## [dogwood.3-fun-1.12.1] - 2020-04-08
 
 ### Changed

--- a/releases/dogwood/3/fun/Dockerfile
+++ b/releases/dogwood/3/fun/Dockerfile
@@ -165,10 +165,8 @@ RUN pip install -r requirements/edx/local.txt
 # setup.cfg declarative packages)
 RUN pip install -r requirements/edx/fun.txt
 
-# Update assets skipping collectstatic (it should be done during deployment)
-RUN NO_PREREQ_INSTALL=1 \
-    paver update_assets --settings=fun.docker_build --skip-collect
-
+# Update assets and run collectstatic to generate the manifest file
+RUN NO_PREREQ_INSTALL=1 paver update_assets --settings=fun.docker_build_production
 
 # === DEVELOPMENT ===
 FROM builder as development
@@ -259,6 +257,10 @@ COPY --from=builder /usr/local /usr/local
 
 # Copy modified sources (sic!)
 COPY --from=builder /edx/app/edxapp/edx-platform  /edx/app/edxapp/edx-platform
+
+# Copy static files manifests so they are available even for set-ups that use the edxapp-nginx image
+COPY --from=builder /edx/app/edxapp/staticfiles/studio/staticfiles.json /edx/app/edxapp/staticfiles/studio/staticfiles.json
+COPY --from=builder /edx/app/edxapp/staticfiles/staticfiles.json /edx/app/edxapp/staticfiles/staticfiles.json
 
 # Now that dependencies are installed and configuration has been set, the above
 # statements will run with a un-privileged user.

--- a/releases/dogwood/3/fun/config/cms/docker_build.py
+++ b/releases/dogwood/3/fun/config/cms/docker_build.py
@@ -1,8 +1,0 @@
-from ..common import *
-
-# This is a minimal settings file allowing us to run "update_assets"
-# in the Dockerfile
-
-DATABASES = {"default": {}}
-
-XQUEUE_INTERFACE = {"url": None, "django_auth": None}

--- a/releases/dogwood/3/fun/config/cms/docker_build_development.py
+++ b/releases/dogwood/3/fun/config/cms/docker_build_development.py
@@ -1,1 +1,8 @@
-docker_build.py
+# This is a minimal settings file allowing us to run "update_assets"
+# in the Dockerfile
+from .docker_run_production import *
+
+DATABASES = {"default": {}}
+
+XQUEUE_INTERFACE = {"url": None, "django_auth": None}
+

--- a/releases/dogwood/3/fun/config/cms/docker_build_production.py
+++ b/releases/dogwood/3/fun/config/cms/docker_build_production.py
@@ -1,1 +1,8 @@
-docker_build.py
+# This is a minimal settings file allowing us to run "update_assets"
+# in the Dockerfile
+from .docker_run_production import *
+
+DATABASES = {"default": {}}
+
+XQUEUE_INTERFACE = {"url": None, "django_auth": None}
+

--- a/releases/dogwood/3/fun/config/cms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/cms/docker_run_production.py
@@ -135,6 +135,7 @@ STATIC_ROOT = path("/edx/app/edxapp/staticfiles/studio")
 STATICFILES_STORAGE = config(
     "STATICFILES_STORAGE", default="cms.envs.fun.storage.CMSManifestStaticFilesStorage"
 )
+CDN_BASE_URL = config("CDN_BASE_URL", default=None)
 
 MEDIA_ROOT = path("/edx/var/edxapp/media/")
 MEDIA_URL = "/media/"

--- a/releases/dogwood/3/fun/config/cms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/cms/docker_run_production.py
@@ -132,8 +132,9 @@ STATIC_URL_BASE = "/static/"
 STATIC_URL = "/static/studio/"
 STATIC_ROOT_BASE = path("/edx/app/edxapp/staticfiles")
 STATIC_ROOT = path("/edx/app/edxapp/staticfiles/studio")
-STATICFILES_STORAGE = "pipeline.storage.PipelineCachedStorage"
-PIPELINE = True
+STATICFILES_STORAGE = config(
+    "STATICFILES_STORAGE", default="cms.envs.fun.storage.CMSManifestStaticFilesStorage"
+)
 
 MEDIA_ROOT = path("/edx/var/edxapp/media/")
 MEDIA_URL = "/media/"

--- a/releases/dogwood/3/fun/config/cms/storage.py
+++ b/releases/dogwood/3/fun/config/cms/storage.py
@@ -1,0 +1,28 @@
+"""
+Django file storage backends for the CMS that works behind a CDN.
+"""
+from django.conf import settings
+from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
+
+from pipeline.storage import PipelineMixin
+
+
+class CMSManifestStaticFilesStorage(
+    PipelineMixin, ManifestStaticFilesStorage
+):
+    """
+    This static files storage backend works when static files are in the `edxapp-nginx` image,
+    eventually placed behing a CDN.
+
+    PipelineMixin: https://github.com/jazzband/django-pipeline
+    """
+
+    def url(self, name, force=False):
+        """Prepend static files path by the CDN base url when configured in settings."""
+        url = super(CMSManifestStaticFilesStorage, self).url(name, force=force)
+
+        cdn_base_url = getattr(settings, "CDN_BASE_URL", None)
+        if cdn_base_url:
+            url = "{:s}{:s}".format(cdn_base_url, url)
+
+        return url

--- a/releases/dogwood/3/fun/config/lms/docker_build.py
+++ b/releases/dogwood/3/fun/config/lms/docker_build.py
@@ -1,8 +1,0 @@
-from ..common import *
-
-# This is a minimal settings file allowing us to run "update_assets"
-# in the Dockerfile
-
-DATABASES = {"default": {}}
-
-XQUEUE_INTERFACE = {"url": None, "django_auth": None}

--- a/releases/dogwood/3/fun/config/lms/docker_build_development.py
+++ b/releases/dogwood/3/fun/config/lms/docker_build_development.py
@@ -1,1 +1,8 @@
-docker_build.py
+# This is a minimal settings file allowing us to run "update_assets"
+# in the Dockerfile
+from .docker_run_development import *
+
+DATABASES = {"default": {}}
+
+XQUEUE_INTERFACE = {"url": None, "django_auth": None}
+

--- a/releases/dogwood/3/fun/config/lms/docker_build_production.py
+++ b/releases/dogwood/3/fun/config/lms/docker_build_production.py
@@ -1,1 +1,8 @@
-docker_build.py
+# This is a minimal settings file allowing us to run "update_assets"
+# in the Dockerfile
+from .docker_run_production import *
+
+DATABASES = {"default": {}}
+
+XQUEUE_INTERFACE = {"url": None, "django_auth": None}
+

--- a/releases/dogwood/3/fun/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/lms/docker_run_production.py
@@ -143,6 +143,7 @@ MEDIA_URL = "/media/"
 STATICFILES_STORAGE = config(
     "STATICFILES_STORAGE", default="lms.envs.fun.storage.LMSManifestStaticFilesStorage"
 )
+CDN_BASE_URL = config("CDN_BASE_URL", default=None)
 
 # DEFAULT_COURSE_ABOUT_IMAGE_URL specifies the default image to show for courses that don't provide one
 DEFAULT_COURSE_ABOUT_IMAGE_URL = config(

--- a/releases/dogwood/3/fun/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/lms/docker_run_production.py
@@ -140,6 +140,10 @@ STATIC_URL = "/static/"
 MEDIA_ROOT = path("/edx/var/edxapp/media/")
 MEDIA_URL = "/media/"
 
+STATICFILES_STORAGE = config(
+    "STATICFILES_STORAGE", default="lms.envs.fun.storage.LMSManifestStaticFilesStorage"
+)
+
 # DEFAULT_COURSE_ABOUT_IMAGE_URL specifies the default image to show for courses that don't provide one
 DEFAULT_COURSE_ABOUT_IMAGE_URL = config(
     "DEFAULT_COURSE_ABOUT_IMAGE_URL", default=DEFAULT_COURSE_ABOUT_IMAGE_URL

--- a/releases/dogwood/3/fun/config/lms/storage.py
+++ b/releases/dogwood/3/fun/config/lms/storage.py
@@ -1,6 +1,7 @@
 """
 Django file storage backend for the LMS that works behind a CDN.
 """
+from django.conf import settings
 from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
 
 from pipeline.storage import PipelineMixin
@@ -11,8 +12,20 @@ class LMSManifestStaticFilesStorage(
     OptimizedFilesMixin, PipelineMixin, ManifestStaticFilesStorage
 ):
     """
-    This static files storage backend works when static files are in the `edxapp-nginx` image.
+    This static files storage backend works when static files are in the `edxapp-nginx` image,
+    eventually placed behing a CDN.
+
     OptimizedFilesMixin: https://github.com/etianen/django-require
     PipelineMixin: https://github.com/jazzband/django-pipeline
     """
+
+    def url(self, name, force=False):
+        """Prepend static files path by the CDN base url when configured in settings."""
+        url = super(LMSManifestStaticFilesStorage, self).url(name, force=force)
+
+        cdn_base_url = getattr(settings, "CDN_BASE_URL", None)
+        if cdn_base_url:
+            url = "{:s}{:s}".format(cdn_base_url, url)
+
+        return url
 

--- a/releases/dogwood/3/fun/config/lms/storage.py
+++ b/releases/dogwood/3/fun/config/lms/storage.py
@@ -1,0 +1,18 @@
+"""
+Django file storage backend for the LMS that works behind a CDN.
+"""
+from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
+
+from pipeline.storage import PipelineMixin
+from require.storage import OptimizedFilesMixin
+
+
+class LMSManifestStaticFilesStorage(
+    OptimizedFilesMixin, PipelineMixin, ManifestStaticFilesStorage
+):
+    """
+    This static files storage backend works when static files are in the `edxapp-nginx` image.
+    OptimizedFilesMixin: https://github.com/etianen/django-require
+    PipelineMixin: https://github.com/jazzband/django-pipeline
+    """
+


### PR DESCRIPTION
## Purpose

We recently [introduced a custom nginx-edxapp image](https://github.com/openfun/openedx-docker/pull/184)  that directly holds static files in order to serve them more efficiently with Kubernetes.

By doing this, we also thought we could speed up deployment because we would not need to run the `collectstatic` command upon each deployment. This last point was not successful because Open edX is using the `CachedStaticFilesStorage` by default, which needs to access static files in order to calculate their hash at runtime, when the application first encounters them.

Using the `ManifestStaticFilesStorage` backend should solve this issue and allow us to remove the static volume and stop running the `collectstatic` command upon deployment.

## Proposal

- [x] Add new static files storage backends for the lms and the cms, based on Django's `ManifestStaticFilesStorage` backend instead of `CachedStaticFilesStorage`,
- [x] Run the `collectstatic` command during image build and save only the manifest files to the production image,
- [x] In `docker-compose`, stop mounting the static directory in edxapp containers, in order to make sure that the application now works without accessing its static files,
- [x] Allow placing static files behind a CDN (while still using nginx as the origin).
