### PR TITLE
🐛(all flavors) fix redis-sentinel support

### DIFF
--- a/env.d/redis-sentinel
+++ b/env.d/redis-sentinel
@@ -7,3 +7,10 @@ BROKER_TRANSPORT_OPTIONS={"sentinels":[["redis-sentinel",26379]],"service_name":
 # Session in redis
 SESSION_REDIS_SENTINEL_LIST=[["redis-sentinel", 26379]]
 SESSION_REDIS_SENTINEL_MASTER_ALIAS=mymaster
+
+# Cache in redis
+CACHE_REDIS_BACKEND=django_redis_sentinel.cache.RedisSentinelCache
+CACHE_REDIS_CLIENT=django_redis_sentinel.client.SentinelClient
+CACHE_REDIS_SENTINEL_SERVICE_NAME=mymaster
+CACHE_REDIS_PORT=26379
+CACHE_REDIS_HOST=redis-sentinel

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -12,6 +12,7 @@ release.
 ### Fixed
 
 - Pin splinter to 0.13.0 to avoid breaking change in 0.14.0
+- Adjust settings to support `REDIS_SERVICE=redis-sentinel`
 
 ## [dogwood.3-fun-1.13.1] - 2020-07-20
 

--- a/releases/dogwood/3/fun/Dockerfile
+++ b/releases/dogwood/3/fun/Dockerfile
@@ -179,8 +179,8 @@ FROM builder as links_collector
 
 ARG EDXAPP_STATIC_ROOT
 
-RUN python manage.py lms collectstatic --link --noinput --settings=fun.docker_run && \
-    python manage.py cms collectstatic --link --noinput --settings=fun.docker_run
+RUN python manage.py lms collectstatic --link --noinput --settings=fun.docker_build_production && \
+    python manage.py cms collectstatic --link --noinput --settings=fun.docker_build_production
 
 # Replace duplicated file by a symlink to decrease the overall size of the
 # final image
@@ -191,8 +191,8 @@ FROM builder as files_collector
 
 ARG EDXAPP_STATIC_ROOT
 
-RUN python manage.py lms collectstatic --noinput --settings=fun.docker_run && \
-    python manage.py cms collectstatic --noinput --settings=fun.docker_run
+RUN python manage.py lms collectstatic --noinput --settings=fun.docker_build_production && \
+    python manage.py cms collectstatic --noinput --settings=fun.docker_build_production
 
 # Replace duplicated file by a symlink to decrease the overall size of the
 # final image

--- a/releases/dogwood/3/fun/config/cms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/cms/docker_run_production.py
@@ -167,53 +167,41 @@ LOG_DIR = config("LOG_DIR", default=path("/edx/var/logs/edx"), formatter=path)
 CACHE_REDIS_HOST = config("CACHE_REDIS_HOST", default="redis")
 CACHE_REDIS_PORT = config("CACHE_REDIS_PORT", default=6379, formatter=int)
 CACHE_REDIS_DB = config("CACHE_REDIS_DB", default=1, formatter=int)
-CACHE_REDIS_URI = "redis://{}:{}/{}".format(CACHE_REDIS_HOST, CACHE_REDIS_PORT, CACHE_REDIS_DB)
-CACHE_REDIS_BACKEND = config("CACHE_REDIS_BACKEND", default="django_redis.cache.RedisCache")
-CACHE_REDIS_CLIENT = config("CACHE_REDIS_CLIENT", default="django_redis.client.DefaultClient")
+CACHE_REDIS_BACKEND = config(
+    "CACHE_REDIS_BACKEND", default="django_redis.cache.RedisCache"
+)
+CACHE_REDIS_URI = "redis://{}:{}/{}".format(
+    CACHE_REDIS_HOST, CACHE_REDIS_PORT, CACHE_REDIS_DB
+)
+CACHE_REDIS_CLIENT = config(
+    "CACHE_REDIS_CLIENT", default="django_redis.client.DefaultClient"
+)
+
+CACHES_DEFAULT_CONFIG = {
+    "BACKEND": CACHE_REDIS_BACKEND,
+    "LOCATION": CACHE_REDIS_URI,
+    "OPTIONS": {"CLIENT_CLASS": CACHE_REDIS_CLIENT},
+}
+
+if "Sentinel" in CACHE_REDIS_BACKEND:
+    CACHES_DEFAULT_CONFIG["LOCATION"] = [(CACHE_REDIS_HOST, CACHE_REDIS_PORT)]
+    CACHES_DEFAULT_CONFIG["OPTIONS"]["SENTINEL_SERVICE_NAME"] = config(
+        "CACHE_REDIS_SENTINEL_SERVICE_NAME", default="mymaster"
+    )
+    CACHES_DEFAULT_CONFIG["OPTIONS"]["REDIS_CLIENT_KWARGS"] = {"db": CACHE_REDIS_DB}
 
 CACHES = config(
     "CACHES",
     default={
-        "default": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "default",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
-        "general": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "general",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
-        "celery": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "celery",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
-        "mongo_metadata_inheritance": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "mongo_metadata_inheritance",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
-        "openassessment_submissions": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "openassessment_submissions",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
+        "default": dict(CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "default"}),
+        "general": dict(CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "general"}),
+        "celery": dict(CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "celery"}),
+        "mongo_metadata_inheritance": dict(
+            CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "mongo_metadata_inheritance"}
+        ),
+        "openassessment_submissions": dict(
+            CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "openassessment_submissions"}
+        ),
         "loc_cache": {
             "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
             "LOCATION": "edx_location_mem_cache",

--- a/releases/dogwood/3/fun/config/lms/docker_build_development.py
+++ b/releases/dogwood/3/fun/config/lms/docker_build_development.py
@@ -5,3 +5,35 @@ from .docker_run_development import *
 DATABASES = {"default": {}}
 
 XQUEUE_INTERFACE = {"url": None, "django_auth": None}
+
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "default",
+    },
+    "general": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "general",
+    },
+    "celery": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "celery",
+    },
+    "mongo_metadata_inheritance": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "mongo_metadata_inheritance",
+    },
+    "openassessment_submissions": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "openassessment_submissions",
+    },
+    "loc_cache": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "loc_cache",
+    },
+    # Cache backend used by Django 1.8 storage backend while processing static files
+    "staticfiles": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "staticfiles",
+    },
+}

--- a/releases/dogwood/3/fun/config/lms/docker_build_production.py
+++ b/releases/dogwood/3/fun/config/lms/docker_build_production.py
@@ -5,3 +5,35 @@ from .docker_run_production import *
 DATABASES = {"default": {}}
 
 XQUEUE_INTERFACE = {"url": None, "django_auth": None}
+
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "default",
+    },
+    "general": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "general",
+    },
+    "celery": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "celery",
+    },
+    "mongo_metadata_inheritance": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "mongo_metadata_inheritance",
+    },
+    "openassessment_submissions": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "openassessment_submissions",
+    },
+    "loc_cache": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "loc_cache",
+    },
+    # Cache backend used by Django 1.8 storage backend while processing static files
+    "staticfiles": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "staticfiles",
+    },
+}

--- a/releases/dogwood/3/fun/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/lms/docker_run_production.py
@@ -267,53 +267,41 @@ if config("SESSION_COOKIE_NAME", default=None):
 CACHE_REDIS_HOST = config("CACHE_REDIS_HOST", default="redis")
 CACHE_REDIS_PORT = config("CACHE_REDIS_PORT", default=6379, formatter=int)
 CACHE_REDIS_DB = config("CACHE_REDIS_DB", default=1, formatter=int)
-CACHE_REDIS_URI = "redis://{}:{}/{}".format(CACHE_REDIS_HOST, CACHE_REDIS_PORT, CACHE_REDIS_DB)
-CACHE_REDIS_BACKEND = config("CACHE_REDIS_BACKEND", default="django_redis.cache.RedisCache")
-CACHE_REDIS_CLIENT = config("CACHE_REDIS_CLIENT", default="django_redis.client.DefaultClient")
+CACHE_REDIS_BACKEND = config(
+    "CACHE_REDIS_BACKEND", default="django_redis.cache.RedisCache"
+)
+CACHE_REDIS_URI = "redis://{}:{}/{}".format(
+    CACHE_REDIS_HOST, CACHE_REDIS_PORT, CACHE_REDIS_DB
+)
+CACHE_REDIS_CLIENT = config(
+    "CACHE_REDIS_CLIENT", default="django_redis.client.DefaultClient"
+)
+
+CACHES_DEFAULT_CONFIG = {
+    "BACKEND": CACHE_REDIS_BACKEND,
+    "LOCATION": CACHE_REDIS_URI,
+    "OPTIONS": {"CLIENT_CLASS": CACHE_REDIS_CLIENT},
+}
+
+if "Sentinel" in CACHE_REDIS_BACKEND:
+    CACHES_DEFAULT_CONFIG["LOCATION"] = [(CACHE_REDIS_HOST, CACHE_REDIS_PORT)]
+    CACHES_DEFAULT_CONFIG["OPTIONS"]["SENTINEL_SERVICE_NAME"] = config(
+        "CACHE_REDIS_SENTINEL_SERVICE_NAME", default="mymaster"
+    )
+    CACHES_DEFAULT_CONFIG["OPTIONS"]["REDIS_CLIENT_KWARGS"] = {"db": CACHE_REDIS_DB}
 
 CACHES = config(
     "CACHES",
     default={
-        "default": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "default",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
-        "general": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "general",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
-        "celery": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "celery",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
-        "mongo_metadata_inheritance": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "mongo_metadata_inheritance",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
-        "openassessment_submissions": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "openassessment_submissions",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
+        "default": dict(CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "default"}),
+        "general": dict(CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "general"}),
+        "celery": dict(CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "celery"}),
+        "mongo_metadata_inheritance": dict(
+            CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "mongo_metadata_inheritance"}
+        ),
+        "openassessment_submissions": dict(
+            CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "openassessment_submissions"}
+        ),
         "loc_cache": {
             "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
             "LOCATION": "edx_location_mem_cache",

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -18,7 +18,9 @@ xblock-utils2==0.3.0
 
 # ==== third-party apps ====
 celery-redis-sentinel==0.3.0
-django-redis==4.5.0  # Force django-redis 4.5.0 to keep Django==1.8
+# django-django-redis-sentinel-redux is not compatible with
+# django-redis > 4.5.0
+django-redis==4.5.0
 django-redis-sentinel-redux==0.2.0
 django-redis-sessions==0.6.1
 raven==6.9.0

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+- Pin `django-redis` version to `4.5.0` to be able to use
+  `django-redis-sentinel-redux`.
+- Adjust settings to support `REDIS_SERVICE=redis-sentinel`
+
 ## [eucalyptus.3-wb-1.9.1] - 2020-07-20
 
 ### Changed

--- a/releases/eucalyptus/3/wb/Dockerfile
+++ b/releases/eucalyptus/3/wb/Dockerfile
@@ -159,8 +159,8 @@ FROM builder as links_collector
 
 ARG EDXAPP_STATIC_ROOT
 
-RUN python manage.py lms collectstatic --link --noinput --settings=fun.docker_run && \
-    python manage.py cms collectstatic --link --noinput --settings=fun.docker_run
+RUN python manage.py lms collectstatic --link --noinput --settings=fun.docker_build_production && \
+    python manage.py cms collectstatic --link --noinput --settings=fun.docker_build_production
 
 # Replace duplicated file by a symlink to decrease the overall size of the
 # final image
@@ -171,8 +171,8 @@ FROM builder as files_collector
 
 ARG EDXAPP_STATIC_ROOT
 
-RUN python manage.py lms collectstatic --noinput --settings=fun.docker_run && \
-    python manage.py cms collectstatic --noinput --settings=fun.docker_run
+RUN python manage.py lms collectstatic --noinput --settings=fun.docker_build_production && \
+    python manage.py cms collectstatic --noinput --settings=fun.docker_build_production
 
 # Replace duplicated file by a symlink to decrease the overall size of the
 # final image

--- a/releases/eucalyptus/3/wb/config/cms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/cms/docker_run_production.py
@@ -161,53 +161,41 @@ LOG_DIR = config("LOG_DIR", default=path("/edx/var/logs/edx"), formatter=path)
 CACHE_REDIS_HOST = config("CACHE_REDIS_HOST", default="redis")
 CACHE_REDIS_PORT = config("CACHE_REDIS_PORT", default=6379, formatter=int)
 CACHE_REDIS_DB = config("CACHE_REDIS_DB", default=1, formatter=int)
-CACHE_REDIS_URI = "redis://{}:{}/{}".format(CACHE_REDIS_HOST, CACHE_REDIS_PORT, CACHE_REDIS_DB)
-CACHE_REDIS_BACKEND = config("CACHE_REDIS_BACKEND", default="django_redis.cache.RedisCache")
-CACHE_REDIS_CLIENT = config("CACHE_REDIS_CLIENT", default="django_redis.client.DefaultClient")
+CACHE_REDIS_BACKEND = config(
+    "CACHE_REDIS_BACKEND", default="django_redis.cache.RedisCache"
+)
+CACHE_REDIS_URI = "redis://{}:{}/{}".format(
+    CACHE_REDIS_HOST, CACHE_REDIS_PORT, CACHE_REDIS_DB
+)
+CACHE_REDIS_CLIENT = config(
+    "CACHE_REDIS_CLIENT", default="django_redis.client.DefaultClient"
+)
+
+CACHES_DEFAULT_CONFIG = {
+    "BACKEND": CACHE_REDIS_BACKEND,
+    "LOCATION": CACHE_REDIS_URI,
+    "OPTIONS": {"CLIENT_CLASS": CACHE_REDIS_CLIENT},
+}
+
+if "Sentinel" in CACHE_REDIS_BACKEND:
+    CACHES_DEFAULT_CONFIG["LOCATION"] = [(CACHE_REDIS_HOST, CACHE_REDIS_PORT)]
+    CACHES_DEFAULT_CONFIG["OPTIONS"]["SENTINEL_SERVICE_NAME"] = config(
+        "CACHE_REDIS_SENTINEL_SERVICE_NAME", default="mymaster"
+    )
+    CACHES_DEFAULT_CONFIG["OPTIONS"]["REDIS_CLIENT_KWARGS"] = {"db": CACHE_REDIS_DB}
 
 CACHES = config(
     "CACHES",
     default={
-        "default": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "default",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
-        "general": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "general",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
-        "celery": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "celery",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
-        "mongo_metadata_inheritance": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "mongo_metadata_inheritance",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
-        "openassessment_submissions": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "openassessment_submissions",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
+        "default": dict(CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "default"}),
+        "general": dict(CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "general"}),
+        "celery": dict(CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "celery"}),
+        "mongo_metadata_inheritance": dict(
+            CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "mongo_metadata_inheritance"}
+        ),
+        "openassessment_submissions": dict(
+            CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "openassessment_submissions"}
+        ),
         "loc_cache": {
             "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
             "LOCATION": "edx_location_mem_cache",

--- a/releases/eucalyptus/3/wb/config/lms/docker_build_development.py
+++ b/releases/eucalyptus/3/wb/config/lms/docker_build_development.py
@@ -5,3 +5,35 @@ from .docker_run_development import *
 DATABASES = {"default": {}}
 
 XQUEUE_INTERFACE = {"url": None, "django_auth": None}
+
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "default",
+    },
+    "general": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "general",
+    },
+    "celery": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "celery",
+    },
+    "mongo_metadata_inheritance": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "mongo_metadata_inheritance",
+    },
+    "openassessment_submissions": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "openassessment_submissions",
+    },
+    "loc_cache": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "loc_cache",
+    },
+    # Cache backend used by Django 1.8 storage backend while processing static files
+    "staticfiles": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "staticfiles",
+    },
+}

--- a/releases/eucalyptus/3/wb/config/lms/docker_build_production.py
+++ b/releases/eucalyptus/3/wb/config/lms/docker_build_production.py
@@ -5,3 +5,35 @@ from .docker_run_production import *
 DATABASES = {"default": {}}
 
 XQUEUE_INTERFACE = {"url": None, "django_auth": None}
+
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "default",
+    },
+    "general": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "general",
+    },
+    "celery": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "celery",
+    },
+    "mongo_metadata_inheritance": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "mongo_metadata_inheritance",
+    },
+    "openassessment_submissions": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "openassessment_submissions",
+    },
+    "loc_cache": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "loc_cache",
+    },
+    # Cache backend used by Django 1.8 storage backend while processing static files
+    "staticfiles": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "staticfiles",
+    },
+}

--- a/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
@@ -286,53 +286,41 @@ if config("SESSION_COOKIE_NAME", default=None):
 CACHE_REDIS_HOST = config("CACHE_REDIS_HOST", default="redis")
 CACHE_REDIS_PORT = config("CACHE_REDIS_PORT", default=6379, formatter=int)
 CACHE_REDIS_DB = config("CACHE_REDIS_DB", default=1, formatter=int)
-CACHE_REDIS_URI = "redis://{}:{}/{}".format(CACHE_REDIS_HOST, CACHE_REDIS_PORT, CACHE_REDIS_DB)
-CACHE_REDIS_BACKEND = config("CACHE_REDIS_BACKEND", default="django_redis.cache.RedisCache")
-CACHE_REDIS_CLIENT = config("CACHE_REDIS_CLIENT", default="django_redis.client.DefaultClient")
+CACHE_REDIS_BACKEND = config(
+    "CACHE_REDIS_BACKEND", default="django_redis.cache.RedisCache"
+)
+CACHE_REDIS_URI = "redis://{}:{}/{}".format(
+    CACHE_REDIS_HOST, CACHE_REDIS_PORT, CACHE_REDIS_DB
+)
+CACHE_REDIS_CLIENT = config(
+    "CACHE_REDIS_CLIENT", default="django_redis.client.DefaultClient"
+)
+
+CACHES_DEFAULT_CONFIG = {
+    "BACKEND": CACHE_REDIS_BACKEND,
+    "LOCATION": CACHE_REDIS_URI,
+    "OPTIONS": {"CLIENT_CLASS": CACHE_REDIS_CLIENT},
+}
+
+if "Sentinel" in CACHE_REDIS_BACKEND:
+    CACHES_DEFAULT_CONFIG["LOCATION"] = [(CACHE_REDIS_HOST, CACHE_REDIS_PORT)]
+    CACHES_DEFAULT_CONFIG["OPTIONS"]["SENTINEL_SERVICE_NAME"] = config(
+        "CACHE_REDIS_SENTINEL_SERVICE_NAME", default="mymaster"
+    )
+    CACHES_DEFAULT_CONFIG["OPTIONS"]["REDIS_CLIENT_KWARGS"] = {"db": CACHE_REDIS_DB}
 
 CACHES = config(
     "CACHES",
     default={
-        "default": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "default",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
-        "general": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "general",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
-        "celery": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "celery",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
-        "mongo_metadata_inheritance": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "mongo_metadata_inheritance",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
-        "openassessment_submissions": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "openassessment_submissions",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
+        "default": dict(CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "default"}),
+        "general": dict(CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "general"}),
+        "celery": dict(CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "celery"}),
+        "mongo_metadata_inheritance": dict(
+            CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "mongo_metadata_inheritance"}
+        ),
+        "openassessment_submissions": dict(
+            CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "openassessment_submissions"}
+        ),
         "loc_cache": {
             "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
             "LOCATION": "edx_location_mem_cache",

--- a/releases/eucalyptus/3/wb/requirements.txt
+++ b/releases/eucalyptus/3/wb/requirements.txt
@@ -12,7 +12,9 @@ xblock-utils2==0.3.0
 
 # ==== third-party apps ====
 celery-redis-sentinel==0.3.0
-django-redis==4.8.0  # Force django-redis 4.8.0 to keep Django==1.8
+# django-django-redis-sentinel-redux is not compatible with
+# django-redis > 4.5.0
+django-redis==4.5.0
 django-redis-sentinel-redux==0.2.0
 django-redis-sessions==0.6.1
 raven==6.9.0

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -9,6 +9,12 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Pin `django-redis` version to `4.5.0` to be able to use
+  `django-redis-sentinel-redux`.
+- Adjust settings to support `REDIS_SERVICE=redis-sentinel`
+
 ## [hawthorn.1-oee-3.3.0] - 2020-05-14
 
 ### Added

--- a/releases/hawthorn/1/oee/Dockerfile
+++ b/releases/hawthorn/1/oee/Dockerfile
@@ -138,8 +138,8 @@ FROM builder as links_collector
 
 ARG EDXAPP_STATIC_ROOT
 
-RUN python manage.py lms collectstatic --link --noinput --settings=fun.docker_run && \
-    python manage.py cms collectstatic --link --noinput --settings=fun.docker_run
+RUN python manage.py lms collectstatic --link --noinput --settings=fun.docker_build_production && \
+    python manage.py cms collectstatic --link --noinput --settings=fun.docker_build_production
 
 # Replace duplicated file by a symlink to decrease the overall size of the
 # final image
@@ -150,8 +150,8 @@ FROM builder as files_collector
 
 ARG EDXAPP_STATIC_ROOT
 
-RUN python manage.py lms collectstatic --noinput --settings=fun.docker_run && \
-    python manage.py cms collectstatic --noinput --settings=fun.docker_run
+RUN python manage.py lms collectstatic --noinput --settings=fun.docker_build_production && \
+    python manage.py cms collectstatic --noinput --settings=fun.docker_build_production
 
 # Replace duplicated file by a symlink to decrease the overall size of the
 # final image

--- a/releases/hawthorn/1/oee/config/cms/docker_run_production.py
+++ b/releases/hawthorn/1/oee/config/cms/docker_run_production.py
@@ -151,53 +151,41 @@ LOG_DIR = config("LOG_DIR", default=path("/edx/var/logs/edx"), formatter=path)
 CACHE_REDIS_HOST = config("CACHE_REDIS_HOST", default="redis")
 CACHE_REDIS_PORT = config("CACHE_REDIS_PORT", default=6379, formatter=int)
 CACHE_REDIS_DB = config("CACHE_REDIS_DB", default=1, formatter=int)
-CACHE_REDIS_URI = "redis://{}:{}/{}".format(CACHE_REDIS_HOST, CACHE_REDIS_PORT, CACHE_REDIS_DB)
-CACHE_REDIS_BACKEND = config("CACHE_REDIS_BACKEND", default="django_redis.cache.RedisCache")
-CACHE_REDIS_CLIENT = config("CACHE_REDIS_CLIENT", default="django_redis.client.DefaultClient")
+CACHE_REDIS_BACKEND = config(
+    "CACHE_REDIS_BACKEND", default="django_redis.cache.RedisCache"
+)
+CACHE_REDIS_URI = "redis://{}:{}/{}".format(
+    CACHE_REDIS_HOST, CACHE_REDIS_PORT, CACHE_REDIS_DB
+)
+CACHE_REDIS_CLIENT = config(
+    "CACHE_REDIS_CLIENT", default="django_redis.client.DefaultClient"
+)
+
+CACHES_DEFAULT_CONFIG = {
+    "BACKEND": CACHE_REDIS_BACKEND,
+    "LOCATION": CACHE_REDIS_URI,
+    "OPTIONS": {"CLIENT_CLASS": CACHE_REDIS_CLIENT},
+}
+
+if "Sentinel" in CACHE_REDIS_BACKEND:
+    CACHES_DEFAULT_CONFIG["LOCATION"] = [(CACHE_REDIS_HOST, CACHE_REDIS_PORT)]
+    CACHES_DEFAULT_CONFIG["OPTIONS"]["SENTINEL_SERVICE_NAME"] = config(
+        "CACHE_REDIS_SENTINEL_SERVICE_NAME", default="mymaster"
+    )
+    CACHES_DEFAULT_CONFIG["OPTIONS"]["REDIS_CLIENT_KWARGS"] = {"db": CACHE_REDIS_DB}
 
 CACHES = config(
     "CACHES",
     default={
-        "default": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "default",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
-        "general": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "general",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
-        "celery": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "celery",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
-        "mongo_metadata_inheritance": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "mongo_metadata_inheritance",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
-        "openassessment_submissions": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "openassessment_submissions",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
+        "default": dict(CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "default"}),
+        "general": dict(CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "general"}),
+        "celery": dict(CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "celery"}),
+        "mongo_metadata_inheritance": dict(
+            CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "mongo_metadata_inheritance"}
+        ),
+        "openassessment_submissions": dict(
+            CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "openassessment_submissions"}
+        ),
         "loc_cache": {
             "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
             "LOCATION": "edx_location_mem_cache",
@@ -229,8 +217,12 @@ SESSION_REDIS_PORT = config("SESSION_REDIS_PORT", default=6379, formatter=int)
 SESSION_REDIS_DB = config("SESSION_REDIS_DB", default=1, formatter=int)
 SESSION_REDIS_PASSWORD = config("SESSION_REDIS_PASSWORD", default=None)
 SESSION_REDIS_PREFIX = config("SESSION_REDIS_PREFIX", default="session")
-SESSION_REDIS_SOCKET_TIMEOUT = config("SESSION_REDIS_SOCKET_TIMEOUT", default=1, formatter=int)
-SESSION_REDIS_RETRY_ON_TIMEOUT = config("SESSION_REDIS_RETRY_ON_TIMEOUT", default=False, formatter=bool)
+SESSION_REDIS_SOCKET_TIMEOUT = config(
+    "SESSION_REDIS_SOCKET_TIMEOUT", default=1, formatter=int
+)
+SESSION_REDIS_RETRY_ON_TIMEOUT = config(
+    "SESSION_REDIS_RETRY_ON_TIMEOUT", default=False, formatter=bool
+)
 
 SESSION_REDIS = config(
     "SESSION_REDIS",
@@ -245,8 +237,12 @@ SESSION_REDIS = config(
     },
     formatter=json.loads,
 )
-SESSION_REDIS_SENTINEL_LIST = config("SESSION_REDIS_SENTINEL_LIST", default=None, formatter=json.loads)
-SESSION_REDIS_SENTINEL_MASTER_ALIAS = config("SESSION_REDIS_SENTINEL_MASTER_ALIAS", default=None)
+SESSION_REDIS_SENTINEL_LIST = config(
+    "SESSION_REDIS_SENTINEL_LIST", default=None, formatter=json.loads
+)
+SESSION_REDIS_SENTINEL_MASTER_ALIAS = config(
+    "SESSION_REDIS_SENTINEL_MASTER_ALIAS", default=None
+)
 
 # social sharing settings
 SOCIAL_SHARING_SETTINGS = config(
@@ -413,13 +409,17 @@ if SENTRY_DSN:
 # strings but edX tries to serialize them with a default json serializer which breaks. We should
 # submit a PR to fix it in edx-platform
 PLATFORM_NAME = config("PLATFORM_NAME", default="Your Platform Name Here")
-PLATFORM_DESCRIPTION = config("PLATFORM_DESCRIPTION", default="Your Platform Description Here")
+PLATFORM_DESCRIPTION = config(
+    "PLATFORM_DESCRIPTION", default="Your Platform Description Here"
+)
 STUDIO_NAME = config("STUDIO_NAME", default=STUDIO_NAME)
 STUDIO_SHORT_NAME = config("STUDIO_SHORT_NAME", default=STUDIO_SHORT_NAME)
 
 # Event Tracking
 TRACKING_IGNORE_URL_PATTERNS = config(
-    "TRACKING_IGNORE_URL_PATTERNS", default=TRACKING_IGNORE_URL_PATTERNS, formatter=json.loads
+    "TRACKING_IGNORE_URL_PATTERNS",
+    default=TRACKING_IGNORE_URL_PATTERNS,
+    formatter=json.loads,
 )
 
 # Heartbeat
@@ -597,7 +597,9 @@ BROKER_URL = "{transport}://{user}:{password}@{host}:{port}/{vhost}".format(
 BROKER_USE_SSL = config("CELERY_BROKER_USE_SSL", default=False, formatter=bool)
 # To use redis-sentinel, refer to the documentation here
 # https://celery-redis-sentinel.readthedocs.io/en/latest/
-BROKER_TRANSPORT_OPTIONS = config("BROKER_TRANSPORT_OPTIONS", default={}, formatter=json.loads)
+BROKER_TRANSPORT_OPTIONS = config(
+    "BROKER_TRANSPORT_OPTIONS", default={}, formatter=json.loads
+)
 
 # Message expiry time in seconds
 CELERY_EVENT_QUEUE_TTL = config("CELERY_EVENT_QUEUE_TTL", default=None, formatter=int)

--- a/releases/hawthorn/1/oee/config/lms/docker_build_development.py
+++ b/releases/hawthorn/1/oee/config/lms/docker_build_development.py
@@ -7,3 +7,35 @@ DEBUG = True
 REQUIRE_DEBUG = True
 
 WEBPACK_CONFIG_PATH = "webpack.dev.config.js"
+
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "default",
+    },
+    "general": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "general",
+    },
+    "celery": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "celery",
+    },
+    "mongo_metadata_inheritance": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "mongo_metadata_inheritance",
+    },
+    "openassessment_submissions": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "openassessment_submissions",
+    },
+    "loc_cache": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "loc_cache",
+    },
+    # Cache backend used by Django 1.8 storage backend while processing static files
+    "staticfiles": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "staticfiles",
+    },
+}

--- a/releases/hawthorn/1/oee/config/lms/docker_build_production.py
+++ b/releases/hawthorn/1/oee/config/lms/docker_build_production.py
@@ -19,6 +19,39 @@ STATIC_ROOT = path("/edx/app/edxapp/staticfiles")
 # Allow setting a custom theme
 DEFAULT_SITE_THEME = config("DEFAULT_SITE_THEME", default=None)
 
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "default",
+    },
+    "general": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "general",
+    },
+    "celery": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "celery",
+    },
+    "mongo_metadata_inheritance": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "mongo_metadata_inheritance",
+    },
+    "openassessment_submissions": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "openassessment_submissions",
+    },
+    "loc_cache": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "loc_cache",
+    },
+    # Cache backend used by Django 1.8 storage backend while processing static files
+    "staticfiles": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "staticfiles",
+    },
+}
+
+
 ########################## Derive Any Derived Settings  #######################
 
 derive_settings(__name__)

--- a/releases/hawthorn/1/oee/config/lms/docker_run_production.py
+++ b/releases/hawthorn/1/oee/config/lms/docker_run_production.py
@@ -256,53 +256,41 @@ if config("SESSION_COOKIE_NAME", default=None):
 CACHE_REDIS_HOST = config("CACHE_REDIS_HOST", default="redis")
 CACHE_REDIS_PORT = config("CACHE_REDIS_PORT", default=6379, formatter=int)
 CACHE_REDIS_DB = config("CACHE_REDIS_DB", default=1, formatter=int)
-CACHE_REDIS_URI = "redis://{}:{}/{}".format(CACHE_REDIS_HOST, CACHE_REDIS_PORT, CACHE_REDIS_DB)
-CACHE_REDIS_BACKEND = config("CACHE_REDIS_BACKEND", default="django_redis.cache.RedisCache")
-CACHE_REDIS_CLIENT = config("CACHE_REDIS_CLIENT", default="django_redis.client.DefaultClient")
+CACHE_REDIS_BACKEND = config(
+    "CACHE_REDIS_BACKEND", default="django_redis.cache.RedisCache"
+)
+CACHE_REDIS_URI = "redis://{}:{}/{}".format(
+    CACHE_REDIS_HOST, CACHE_REDIS_PORT, CACHE_REDIS_DB
+)
+CACHE_REDIS_CLIENT = config(
+    "CACHE_REDIS_CLIENT", default="django_redis.client.DefaultClient"
+)
+
+CACHES_DEFAULT_CONFIG = {
+    "BACKEND": CACHE_REDIS_BACKEND,
+    "LOCATION": CACHE_REDIS_URI,
+    "OPTIONS": {"CLIENT_CLASS": CACHE_REDIS_CLIENT},
+}
+
+if "Sentinel" in CACHE_REDIS_BACKEND:
+    CACHES_DEFAULT_CONFIG["LOCATION"] = [(CACHE_REDIS_HOST, CACHE_REDIS_PORT)]
+    CACHES_DEFAULT_CONFIG["OPTIONS"]["SENTINEL_SERVICE_NAME"] = config(
+        "CACHE_REDIS_SENTINEL_SERVICE_NAME", default="mymaster"
+    )
+    CACHES_DEFAULT_CONFIG["OPTIONS"]["REDIS_CLIENT_KWARGS"] = {"db": CACHE_REDIS_DB}
 
 CACHES = config(
     "CACHES",
     default={
-        "default": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "default",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
-        "general": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "general",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
-        "celery": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "celery",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
-        "mongo_metadata_inheritance": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "mongo_metadata_inheritance",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
-        "openassessment_submissions": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "openassessment_submissions",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
+        "default": dict(CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "default"}),
+        "general": dict(CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "general"}),
+        "celery": dict(CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "celery"}),
+        "mongo_metadata_inheritance": dict(
+            CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "mongo_metadata_inheritance"}
+        ),
+        "openassessment_submissions": dict(
+            CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "openassessment_submissions"}
+        ),
         "loc_cache": {
             "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
             "LOCATION": "edx_location_mem_cache",

--- a/releases/hawthorn/1/oee/requirements.txt
+++ b/releases/hawthorn/1/oee/requirements.txt
@@ -8,6 +8,9 @@ configurable_lti_consumer-xblock==1.2.3
 
 # ==== third-party apps ====
 celery-redis-sentinel==0.3.0
+# django-django-redis-sentinel-redux is not compatible with
+# django-redis > 4.5.0
+django-redis==4.5.0
 django-redis-sentinel-redux==0.2.0
 django-redis-sessions==0.6.1
 raven==6.9.0


### PR DESCRIPTION

## Purpose

We want to use redis-sentinel as a cache backend in openedx-docker (all flavors).

As documented in the README, we should be able to do it by setting `export REDIS_SERVICE=redis-sentinel`.

But it does not work, the bootstrap of the project fails because the cache settings does not take this into account.

On top of that, on `hawthorn` and `dogwood`, the installed  `django-redis` dependency is not compatible with `django-redis-sentinel-redux`.


## Proposal

- Dogwood
  - [x] Fix settings to take `REDIS_SERVICE` into account

- Hawthorn
  - [x] Fix settings to take `REDIS_SERVICE` into account
  - [x] Pin `django-redis` to 4.5.0

- Eucalyptus
  - [x] Fix settings to take `REDIS_SERVICE` into account
  - [x] Pin `django-redis` to 4.5.0

