### PR TITLE
🔖(hawthorn/1/oee) bump to hawthorn.1-oee-3.3.1

### DIFF
--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [hawthorn.1-oee-3.3.1] - 2020-09-01
+
 ### Fixed
 
 - Pin `django-redis` version to `4.5.0` to be able to use
@@ -300,7 +302,8 @@ First release of OpenEdx extended.
 
 - Add a configurable LTI consumer xblock
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-3.3.0..HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.3.1..HEAD
+[hawthorn.1-oee-3.3.1]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.3.0...hawthorn.1-oee-3.3.1
 [hawthorn.1-oee-3.3.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.2.0...hawthorn.1-oee-3.3.0
 [hawthorn.1-oee-3.2.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.1.2...hawthorn.1-oee-3.2.0
 [hawthorn.1-oee-3.1.2]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.1.1...hawthorn.1-oee-3.1.2


### PR DESCRIPTION
### Fixed

- Pin `django-redis` version to `4.5.0` to be able to use
  `django-redis-sentinel-redux`.
- Adjust settings to support `REDIS_SERVICE=redis-sentinel`
