### PR TITLE
🔖 (eucalyptus + dogwood) bump versions

### DIFF
--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-1.13.2] - 2020-09-01
+
 ### Fixed
 
 - Pin splinter to 0.13.0 to avoid breaking change in 0.14.0
@@ -296,7 +298,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.13.1...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.13.2...HEAD
+[dogwood.3-fun-1.13.2]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.13.1...dogwood.3-fun-1.13.2
 [dogwood.3-fun-1.13.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.13.0...dogwood.3-fun-1.13.1
 [dogwood.3-fun-1.13.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.12.1...dogwood.3-fun-1.13.0
 [dogwood.3-fun-1.12.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.12.0...dogwood.3-fun-1.12.1

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+## [eucalyptus.3-wb-1.9.2] - 2020-09-01
+
+### Fixed
+
 - Pin `django-redis` version to `4.5.0` to be able to use
   `django-redis-sentinel-redux`.
 - Adjust settings to support `REDIS_SERVICE=redis-sentinel`
@@ -240,7 +244,8 @@ release.
 - Set replicaSet and read_preference in mongodb connection
 - Add missing support for redis sentinel
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.9.1...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.9.2...HEAD
+[eucalyptus.3-wb-1.9.2]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.9.1...eucalyptus.3-wb-1.9.2
 [eucalyptus.3-wb-1.9.1]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.9.0...eucalyptus.3-wb-1.9.1
 [eucalyptus.3-wb-1.9.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.8.1...eucalyptus.3-wb-1.9.0
 [eucalyptus.3-wb-1.8.1]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.8.0...eucalyptus.3-wb-1.8.1


### PR DESCRIPTION
## eucalyptus.3-wb-1.9.2 - 2020-09-01

### Fixed

- Pin `django-redis` version to `4.5.0` to be able to use
  `django-redis-sentinel-redux`.
- Adjust settings to support `REDIS_SERVICE=redis-sentinel`


## dogwood.3-fun-1.13.2 - 2020-09-01

### Fixed

- Pin splinter to 0.13.0 to avoid breaking change in 0.14.0
- Adjust settings to support `REDIS_SERVICE=redis-sentinel`
