### PR TITLE
Release all flavors on 14/05/2020

### DIFF
--- a/releases/dogwood/3/bare/CHANGELOG.md
+++ b/releases/dogwood/3/bare/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-1.3.0] - 2020-05-14
+
 ### Added
 
 - Allow serving static files via a CDN
@@ -101,7 +103,8 @@ release.
 
 First experimental release of OpenEdx `dogwood.3` (bare flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-1.2.2...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-1.3.0...HEAD
+[dogwood.3-1.3.0]: https://github.com/openfun/openedx-docker/compare/tag/dogwood.3-1.2.2...dogwood.3-1.3.0
 [dogwood.3-1.2.2]: https://github.com/openfun/openedx-docker/compare/tag/dogwood.3-1.2.1...dogwood.3-1.2.2
 [dogwood.3-1.2.1]: https://github.com/openfun/openedx-docker/compare/tag/dogwood.3-1.2.0...dogwood.3-1.2.1
 [dogwood.3-1.2.0]: https://github.com/openfun/openedx-docker/compare/tag/dogwood.3-1.1.5...dogwood.3-1.2.0

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-1.13.0] - 2020-05-14
+
 ### Added
 
 - Allow serving static files via a CDN
@@ -283,7 +285,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.12.1...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.13.0...HEAD
+[dogwood.3-fun-1.13.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.12.1...dogwood.3-fun-1.13.0
 [dogwood.3-fun-1.12.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.12.0...dogwood.3-fun-1.12.1
 [dogwood.3-fun-1.12.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.11.0...dogwood.3-fun-1.12.0
 [dogwood.3-fun-1.11.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.10.0...dogwood.3-fun-1.11.0

--- a/releases/eucalyptus/3/bare/CHANGELOG.md
+++ b/releases/eucalyptus/3/bare/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [eucalyptus.3-1.2.0] - 2020-05-14
+
 ### Added
 
 - Allow serving static files via a CDN
@@ -92,7 +94,8 @@ release.
 
 - First experimental release of OpenEdx `eucalyptus.3` (bare flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.1.2...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.2.0...HEAD
+[eucalyptus.3-1.2.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.1.2...eucalyptus.3-1.2.0
 [eucalyptus.3-1.1.2]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.1.1...eucalyptus.3-1.1.2
 [eucalyptus.3-1.1.1]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.1.0...eucalyptus.3-1.1.1
 [eucalyptus.3-1.1.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.0.4...eucalyptus.3-1.1.0

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [eucalyptus.3-wb-1.9.0] - 2020-05-14
+
 ### Added
 
 - Allow serving static files via a CDN
@@ -17,8 +19,8 @@ release.
 
 ### Changed
 
-- Collect static files in the `edxapp` image so it can run without mounting a volume
-  for its static files in Kubernetes
+- Collect static files in the `edxapp` image so it can run without mounting a
+  volume for its static files in Kubernetes
 - Configure most Django cache backends to Redis
 
 ### Removed
@@ -229,7 +231,8 @@ release.
 - Set replicaSet and read_preference in mongodb connection
 - Add missing support for redis sentinel
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.8.1...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.9.0...HEAD
+[eucalyptus.3-wb-1.9.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.8.1...eucalyptus.3-wb-1.9.0
 [eucalyptus.3-wb-1.8.1]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.8.0...eucalyptus.3-wb-1.8.1
 [eucalyptus.3-wb-1.8.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.7.4...eucalyptus.3-wb-1.8.0
 [eucalyptus.3-wb-1.7.4]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.7.3...eucalyptus.3-wb-1.7.4

--- a/releases/hawthorn/1/bare/CHANGELOG.md
+++ b/releases/hawthorn/1/bare/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [hawthorn.1-3.3.0] - 2020-05-14
+
 ### Added
 
 - Allow serving static files via a CDN
@@ -243,7 +245,8 @@ result of updating our OpenEdX images from `ginkgo` to `hawthorn.1`. It is not
 functional and is intended for development and debugging work in
 [Arnold](https://github.com/openfun/arnold).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-3.2.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-3.3.0...HEAD
+[hawthorn.1-3.3.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-3.2.0...hawthorn.1-3.3.0
 [hawthorn.1-3.2.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-3.1.1...hawthorn.1-3.2.0
 [hawthorn.1-3.1.1]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-3.1.0...hawthorn.1-3.1.1
 [hawthorn.1-3.1.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-3.0.0...hawthorn.1-3.1.0

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [hawthorn.1-oee-3.3.0] - 2020-05-14
+
 ### Added
 
 - Allow serving static files via a CDN
@@ -292,7 +294,8 @@ First release of OpenEdx extended.
 
 - Add a configurable LTI consumer xblock
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-3.2.0..HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-3.3.0..HEAD
+[hawthorn.1-oee-3.3.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.2.0...hawthorn.1-oee-3.3.0
 [hawthorn.1-oee-3.2.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.1.2...hawthorn.1-oee-3.2.0
 [hawthorn.1-oee-3.1.2]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.1.1...hawthorn.1-oee-3.1.2
 [hawthorn.1-oee-3.1.1]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.1.0...hawthorn.1-oee-3.1.1


### PR DESCRIPTION
# dogwood.3-1.3.0

### Added

- Allow serving static files via a CDN
- Rate limiting authentication backend that works behind proxies

### Changed

- Collect static files in the `edxapp` image so it can run without mounting a volume
  for its static files in Kubernetes
- Refactor the way authentication backends are configured to make it straightforward
- Set basic authentification backend for development environment

# dogwood.3-fun-1.13.0

### Added

- Allow serving static files via a CDN

### Changed

- Collect static files in the `edxapp` image so it can run without mounting a volume
  for its static files in Kubernetes

# eucalyptus.3-1.2.0

### Added

- Allow serving static files via a CDN
- Rate limiting authentication backend that works behind proxies

### Changed

- Collect static files in the `edxapp` image so it can run without mounting a volume
  for its static files in Kubernetes
- Refactor the way authentication backends are configured to make it straightforward
- Set basic authentification backend for development environment

# eucalyptus.3-wb-1.9.0

### Added

- Allow serving static files via a CDN
- Add `django-redis-sentinel-redux` to allow the use of Redis Sentinel for
  Django cache

### Changed

- Collect static files in the `edxapp` image so it can run without mounting a
  volume for its static files in Kubernetes
- Configure most Django cache backends to Redis

### Removed

- Remove now useless Memcached settings

# hawthorn.1-3.3.0

### Added

- Allow serving static files via a CDN

### Changed

- Collect static files in the `edxapp` image so it can run without mounting a volume
  for its static files in Kubernetes

# hawthorn.1-oee-3.3.0

### Added

- Allow serving static files via a CDN
- Add `django-redis-sentinel-redux` to allow the use of Redis Sentinel for
  Django cache

### Changed

- Collect static files in the `edxapp` image so it can run without mounting a volume
  for its static files in Kubernetes
- Configure most Django cache backends to Redis

### Removed

- Remove now useless Memcached settings
