### PR TITLE
add MKTG_URLS setting

### DIFF
--- a/env.d/development
+++ b/env.d/development
@@ -18,6 +18,11 @@ EMAIL_PORT=1025
 # Python
 PYTHONUNBUFFERED=1
 
+# Marketing urls
+# urls used when marketing sites is enabled. To enable it, set ENABLE_MKTG_SITE to true
+# in the FEATURES setting.
+# MKTG_URLS={"COURSES": "https://www.fun-mooc.fr"}
+
 # Features
 FEATURES={"AUTOMATIC_AUTH_FOR_TESTING": true, "RESTRICT_AUTOMATIC_AUTH": false, "ENABLE_OAUTH2_PROVIDER": true}
 OAUTH_ENFORCE_SECURE=

--- a/releases/eucalyptus/3/bare/CHANGELOG.md
+++ b/releases/eucalyptus/3/bare/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Added
+
+- add MKTG_URLS setting
+
 ## [eucalyptus.3-1.2.0] - 2020-05-14
 
 ### Added

--- a/releases/eucalyptus/3/bare/config/lms/docker_run_production.py
+++ b/releases/eucalyptus/3/bare/config/lms/docker_run_production.py
@@ -391,6 +391,7 @@ ENABLE_COMPREHENSIVE_THEMING = config(
 
 # Marketing link overrides
 MKTG_URL_LINK_MAP = config("MKTG_URL_LINK_MAP", default={}, formatter=json.loads)
+MKTG_URLS = config("MKTG_URLS", default={}, formatter=json.loads)
 
 SUPPORT_SITE_LINK = config("SUPPORT_SITE_LINK", default=SUPPORT_SITE_LINK)
 

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Added
+
+- add MKTG_URLS setting
+
 ## [eucalyptus.3-wb-1.9.1] - 2020-07-20
 
 ### Changed

--- a/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
@@ -434,6 +434,7 @@ ENABLE_COMPREHENSIVE_THEMING = config(
 
 # Marketing link overrides
 MKTG_URL_LINK_MAP = config("MKTG_URL_LINK_MAP", default={}, formatter=json.loads)
+MKTG_URLS = config("MKTG_URLS", default={}, formatter=json.loads)
 
 SUPPORT_SITE_LINK = config("SUPPORT_SITE_LINK", default=SUPPORT_SITE_LINK)
 

--- a/releases/hawthorn/1/bare/CHANGELOG.md
+++ b/releases/hawthorn/1/bare/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Added
+
+- add MKTG_URLS setting
+
 ## [hawthorn.1-3.3.0] - 2020-05-14
 
 ### Added

--- a/releases/hawthorn/1/bare/config/lms/docker_run_production.py
+++ b/releases/hawthorn/1/bare/config/lms/docker_run_production.py
@@ -386,6 +386,7 @@ ENABLE_COMPREHENSIVE_THEMING = config(
 
 # Marketing link overrides
 MKTG_URL_LINK_MAP = config("MKTG_URL_LINK_MAP", default={}, formatter=json.loads)
+MKTG_URLS = config("MKTG_URLS", default={}, formatter=json.loads)
 
 # Intentional defaults.
 SUPPORT_SITE_LINK = config("SUPPORT_SITE_LINK", default=SUPPORT_SITE_LINK)

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Added
+
+- add MKTG_URLS setting
+
 ## [hawthorn.1-oee-3.3.0] - 2020-05-14
 
 ### Added

--- a/releases/hawthorn/1/oee/config/lms/docker_run_production.py
+++ b/releases/hawthorn/1/oee/config/lms/docker_run_production.py
@@ -429,6 +429,7 @@ ENABLE_COMPREHENSIVE_THEMING = config(
 
 # Marketing link overrides
 MKTG_URL_LINK_MAP = config("MKTG_URL_LINK_MAP", default={}, formatter=json.loads)
+MKTG_URLS = config("MKTG_URLS", default={}, formatter=json.loads)
 
 # Intentional defaults.
 SUPPORT_SITE_LINK = config("SUPPORT_SITE_LINK", default=SUPPORT_SITE_LINK)


### PR DESCRIPTION
## Purpose

We want to use MKTG_URLS. This setting is used by edx when
FEATURES.ENABLE_MKTG_SITE is enabled. MKTG_URLS is a mapping url in json
format, the jey are the same than MKTG_URL_LINK_MAP setting and the
value can be relative or absolute urls. This setting is used by mako
templating in the function marketing_link.


## Proposal

- [x] add MKTG_URLS setting to hawtorn
- [x] add MKTG_URLS setting to eucalyptus