### PR TITLE
👷(circleci) fix image tag in circleci hub job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,8 @@ EDX_DEMO_ARCHIVE_URL      ?= https://github.com/edx/edx-demo-course/archive/$(ED
 
 # Docker images
 EDXAPP_IMAGE_NAME         ?= edxapp
+EDXAPP_NGINX_IMAGE_NAME   ?= edxapp-nginx
 EDXAPP_IMAGE_TAG          ?= $(EDX_RELEASE)-$(FLAVOR)
-
-# Extras
-EXTRAS_NGINX_IMAGE_NAME   ?= edxapp-nginx
-EXTRAS_NGINX_IMAGE_TAG    ?= $(EDXAPP_IMAGE_TAG)
 
 # Redis service used
 REDIS_SERVICE             ?= redis
@@ -261,8 +258,7 @@ info:  ## get activated release info
 	@echo -e "* REDIS_SERVICE              : $(COLOR_INFO)$(REDIS_SERVICE)$(COLOR_RESET)"
 	@echo -e "* EDXAPP_IMAGE_NAME          : $(COLOR_INFO)$(EDXAPP_IMAGE_NAME)$(COLOR_RESET)"
 	@echo -e "* EDXAPP_IMAGE_TAG           : $(COLOR_INFO)$(EDXAPP_IMAGE_TAG)$(COLOR_RESET)"
-	@echo -e "* EXTRAS_NGINX_IMAGE_NAME    : $(COLOR_INFO)$(EXTRAS_NGINX_IMAGE_NAME)$(COLOR_RESET)"
-	@echo -e "* EXTRAS_NGINX_IMAGE_TAG     : $(COLOR_INFO)$(EXTRAS_NGINX_IMAGE_TAG)$(COLOR_RESET)"
+	@echo -e "* EDXAPP_NGINX_IMAGE_NAME    : $(COLOR_INFO)$(EDXAPP_NGINX_IMAGE_NAME)$(COLOR_RESET)"
 	@echo -e ""
 .PHONY: info
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,7 +155,7 @@ services:
       args:
         EDX_RELEASE_REF: ${EDX_RELEASE_REF:-release-2018-08-29-14.14}
         EDX_ARCHIVE_URL: ${EDX_ARCHIVE_URL:-https://github.com/edx/edx-platform/archive/release-2018-08-29-14.14.tar.gz}
-    image: "${NGINX_IMAGE_NAME:-edxapp-nginx}:${NGINX_IMAGE_TAG:-master-bare}"
+    image: "${EDXAPP_NGINX_IMAGE_NAME:-edxapp-nginx}:${EDXAPP_IMAGE_TAG:-master-bare}"
     ports:
       - "8073:8071"
       - "8083:8081"


### PR DESCRIPTION
## Purpose

CI failed to publish the new releases to Docker Hub.

## Proposal

The nginx image tag was not set to `EDXAPP_IMAGE_TAG` and I mixed up what is the base `nginx` image and what is the result `edxapp-nginx` image.
