### PR TITLE
🎨(bin) sort release in reverse order for bin/activate

### DIFF
--- a/bin/activate
+++ b/bin/activate
@@ -23,6 +23,7 @@ function select_release(){
     read -r -a releases <<< $(
         find "${PROJECT_DIRECTORY}/releases/" -maxdepth 4 -name Dockerfile |
         sed "s|${PROJECT_DIRECTORY}/releases/\\(.*\\)/Dockerfile|\\1|g" |
+        sort -fir |
         xargs
     )
     n_releases=${#releases[@]}


### PR DESCRIPTION
## Purpose

In order to easily identify the history of the different release
when running the bin/activate command, a sort operation is added
to have the most recent branches first.

## Proposal

Adding a `sort` command enables to sort the list of release (in reverse order) to have the most recent release first (sorted by alphabetical order)

Before (unordered):
```plain
Select an available flavored release to activate:
[1] master/bare (default)
[2] dogwood/3/fun
[3] dogwood/3/bare
[4] ironwood/2/bare
[5] eucalyptus/3/wb
[6] eucalyptus/3/bare
[7] hawthorn/1/oee
[8] hawthorn/1/bare
```

After (most recent first):
```plain
Select an available flavored release to activate:
[1] master/bare (default)
[2] ironwood/2/bare
[3] hawthorn/1/oee
[4] hawthorn/1/bare
[5] eucalyptus/3/wb
[6] eucalyptus/3/bare
[7] dogwood/3/fun
[8] dogwood/3/bare
```