### PR TITLE
Ironwood.2 (bare & oee) flavor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,27 +144,19 @@ jobs:
   #
   # Note that the job name should match the EDX_RELEASE value
 
-  # Run jobs for the dogwood.3-bare release
-  dogwood.3-bare:
+  # No changes detected for dogwood.3-bare
+  # No changes detected for dogwood.3-fun
+  # No changes detected for eucalyptus.3-bare
+  # No changes detected for eucalyptus.3-wb
+  # No changes detected for hawthorn.1-bare
+  # No changes detected for hawthorn.1-oee
+  # Run jobs for the ironwood.2-bare release
+  ironwood.2-bare:
     <<: [*defaults, *build_steps]
-  # Run jobs for the dogwood.3-fun release
-  dogwood.3-fun:
+  # Run jobs for the ironwood.2-oee release
+  ironwood.2-oee:
     <<: [*defaults, *build_steps]
-  # Run jobs for the eucalyptus.3-bare release
-  eucalyptus.3-bare:
-    <<: [*defaults, *build_steps]
-  # Run jobs for the eucalyptus.3-wb release
-  eucalyptus.3-wb:
-    <<: [*defaults, *build_steps]
-  # Run jobs for the hawthorn.1-bare release
-  hawthorn.1-bare:
-    <<: [*defaults, *build_steps]
-  # Run jobs for the hawthorn.1-oee release
-  hawthorn.1-oee:
-    <<: [*defaults, *build_steps]
-  # Run jobs for the master.0-bare release
-  master.0-bare:
-    <<: [*defaults, *build_steps]
+  # No changes detected for master.0-bare
 
   # Hub job
   hub:
@@ -253,55 +245,27 @@ workflows:
 
       # Build jobs
 
-      # Run jobs for the dogwood.3-bare release
-      - dogwood.3-bare:
+      # No changes detected so no job to run for dogwood.3-bare
+      # No changes detected so no job to run for dogwood.3-fun
+      # No changes detected so no job to run for eucalyptus.3-bare
+      # No changes detected so no job to run for eucalyptus.3-wb
+      # No changes detected so no job to run for hawthorn.1-bare
+      # No changes detected so no job to run for hawthorn.1-oee
+      # Run jobs for the ironwood.2-bare release
+      - ironwood.2-bare:
           requires:
             - check-configuration
           filters:
             tags:
               ignore: /.*/
-      # Run jobs for the dogwood.3-fun release
-      - dogwood.3-fun:
+      # Run jobs for the ironwood.2-oee release
+      - ironwood.2-oee:
           requires:
             - check-configuration
           filters:
             tags:
               ignore: /.*/
-      # Run jobs for the eucalyptus.3-bare release
-      - eucalyptus.3-bare:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
-      # Run jobs for the eucalyptus.3-wb release
-      - eucalyptus.3-wb:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
-      # Run jobs for the hawthorn.1-bare release
-      - hawthorn.1-bare:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
-      # Run jobs for the hawthorn.1-oee release
-      - hawthorn.1-oee:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
-      # Run jobs for the master.0-bare release
-      - master.0-bare:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
+      # No changes detected so no job to run for master.0-bare
 
       # We are pushing to Docker only images that are the result of a tag respecting the pattern:
       #    **{branch-name}-x.y.z**

--- a/env.d/production
+++ b/env.d/production
@@ -1,0 +1,2 @@
+LMS_BASE=localhost:8073
+CMS_BASE=localhost:8083

--- a/releases/ironwood/2/bare/CHANGELOG.md
+++ b/releases/ironwood/2/bare/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic
+Versioning](https://semver.org/spec/v2.0.0.html) for each flavored OpenEdx
+release.
+
+## [Unreleased]
+
+## [ironwood.2-1.0.0] - 2019-06-04
+
+### Added
+
+- First release of an `ironwood.2-bare` Docker image.

--- a/releases/ironwood/2/bare/Dockerfile
+++ b/releases/ironwood/2/bare/Dockerfile
@@ -1,0 +1,272 @@
+# EDX-PLATFORM multi-stage docker build
+
+# Change release to build, by providing the EDX_RELEASE_REF build argument to
+# your build command:
+#
+# $ docker build \
+#     --build-arg EDX_RELEASE_REF="open-release/ironwood.2" \
+#     -t edxapp:ironwood.2 \
+#     .
+ARG DOCKER_UID=1000
+ARG DOCKER_GID=1000
+ARG EDX_RELEASE_REF=open-release/ironwood.2
+ARG EDXAPP_STATIC_ROOT=/edx/app/edxapp/staticfiles
+ARG NGINX_IMAGE_NAME=fundocker/openshift-nginx
+ARG NGINX_IMAGE_TAG=1.13
+
+# === BASE ===
+FROM ubuntu:16.04 as base
+
+# Configure locales & timezone
+RUN apt-get update && \
+    apt-get install -y \
+      gettext \
+      locales \
+      tzdata && \
+    rm -rf /var/lib/apt/lists/*
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    locale-gen
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+# === DOWNLOAD ===
+FROM base as downloads
+
+WORKDIR /downloads
+
+# Install curl
+RUN apt-get update && \
+    apt-get install -y curl
+
+# Download pip installer
+RUN curl -sLo get-pip.py https://bootstrap.pypa.io/get-pip.py
+
+# Download edxapp release
+# Get default EDX_RELEASE_REF value (defined on top)
+ARG EDX_RELEASE_REF
+RUN curl -sLo edxapp.tgz https://github.com/edx/edx-platform/archive/$EDX_RELEASE_REF.tar.gz && \
+    tar xzf edxapp.tgz
+
+
+# === EDXAPP ===
+FROM base as edxapp
+
+# Install apt https support (required to use node sources repository)
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y \
+      apt-transport-https
+
+# Add a recent release of nodejs to apt sources (ubuntu package for precise is
+# broken)
+RUN echo "deb https://deb.nodesource.com/node_10.x trusty main" \
+	> /etc/apt/sources.list.d/nodesource.list && \
+    curl -s 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key' | apt-key add -
+
+# Install base system dependencies
+RUN apt-get update && \
+    apt-get install -y \
+      nodejs \
+      python && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /edx/app/edxapp/edx-platform
+
+# Get default EDX_RELEASE_REF value (defined on top)
+ARG EDX_RELEASE_REF
+COPY --from=downloads /downloads/edx-platform-* .
+
+# We copy default configuration files to "/config" and we point to them via
+# symlinks. That allows to easily override default configurations by mounting a
+# docker volume.
+COPY ./config /config
+RUN ln -sf /config/lms /edx/app/edxapp/edx-platform/lms/envs/fun && \
+    ln -sf /config/cms /edx/app/edxapp/edx-platform/cms/envs/fun
+
+# Add node_modules/.bin to the PATH so that paver-related commands can execute
+# node scripts
+ENV PATH="/edx/app/edxapp/edx-platform/node_modules/.bin:${PATH}"
+
+# === BUILDER ===
+FROM edxapp as builder
+
+WORKDIR /builder
+
+# Install builder system dependencies
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y \
+    build-essential \
+    gettext \
+    git \
+    graphviz-dev \
+    libgeos-dev \
+    libmysqlclient-dev \
+    libxml2-dev \
+    libxmlsec1-dev \
+    python-dev \
+    rdfind && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install the latest pip release
+COPY --from=downloads /downloads/get-pip.py ./get-pip.py
+RUN python get-pip.py
+
+WORKDIR /edx/app/edxapp/edx-platform
+
+# Install python dependencies
+RUN pip install --src /usr/local/src -r requirements/edx/base.txt
+RUN pip install gunicorn==19.9.0
+
+# Install Javascript requirements
+RUN npm install
+
+# Update assets skipping collectstatic (it should be done during deployment)
+RUN NO_PREREQ_INSTALL=1 \
+    paver update_assets --settings=fun.docker_build_production --skip-collect
+
+# === STATIC LINKS COLLECTOR ===
+FROM builder as links_collector
+
+ARG EDXAPP_STATIC_ROOT
+
+RUN python manage.py lms collectstatic --link --noinput --settings=fun.docker_run && \
+    python manage.py cms collectstatic --link --noinput --settings=fun.docker_run
+
+# Replace duplicated file by a symlink to decrease the overall size of the
+# final image
+RUN rdfind -makesymlinks true -followsymlinks true ${EDXAPP_STATIC_ROOT}
+
+# === STATIC FILES COLLECTOR ===
+FROM builder as files_collector
+
+ARG EDXAPP_STATIC_ROOT
+
+RUN python manage.py lms collectstatic --noinput --settings=fun.docker_run && \
+    python manage.py cms collectstatic --noinput --settings=fun.docker_run
+
+# Replace duplicated file by a symlink to decrease the overall size of the
+# final image
+RUN rdfind -makesymlinks true ${EDXAPP_STATIC_ROOT}
+
+# === DEVELOPMENT ===
+FROM builder as development
+
+ARG DOCKER_UID
+ARG DOCKER_GID
+ARG EDX_RELEASE_REF
+
+# Install system dependencies
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y \
+      libsqlite3-dev \
+      mongodb && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN groupadd --gid ${DOCKER_GID} edx || \
+      echo "Group with ID ${DOCKER_GID} already exists." && \
+    useradd \
+      --create-home \
+      --home-dir /home/edx \
+      --uid ${DOCKER_UID} \
+      --gid ${DOCKER_GID} \
+      edx
+
+# To prevent permission issues related to the non-priviledged user running in
+# development, we will install development dependencies in a python virtual
+# environment belonging to that user
+RUN pip install virtualenv
+
+# Create the virtualenv directory where we will install python development
+# dependencies
+RUN mkdir -p /edx/app/edxapp/venv && \
+    chown -R ${DOCKER_UID}:${DOCKER_GID} /edx/app/edxapp/venv
+
+# Change edxapp directory owner to allow the development image docker user to
+# perform installations from edxapp sources (yeah, I know...)
+RUN chown -R ${DOCKER_UID}:${DOCKER_GID} /edx/app/edxapp
+
+# Copy the entrypoint that will activate the virtualenv
+COPY ./entrypoint.sh /usr/local/bin/entrypoint.sh
+
+# Switch to an un-privileged user matching the host user to prevent permission
+# issues with volumes (host folders)
+USER ${DOCKER_UID}:${DOCKER_GID}
+
+# Create the virtualenv with a non-priviledged user
+RUN virtualenv -p python2.7 --system-site-packages /edx/app/edxapp/venv
+
+# Install development dependencies in a virtualenv
+RUN bash -c "source /edx/app/edxapp/venv/bin/activate && \
+    pip install --no-cache-dir -r requirements/edx/testing.txt && \
+    pip install --no-cache-dir -r requirements/edx/development.txt"
+
+ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]
+
+
+# === PRODUCTION ===
+FROM edxapp as production
+
+ARG EDXAPP_STATIC_ROOT
+
+# Install runner system dependencies
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y \
+    libgeos-dev \
+    libmysqlclient20 \
+    libxml2 \
+    libxmlsec1-dev \
+    lynx \
+    tzdata && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy installed dependencies
+COPY --from=builder /usr/local /usr/local
+
+# Copy modified sources (sic!)
+COPY --from=builder /edx/app/edxapp/edx-platform  /edx/app/edxapp/edx-platform
+
+# Copy static files
+COPY --from=links_collector ${EDXAPP_STATIC_ROOT} ${EDXAPP_STATIC_ROOT}
+
+# Now that dependencies are installed and configuration has been set, the above
+# statements will run with a un-privileged user.
+USER 10000
+
+# To start the CMS, inject the SERVICE_VARIANT=cms environment variable
+# (defaults to "lms")
+ENV SERVICE_VARIANT=lms
+
+# Gunicorn configuration
+#
+# We want to be able to easily increase gunicorn if needed
+ENV GUNICORN_TIMEOUT 300
+
+# In docker we must increase the number of workers and threads created
+# by gunicorn.
+# This blogpost explains why and how to do that https://pythonspeed.com/articles/gunicorn-in-docker/
+ENV GUNICORN_WORKERS 3
+ENV GUNICORN_THREADS 6
+
+# Use Gunicorn in production as web server
+CMD DJANGO_SETTINGS_MODULE=${SERVICE_VARIANT}.envs.fun.docker_run \
+    gunicorn \
+      --name=${SERVICE_VARIANT} \
+      --bind=0.0.0.0:8000 \
+      --max-requests=1000 \
+      --timeout=${GUNICORN_TIMEOUT} \
+      --workers=${GUNICORN_WORKERS} \
+      --threads=${GUNICORN_THREADS} \
+      ${SERVICE_VARIANT}.wsgi:application
+
+# === NGINX ===
+FROM ${NGINX_IMAGE_NAME}:${NGINX_IMAGE_TAG} as nginx
+
+ARG EDXAPP_STATIC_ROOT
+
+RUN mkdir -p ${EDXAPP_STATIC_ROOT}
+
+COPY --from=files_collector ${EDXAPP_STATIC_ROOT} ${EDXAPP_STATIC_ROOT}

--- a/releases/ironwood/2/bare/activate
+++ b/releases/ironwood/2/bare/activate
@@ -1,0 +1,4 @@
+export EDX_RELEASE="ironwood.2"
+export FLAVOR="bare"
+export EDX_RELEASE_REF="open-release/ironwood.2"
+export EDX_DEMO_RELEASE_REF="open-release/ironwood.2"

--- a/releases/ironwood/2/bare/config/cms/docker_build_development.py
+++ b/releases/ironwood/2/bare/config/cms/docker_build_development.py
@@ -1,0 +1,9 @@
+# This is a minimal settings file allowing us to run "update_assets"
+# in the Dockerfile for the development image of the edxapp CMS
+
+from .docker_build_production import *
+
+DEBUG = True
+REQUIRE_DEBUG = True
+
+WEBPACK_CONFIG_PATH = "webpack.dev.config.js"

--- a/releases/ironwood/2/bare/config/cms/docker_build_production.py
+++ b/releases/ironwood/2/bare/config/cms/docker_build_production.py
@@ -1,0 +1,29 @@
+# This is a minimal settings file allowing us to run "update_assets"
+# in the Dockerfile for the production image of the edxapp CMS
+
+from openedx.core.lib.derived import derive_settings
+
+from lms.envs.fun.utils import Configuration
+from path import Path as path
+
+from .docker_run_production import *
+
+# Load custom configuration parameters
+config = Configuration()
+
+DATABASES = {"default": {}}
+
+XQUEUE_INTERFACE = {"url": None, "django_auth": None}
+
+# We need to override STATIC_ROOT because for CMS, edX appends the value of
+# "EDX_PLATFORM_REVISION" to it by default and we don't want to use this.
+# We should use Django's ManifestStaticFilesStorage for this purpose.
+STATIC_URL = "/static/studio/"
+STATIC_ROOT = path("/edx/app/edxapp/staticfiles/studio")
+
+# Allow setting a custom theme
+DEFAULT_SITE_THEME = config("DEFAULT_SITE_THEME", default=None)
+
+########################## Derive Any Derived Settings  #######################
+
+derive_settings(__name__)

--- a/releases/ironwood/2/bare/config/cms/docker_run.py
+++ b/releases/ironwood/2/bare/config/cms/docker_run.py
@@ -1,0 +1,3 @@
+# This file is meant to import the environment related settings file
+
+from docker_run_production import *

--- a/releases/ironwood/2/bare/config/cms/docker_run_ci.py
+++ b/releases/ironwood/2/bare/config/cms/docker_run_ci.py
@@ -1,0 +1,14 @@
+# This file includes overrides to build the `CI` environment for the CMS, starting from
+# the settings of the `production` environment
+
+from docker_run_production import *
+
+
+DEBUG = True
+
+EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+
+PIPELINE_ENABLED = False
+STATICFILES_STORAGE = "openedx.core.storage.DevelopmentStorage"
+
+ALLOWED_HOSTS = ["*"]

--- a/releases/ironwood/2/bare/config/cms/docker_run_development.py
+++ b/releases/ironwood/2/bare/config/cms/docker_run_development.py
@@ -1,0 +1,24 @@
+# This file includes overrides to build the `development` environment for the CMS, starting from
+# the settings of the `production` environment
+
+from docker_run_production import *
+from lms.envs.fun.utils import Configuration
+
+# Load custom configuration parameters from yaml files
+config = Configuration(os.path.dirname(__file__))
+
+if "sentry" in LOGGING.get("handlers"):
+    LOGGING["handlers"]["sentry"]["environment"] = "development"
+
+DEBUG = True
+REQUIRE_DEBUG = True
+
+EMAIL_BACKEND = config(
+    "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"
+)
+
+
+PIPELINE_ENABLED = False
+STATICFILES_STORAGE = "openedx.core.storage.DevelopmentStorage"
+
+ALLOWED_HOSTS = ["*"]

--- a/releases/ironwood/2/bare/config/cms/docker_run_feature.py
+++ b/releases/ironwood/2/bare/config/cms/docker_run_feature.py
@@ -1,0 +1,14 @@
+# This file includes overrides to build the `feature` environment for the CMS starting from the
+# settings of the `production` environment
+
+from docker_run_production import *
+from lms.envs.fun.utils import Configuration
+
+# Load custom configuration parameters from yaml files
+config = Configuration(os.path.dirname(__file__))
+
+LOGGING["handlers"]["sentry"]["environment"] = "feature"
+
+EMAIL_BACKEND = config(
+    "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"
+)

--- a/releases/ironwood/2/bare/config/cms/docker_run_preprod.py
+++ b/releases/ironwood/2/bare/config/cms/docker_run_preprod.py
@@ -1,0 +1,14 @@
+# This file includes overrides to build the `preprod` environment for the CMS starting from the
+# settings of the `production` environment
+
+from docker_run_production import *
+from lms.envs.fun.utils import Configuration
+
+# Load custom configuration parameters from yaml files
+config = Configuration(os.path.dirname(__file__))
+
+LOGGING["handlers"]["sentry"]["environment"] = "preprod"
+
+EMAIL_BACKEND = config(
+    "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"
+)

--- a/releases/ironwood/2/bare/config/cms/docker_run_production.py
+++ b/releases/ironwood/2/bare/config/cms/docker_run_production.py
@@ -1,0 +1,787 @@
+"""
+This is the settings to run the Open edX CMS with Docker the FUN way.
+"""
+
+import json
+import os
+import platform
+
+from lms.envs.fun.utils import Configuration
+from openedx.core.lib.derived import derive_settings
+from path import Path as path
+from xmodule.modulestore.modulestore_settings import (
+    convert_module_store_setting_if_needed
+)
+
+from ..common import *
+
+
+# Load custom configuration parameters from yaml files
+config = Configuration(os.path.dirname(__file__))
+
+# edX has now started using "settings.ENV_TOKENS" and "settings.AUTH_TOKENS" everywhere in the
+# project, not just in the settings. Let's make sure our settings still work in this case
+ENV_TOKENS = config
+AUTH_TOKENS = config
+
+############### ALWAYS THE SAME ################################
+
+RELEASE = config("RELEASE", default=None)
+DEBUG = False
+
+# IMPORTANT: With this enabled, the server must always be behind a proxy that
+# strips the header HTTP_X_FORWARDED_PROTO from client requests. Otherwise,
+# a user can fool our server into thinking it was an https connection.
+# See
+# https://docs.djangoproject.com/en/dev/ref/settings/#secure-proxy-ssl-header
+# for other warnings.
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
+###################################### CELERY  ################################
+
+CELERY_ALWAYS_EAGER = config("CELERY_ALWAYS_EAGER", default=False, formatter=bool)
+
+# Don't use a connection pool, since connections are dropped by ELB.
+BROKER_POOL_LIMIT = 0
+BROKER_CONNECTION_TIMEOUT = 1
+
+# For the Result Store, use the django cache named 'celery'
+CELERY_RESULT_BACKEND = config(
+    "CELERY_RESULT_BACKEND", default="djcelery.backends.cache:CacheBackend"
+)
+
+# When the broker is behind an ELB, use a heartbeat to refresh the
+# connection and to detect if it has been dropped.
+BROKER_HEARTBEAT = 60.0
+BROKER_HEARTBEAT_CHECKRATE = 2
+
+# Each worker should only fetch one message at a time
+CELERYD_PREFETCH_MULTIPLIER = 1
+
+# Celery queues
+DEFAULT_PRIORITY_QUEUE = config(
+    "DEFAULT_PRIORITY_QUEUE", default="edx.cms.core.default"
+)
+HIGH_PRIORITY_QUEUE = config("HIGH_PRIORITY_QUEUE", default="edx.cms.core.high")
+LOW_PRIORITY_QUEUE = config("LOW_PRIORITY_QUEUE", default="edx.cms.core.low")
+
+CELERY_DEFAULT_QUEUE = DEFAULT_PRIORITY_QUEUE
+CELERY_DEFAULT_ROUTING_KEY = DEFAULT_PRIORITY_QUEUE
+
+CELERY_QUEUES = config(
+    "CELERY_QUEUES",
+    default={
+        DEFAULT_PRIORITY_QUEUE: {},
+        HIGH_PRIORITY_QUEUE: {},
+        LOW_PRIORITY_QUEUE: {},
+    },
+    formatter=json.loads,
+)
+
+CELERY_ROUTES = "cms.celery.Router"
+
+# Force accepted content to "json" only. If we also accept pickle-serialized
+# messages, the worker will crash when it's running with a privileged user (even
+# if it's not the root user but a user belonging to the root group, which is the
+# case with OpenShift for example).
+CELERY_ACCEPT_CONTENT = ["json"]
+
+############# NON-SECURE ENV CONFIG ##############################
+# Things like server locations, ports, etc.
+
+# DEFAULT_COURSE_ABOUT_IMAGE_URL specifies the default image to show for courses that don't
+# provide one
+DEFAULT_COURSE_ABOUT_IMAGE_URL = config(
+    "DEFAULT_COURSE_ABOUT_IMAGE_URL", default=DEFAULT_COURSE_ABOUT_IMAGE_URL
+)
+
+DEFAULT_COURSE_VISIBILITY_IN_CATALOG = config(
+    "DEFAULT_COURSE_VISIBILITY_IN_CATALOG", default=DEFAULT_COURSE_VISIBILITY_IN_CATALOG
+)
+
+# DEFAULT_MOBILE_AVAILABLE specifies if the course is available for mobile by default
+DEFAULT_MOBILE_AVAILABLE = config(
+    "DEFAULT_MOBILE_AVAILABLE", default=DEFAULT_MOBILE_AVAILABLE, formatter=bool
+)
+
+# GITHUB_REPO_ROOT is the base directory
+# for course data
+GITHUB_REPO_ROOT = config("GITHUB_REPO_ROOT", default=GITHUB_REPO_ROOT)
+
+STATIC_URL = "/static/studio/"
+STATIC_ROOT_BASE = path("/edx/app/edxapp/staticfiles")
+STATIC_ROOT = path("/edx/app/edxapp/staticfiles/studio")
+STATICFILES_STORAGE = config(
+    "STATICFILES_STORAGE", default="lms.envs.fun.storage.CDNProductionStorage"
+)
+CDN_BASE_URL = config("CDN_BASE_URL", default=None)
+
+WEBPACK_LOADER["DEFAULT"]["STATS_FILE"] = STATIC_ROOT / "webpack-stats.json"
+
+EMAIL_BACKEND = config(
+    "EMAIL_BACKEND", default="django.core.mail.backends.smtp.EmailBackend"
+)
+EMAIL_FILE_PATH = config("EMAIL_FILE_PATH", default=None)
+
+EMAIL_HOST = config("EMAIL_HOST", default="localhost")
+EMAIL_PORT = config("EMAIL_PORT", default=25, formatter=int)
+EMAIL_USE_TLS = config("EMAIL_USE_TLS", default=False, formatter=bool)
+
+LMS_BASE = config("LMS_BASE", default="localhost:8072")
+CMS_BASE = config("CMS_BASE", default="localhost:8082")
+
+LMS_ROOT_URL = config("LMS_ROOT_URL", default="http://{:s}".format(LMS_BASE))
+LMS_INTERNAL_ROOT_URL = config("LMS_INTERNAL_ROOT_URL", default=LMS_ROOT_URL)
+
+ENTERPRISE_API_URL = config(
+    "ENTERPRISE_API_URL", default=LMS_INTERNAL_ROOT_URL + "/enterprise/api/v1/"
+)
+ENTERPRISE_CONSENT_API_URL = config(
+    "ENTERPRISE_CONSENT_API_URL", default=LMS_INTERNAL_ROOT_URL + "/consent/api/v1/"
+)
+
+SITE_NAME = config("SITE_NAME", default=CMS_BASE)
+
+ALLOWED_HOSTS = config(
+    "ALLOWED_HOSTS", default=[CMS_BASE.split(":")[0]], formatter=json.loads
+)
+
+LOG_DIR = config("LOG_DIR", default=path("/edx/var/logs/edx"), formatter=path)
+
+MEMCACHED_HOST = config("MEMCACHED_HOST", default="memcached")
+MEMCACHED_PORT = config("MEMCACHED_PORT", default=11211, formatter=int)
+
+CACHES = config(
+    "CACHES",
+    default={
+        "default": {
+            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
+            "KEY_FUNCTION": "util.memcache.safe_key",
+        },
+        "general": {
+            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
+            "KEY_FUNCTION": "util.memcache.safe_key",
+        },
+        "loc_cache": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "edx_location_mem_cache",
+        },
+        "celery": {
+            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
+            "KEY_FUNCTION": "util.memcache.safe_key",
+            "KEY_PREFIX": "celery",
+        },
+        "mongo_metadata_inheritance": {
+            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
+            "KEY_FUNCTION": "util.memcache.safe_key",
+            "KEY_PREFIX": "mongo_metadata_inheritance",
+        },
+        "openassessment_submissions": {
+            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
+            "KEY_FUNCTION": "util.memcache.safe_key",
+            "KEY_PREFIX": "openassessment_submissions",
+        },
+        "staticfiles": {
+            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
+            "KEY_FUNCTION": "util.memcache.safe_key",
+            "KEY_PREFIX": "staticfiles",
+        },
+    },
+    formatter=json.loads,
+)
+
+SESSION_COOKIE_DOMAIN = config("SESSION_COOKIE_DOMAIN", default=None)
+SESSION_COOKIE_HTTPONLY = config(
+    "SESSION_COOKIE_HTTPONLY", default=True, formatter=bool
+)
+SESSION_ENGINE = config(
+    "SESSION_ENGINE", default="django.contrib.sessions.backends.cache"
+)
+SESSION_COOKIE_SECURE = config(
+    "SESSION_COOKIE_SECURE", default=SESSION_COOKIE_SECURE, formatter=bool
+)
+SESSION_SAVE_EVERY_REQUEST = config(
+    "SESSION_SAVE_EVERY_REQUEST", default=SESSION_SAVE_EVERY_REQUEST, formatter=bool
+)
+
+# social sharing settings
+SOCIAL_SHARING_SETTINGS = config(
+    "SOCIAL_SHARING_SETTINGS", default=SOCIAL_SHARING_SETTINGS, formatter=json.loads
+)
+
+REGISTRATION_EMAIL_PATTERNS_ALLOWED = config(
+    "REGISTRATION_EMAIL_PATTERNS_ALLOWED", default=None, formatter=json.loads
+)
+
+# allow for environments to specify what cookie name our login subsystem should use
+# this is to fix a bug regarding simultaneous logins between edx.org and edge.edx.org which can
+# happen with some browsers (e.g. Firefox)
+if config("SESSION_COOKIE_NAME", default=None):
+    # NOTE, there's a bug in Django (http://bugs.python.org/issue18012) which necessitates this
+    # being a str()
+    SESSION_COOKIE_NAME = str(config("SESSION_COOKIE_NAME"))
+
+# Set the names of cookies shared with the marketing site
+# These have the same cookie domain as the session, which in production
+# usually includes subdomains.
+EDXMKTG_LOGGED_IN_COOKIE_NAME = config(
+    "EDXMKTG_LOGGED_IN_COOKIE_NAME", default=EDXMKTG_LOGGED_IN_COOKIE_NAME
+)
+EDXMKTG_USER_INFO_COOKIE_NAME = config(
+    "EDXMKTG_USER_INFO_COOKIE_NAME", default=EDXMKTG_USER_INFO_COOKIE_NAME
+)
+
+# Determines whether the CSRF token can be transported on
+# unencrypted channels. It is set to False here for backward compatibility,
+# but it is highly recommended that this is True for environments accessed
+# by end users.
+CSRF_COOKIE_SECURE = config("CSRF_COOKIE_SECURE", default=False, formatter=bool)
+
+# Email overrides
+DEFAULT_FROM_EMAIL = config("DEFAULT_FROM_EMAIL", default=DEFAULT_FROM_EMAIL)
+DEFAULT_FEEDBACK_EMAIL = config(
+    "DEFAULT_FEEDBACK_EMAIL", default=DEFAULT_FEEDBACK_EMAIL
+)
+ADMINS = config("ADMINS", default=ADMINS, formatter=json.loads)
+SERVER_EMAIL = config("SERVER_EMAIL", default=SERVER_EMAIL)
+MKTG_URLS = config("MKTG_URLS", default=MKTG_URLS, formatter=json.loads)
+TECH_SUPPORT_EMAIL = config("TECH_SUPPORT_EMAIL", default=TECH_SUPPORT_EMAIL)
+
+for name, value in config("CODE_JAIL", default={}, formatter=json.loads).items():
+    oldvalue = CODE_JAIL.get(name)
+    if isinstance(oldvalue, dict):
+        for subname, subvalue in value.items():
+            oldvalue[subname] = subvalue
+    else:
+        CODE_JAIL[name] = value
+
+COURSES_WITH_UNSAFE_CODE = config(
+    "COURSES_WITH_UNSAFE_CODE", default=[], formatter=json.loads
+)
+
+ASSET_IGNORE_REGEX = config("ASSET_IGNORE_REGEX", default=ASSET_IGNORE_REGEX)
+
+LOCALE_PATHS = config("LOCALE_PATHS", default=LOCALE_PATHS, formatter=json.loads)
+
+COMPREHENSIVE_THEME_DIRS = (
+    config(
+        "COMPREHENSIVE_THEME_DIRS",
+        default=COMPREHENSIVE_THEME_DIRS,
+        formatter=json.loads,
+    )
+    or []
+)
+
+# COMPREHENSIVE_THEME_LOCALE_PATHS contain the paths to themes locale directories e.g.
+# "COMPREHENSIVE_THEME_LOCALE_PATHS" : [
+#        "/edx/src/edx-themes/conf/locale"
+#    ],
+COMPREHENSIVE_THEME_LOCALE_PATHS = config(
+    "COMPREHENSIVE_THEME_LOCALE_PATHS", default=[], formatter=json.loads
+)
+
+DEFAULT_SITE_THEME = config("DEFAULT_SITE_THEME", default=DEFAULT_SITE_THEME)
+ENABLE_COMPREHENSIVE_THEMING = config(
+    "ENABLE_COMPREHENSIVE_THEMING", default=ENABLE_COMPREHENSIVE_THEMING, formatter=bool
+)
+
+# Timezone overrides
+TIME_ZONE = config("TIME_ZONE", default=TIME_ZONE)
+
+# Push to LMS overrides
+GIT_REPO_EXPORT_DIR = config(
+    "GIT_REPO_EXPORT_DIR",
+    default=path("/edx/var/edxapp/export_course_repos"),
+    formatter=path,
+)
+
+# Translation overrides
+LANGUAGES = config("LANGUAGES", default=LANGUAGES, formatter=json.loads)
+LANGUAGE_CODE = config("LANGUAGE_CODE", default=LANGUAGE_CODE)
+LANGUAGE_COOKIE = config("LANGUAGE_COOKIE", default=LANGUAGE_COOKIE)
+
+USE_I18N = config("USE_I18N", default=USE_I18N, formatter=bool)
+ALL_LANGUAGES = config("ALL_LANGUAGES", default=ALL_LANGUAGES, formatter=json.loads)
+
+# Override feature by feature by whatever is being redefined in the settings.yaml file
+CONFIG_FEATURES = config("FEATURES", default={}, formatter=json.loads)
+FEATURES.update(CONFIG_FEATURES)
+
+# Additional installed apps
+for app in config("ADDL_INSTALLED_APPS", default=[], formatter=json.loads):
+    INSTALLED_APPS.append(app)
+
+WIKI_ENABLED = config("WIKI_ENABLED", default=WIKI_ENABLED, formatter=bool)
+
+# Configure Logging
+
+# Default format for syslog logging
+standard_format = "%(asctime)s %(levelname)s %(process)d [%(name)s] %(filename)s:%(lineno)d - %(message)s"
+syslog_format = (
+    "[variant:cms][%(name)s][env:sandbox] %(levelname)s "
+    "[{hostname}  %(process)d] [%(filename)s:%(lineno)d] - %(message)s"
+).format(hostname=platform.node().split(".")[0])
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "local": {
+            "formatter": "syslog_format",
+            "class": "logging.StreamHandler",
+            "level": "INFO",
+        },
+        "tracking": {
+            "formatter": "raw",
+            "class": "logging.StreamHandler",
+            "level": "DEBUG",
+        },
+        "console": {
+            "formatter": "standard",
+            "class": "logging.StreamHandler",
+            "level": "INFO",
+        },
+    },
+    "formatters": {
+        "raw": {"format": "%(message)s"},
+        "syslog_format": {"format": syslog_format},
+        "standard": {"format": standard_format},
+    },
+    "filters": {"require_debug_false": {"()": "django.utils.log.RequireDebugFalse"}},
+    "loggers": {
+        "": {"level": "INFO", "propagate": False, "handlers": ["console", "local"]},
+        "tracking": {"level": "DEBUG", "propagate": False, "handlers": ["tracking"]},
+    },
+}
+
+SENTRY_DSN = config("SENTRY_DSN", default=None)
+if SENTRY_DSN:
+    LOGGING["loggers"][""]["handlers"].append("sentry")
+    LOGGING["handlers"]["sentry"] = {
+        "class": "raven.handlers.logging.SentryHandler",
+        "dsn": SENTRY_DSN,
+        "level": "ERROR",
+        "environment": "production",
+        "release": RELEASE,
+    }
+
+# FIXME: the PLATFORM_NAME and PLATFORM_DESCRIPTION settings should be set to lazy translatable
+# strings but edX tries to serialize them with a default json serializer which breaks. We should
+# submit a PR to fix it in edx-platform
+PLATFORM_NAME = config("PLATFORM_NAME", default="Your Platform Name Here")
+PLATFORM_DESCRIPTION = config("PLATFORM_DESCRIPTION", default="Your Platform Description Here")
+STUDIO_NAME = config("STUDIO_NAME", default=STUDIO_NAME)
+STUDIO_SHORT_NAME = config("STUDIO_SHORT_NAME", default=STUDIO_SHORT_NAME)
+
+# Event Tracking
+TRACKING_IGNORE_URL_PATTERNS = config(
+    "TRACKING_IGNORE_URL_PATTERNS", default=TRACKING_IGNORE_URL_PATTERNS, formatter=json.loads
+)
+
+# Heartbeat
+HEARTBEAT_CHECKS = config(
+    "HEARTBEAT_CHECKS", default=HEARTBEAT_CHECKS, formatter=json.loads
+)
+HEARTBEAT_EXTENDED_CHECKS = config(
+    "HEARTBEAT_EXTENDED_CHECKS", default=HEARTBEAT_EXTENDED_CHECKS, formatter=json.loads
+)
+HEARTBEAT_CELERY_TIMEOUT = config(
+    "HEARTBEAT_CELERY_TIMEOUT", default=HEARTBEAT_CELERY_TIMEOUT, formatter=int
+)
+
+# Django CAS external authentication settings
+CAS_EXTRA_LOGIN_PARAMS = config(
+    "CAS_EXTRA_LOGIN_PARAMS", default=None, formatter=json.loads
+)
+if FEATURES.get("AUTH_USE_CAS"):
+    CAS_SERVER_URL = config("CAS_SERVER_URL", default=None)
+    AUTHENTICATION_BACKENDS = [
+        "django.contrib.auth.backends.ModelBackend",
+        "django_cas.backends.CASBackend",
+    ]
+    INSTALLED_APPS.append("django_cas")
+    MIDDLEWARE_CLASSES.append("django_cas.middleware.CASMiddleware")
+    CAS_ATTRIBUTE_CALLBACK = config(
+        "CAS_ATTRIBUTE_CALLBACK", default=None, formatter=json.loads
+    )
+    if CAS_ATTRIBUTE_CALLBACK:
+        import importlib
+
+        CAS_USER_DETAILS_RESOLVER = getattr(
+            importlib.import_module(CAS_ATTRIBUTE_CALLBACK["module"]),
+            CAS_ATTRIBUTE_CALLBACK["function"],
+        )
+
+# Specific setting for the File Upload Service to store media in a bucket.
+FILE_UPLOAD_STORAGE_BUCKET_NAME = config(
+    "FILE_UPLOAD_STORAGE_BUCKET_NAME", default="uploads"
+)
+FILE_UPLOAD_STORAGE_PREFIX = config(
+    "FILE_UPLOAD_STORAGE_PREFIX", default=FILE_UPLOAD_STORAGE_PREFIX
+)
+
+# Zendesk
+ZENDESK_URL = config("ZENDESK_URL", default=ZENDESK_URL)
+ZENDESK_CUSTOM_FIELDS = config(
+    "ZENDESK_CUSTOM_FIELDS", default=ZENDESK_CUSTOM_FIELDS, formatter=json.loads
+)
+
+################ SECURE AUTH ITEMS ###############################
+
+############### XBlock filesystem field config ##########
+DJFS = config("DJFS", default=None, formatter=json.loads)
+
+EMAIL_HOST_USER = config("EMAIL_HOST_USER", default=EMAIL_HOST_USER)
+EMAIL_HOST_PASSWORD = config("EMAIL_HOST_PASSWORD", default=EMAIL_HOST_PASSWORD)
+
+# Note that this is the Studio key for Segment. There is a separate key for the LMS.
+CMS_SEGMENT_KEY = config("SEGMENT_KEY", default=None)
+
+SECRET_KEY = config("SECRET_KEY", default="ThisIsAnExampleKeyForDevPurposeOnly")
+
+DEFAULT_FILE_STORAGE = config(
+    "DEFAULT_FILE_STORAGE", default="django.core.files.storage.FileSystemStorage"
+)
+
+USER_TASKS_ARTIFACT_STORAGE = COURSE_IMPORT_EXPORT_STORAGE
+
+# Databases
+
+DATABASE_ENGINE = config("DATABASE_ENGINE", default="django.db.backends.mysql")
+DATABASE_HOST = config("DATABASE_HOST", default="mysql")
+DATABASE_PORT = config("DATABASE_PORT", default=3306, formatter=int)
+DATABASE_NAME = config("DATABASE_NAME", default="edxapp")
+DATABASE_USER = config("DATABASE_USER", default="edxapp_user")
+DATABASE_PASSWORD = config("DATABASE_PASSWORD", default="password")
+
+DATABASES = config(
+    "DATABASES",
+    default={
+        "default": {
+            "ENGINE": DATABASE_ENGINE,
+            "HOST": DATABASE_HOST,
+            "PORT": DATABASE_PORT,
+            "NAME": DATABASE_NAME,
+            "USER": DATABASE_USER,
+            "PASSWORD": DATABASE_PASSWORD,
+        }
+    },
+    formatter=json.loads,
+)
+
+# Configure the MODULESTORE
+MODULESTORE = convert_module_store_setting_if_needed(
+    config("MODULESTORE", default=MODULESTORE, formatter=json.loads)
+)
+
+MONGODB_PASSWORD = config("MONGODB_PASSWORD", default="")
+MONGODB_HOST = config("MONGODB_HOST", default="mongodb")
+MONGODB_PORT = config("MONGODB_PORT", default=27017, formatter=int)
+MONGODB_NAME = config("MONGODB_NAME", default="edxapp")
+MONGODB_USER = config("MONGODB_USER", default=None)
+MONGODB_SSL = config("MONGODB_SSL", default=False, formatter=bool)
+MONGODB_REPLICASET = config("MONGODB_REPLICASET", default=None)
+# Accepted read_preference value can be found here https://github.com/mongodb/mongo-python-driver/blob/2.9.1/pymongo/read_preferences.py#L54
+MONGODB_READ_PREFERENCE = config("MONGODB_READ_PREFERENCE", default="PRIMARY")
+
+DOC_STORE_CONFIG = config(
+    "DOC_STORE_CONFIG",
+    default={
+        "collection": "modulestore",
+        "host": MONGODB_HOST,
+        "port": MONGODB_PORT,
+        "db": MONGODB_NAME,
+        "user": MONGODB_USER,
+        "password": MONGODB_PASSWORD,
+        "ssl": MONGODB_SSL,
+        "replicaSet": MONGODB_REPLICASET,
+        "read_preference": MONGODB_READ_PREFERENCE,
+    },
+    formatter=json.loads,
+)
+
+MODULESTORE_FIELD_OVERRIDE_PROVIDERS = config(
+    "MODULESTORE_FIELD_OVERRIDE_PROVIDERS",
+    default=MODULESTORE_FIELD_OVERRIDE_PROVIDERS,
+    formatter=json.loads,
+)
+
+XBLOCK_FIELD_DATA_WRAPPERS = config(
+    "XBLOCK_FIELD_DATA_WRAPPERS",
+    default=XBLOCK_FIELD_DATA_WRAPPERS,
+    formatter=json.loads,
+)
+
+CONTENTSTORE = config(
+    "CONTENTSTORE",
+    default={
+        "DOC_STORE_CONFIG": DOC_STORE_CONFIG,
+        "ENGINE": "xmodule.contentstore.mongo.MongoContentStore",
+    },
+    formatter=json.loads,
+)
+
+update_module_store_settings(MODULESTORE, doc_store_settings=DOC_STORE_CONFIG)
+
+# Datadog for events!
+DATADOG = config("DATADOG", default={}, formatter=json.loads)
+
+# TODO: deprecated (compatibility with previous settings)
+DATADOG["api_key"] = config("DATADOG_API", default=None)
+
+# Celery Broker
+CELERY_BROKER_TRANSPORT = config("CELERY_BROKER_TRANSPORT", default="redis")
+CELERY_BROKER_USER = config("CELERY_BROKER_USER", default="")
+CELERY_BROKER_PASSWORD = config("CELERY_BROKER_PASSWORD", default="")
+CELERY_BROKER_HOST = config("CELERY_BROKER_HOST", default="redis")
+CELERY_BROKER_PORT = config("CELERY_BROKER_PORT", default=6379, formatter=int)
+CELERY_BROKER_VHOST = config("CELERY_BROKER_VHOST", default=0, formatter=int)
+
+BROKER_URL = "{transport}://{user}:{password}@{host}:{port}/{vhost}".format(
+    transport=CELERY_BROKER_TRANSPORT,
+    user=CELERY_BROKER_USER,
+    password=CELERY_BROKER_PASSWORD,
+    host=CELERY_BROKER_HOST,
+    port=CELERY_BROKER_PORT,
+    vhost=CELERY_BROKER_VHOST,
+)
+BROKER_USE_SSL = config("CELERY_BROKER_USE_SSL", default=False, formatter=bool)
+
+# Message expiry time in seconds
+CELERY_EVENT_QUEUE_TTL = config("CELERY_EVENT_QUEUE_TTL", default=None, formatter=int)
+
+# Queue to use for updating grades due to grading policy change
+POLICY_CHANGE_GRADES_ROUTING_KEY = config(
+    "POLICY_CHANGE_GRADES_ROUTING_KEY", default=LOW_PRIORITY_QUEUE
+)
+
+# Event tracking
+TRACKING_BACKENDS.update(config("TRACKING_BACKENDS", default={}, formatter=json.loads))
+EVENT_TRACKING_BACKENDS["tracking_logs"]["OPTIONS"]["backends"].update(
+    config("EVENT_TRACKING_BACKENDS", default={}, formatter=json.loads)
+)
+EVENT_TRACKING_BACKENDS["segmentio"]["OPTIONS"]["processors"][0]["OPTIONS"][
+    "whitelist"
+].extend(
+    config("EVENT_TRACKING_SEGMENTIO_EMIT_WHITELIST", default=[], formatter=json.loads)
+)
+
+##### ACCOUNT LOCKOUT DEFAULT PARAMETERS #####
+MAX_FAILED_LOGIN_ATTEMPTS_ALLOWED = config(
+    "MAX_FAILED_LOGIN_ATTEMPTS_ALLOWED", default=5, formatter=int
+)
+MAX_FAILED_LOGIN_ATTEMPTS_LOCKOUT_PERIOD_SECS = config(
+    "MAX_FAILED_LOGIN_ATTEMPTS_LOCKOUT_PERIOD_SECS", default=15 * 60, formatter=int
+)
+
+#### PASSWORD POLICY SETTINGS #####
+PASSWORD_MIN_LENGTH = config("PASSWORD_MIN_LENGTH", default=12, formatter=int)
+PASSWORD_MAX_LENGTH = config("PASSWORD_MAX_LENGTH", default=None, formatter=int)
+
+PASSWORD_COMPLEXITY = config(
+    "PASSWORD_COMPLEXITY",
+    default={"UPPER": 1, "LOWER": 1, "DIGITS": 1},
+    formatter=json.loads,
+)
+PASSWORD_DICTIONARY_EDIT_DISTANCE_THRESHOLD = config(
+    "PASSWORD_DICTIONARY_EDIT_DISTANCE_THRESHOLD",
+    default=PASSWORD_DICTIONARY_EDIT_DISTANCE_THRESHOLD,
+    formatter=int,
+)
+PASSWORD_DICTIONARY = config("PASSWORD_DICTIONARY", default=[], formatter=json.loads)
+
+### INACTIVITY SETTINGS ####
+SESSION_INACTIVITY_TIMEOUT_IN_SECONDS = config(
+    "SESSION_INACTIVITY_TIMEOUT_IN_SECONDS", default=None, formatter=int
+)
+
+##### X-Frame-Options response header settings #####
+X_FRAME_OPTIONS = config("X_FRAME_OPTIONS", default=X_FRAME_OPTIONS)
+
+##### ADVANCED_SECURITY_CONFIG #####
+ADVANCED_SECURITY_CONFIG = config(
+    "ADVANCED_SECURITY_CONFIG", default={}, formatter=json.loads
+)
+
+################ ADVANCED COMPONENT/PROBLEM TYPES ###############
+
+ADVANCED_PROBLEM_TYPES = config(
+    "ADVANCED_PROBLEM_TYPES", default=ADVANCED_PROBLEM_TYPES, formatter=json.loads
+)
+
+################ VIDEO UPLOAD PIPELINE ###############
+
+VIDEO_UPLOAD_PIPELINE = config(
+    "VIDEO_UPLOAD_PIPELINE", default=VIDEO_UPLOAD_PIPELINE, formatter=json.loads
+)
+
+################ VIDEO IMAGE STORAGE ###############
+
+VIDEO_IMAGE_SETTINGS = config(
+    "VIDEO_IMAGE_SETTINGS", default=VIDEO_IMAGE_SETTINGS, formatter=json.loads
+)
+
+################ VIDEO TRANSCRIPTS STORAGE ###############
+
+VIDEO_TRANSCRIPTS_SETTINGS = config(
+    "VIDEO_TRANSCRIPTS_SETTINGS",
+    default=VIDEO_TRANSCRIPTS_SETTINGS,
+    formatter=json.loads,
+)
+
+################ PUSH NOTIFICATIONS ###############
+
+PARSE_KEYS = config("PARSE_KEYS", default={}, formatter=json.loads)
+
+
+# Video Caching. Pairing country codes with CDN URLs.
+# Example: {'CN': 'http://api.xuetangx.com/edx/video?s3_url='}
+VIDEO_CDN_URL = config("VIDEO_CDN_URL", default={}, formatter=json.loads)
+
+if FEATURES["ENABLE_COURSEWARE_INDEX"] or FEATURES["ENABLE_LIBRARY_INDEX"]:
+    # Use ElasticSearch for the search engine
+    SEARCH_ENGINE = "search.elastic.ElasticSearchEngine"
+
+ELASTIC_SEARCH_CONFIG = config(
+    "ELASTIC_SEARCH_CONFIG", default=[{}], formatter=json.loads
+)
+
+XBLOCK_SETTINGS = config("XBLOCK_SETTINGS", default={}, formatter=json.loads)
+XBLOCK_SETTINGS.setdefault("VideoDescriptor", {})["licensing_enabled"] = FEATURES.get(
+    "LICENSING", False
+)
+XBLOCK_SETTINGS.setdefault("VideoModule", {})["YOUTUBE_API_KEY"] = config(
+    "YOUTUBE_API_KEY", default=YOUTUBE_API_KEY
+)
+
+################# PROCTORING CONFIGURATION ##################
+
+PROCTORING_BACKEND_PROVIDER = config(
+    "PROCTORING_BACKEND_PROVIDER", default=PROCTORING_BACKEND_PROVIDER
+)
+PROCTORING_SETTINGS = config(
+    "PROCTORING_SETTINGS", default=PROCTORING_SETTINGS, formatter=json.loads
+)
+
+################# MICROSITE ####################
+# microsite specific configurations.
+MICROSITE_CONFIGURATION = config(
+    "MICROSITE_CONFIGURATION", default={}, formatter=json.loads
+)
+MICROSITE_ROOT_DIR = path(config("MICROSITE_ROOT_DIR", default=""))
+# this setting specify which backend to be used when pulling microsite specific configuration
+MICROSITE_BACKEND = config("MICROSITE_BACKEND", default=MICROSITE_BACKEND)
+# this setting specify which backend to be used when loading microsite specific templates
+MICROSITE_TEMPLATE_BACKEND = config(
+    "MICROSITE_TEMPLATE_BACKEND", default=MICROSITE_TEMPLATE_BACKEND
+)
+# TTL for microsite database template cache
+MICROSITE_DATABASE_TEMPLATE_CACHE_TTL = config(
+    "MICROSITE_DATABASE_TEMPLATE_CACHE_TTL",
+    default=MICROSITE_DATABASE_TEMPLATE_CACHE_TTL,
+    formatter=int,
+)
+
+############################ OAUTH2 Provider ###################################
+
+# OpenID Connect issuer ID. Normally the URL of the authentication endpoint.
+OAUTH_OIDC_ISSUER = config("OAUTH_OIDC_ISSUER", default=None)
+
+#### JWT configuration ####
+JWT_AUTH.update(config("JWT_AUTH", default={}, formatter=json.loads))
+
+######################## CUSTOM COURSES for EDX CONNECTOR ######################
+if FEATURES.get("CUSTOM_COURSES_EDX"):
+    INSTALLED_APPS.append("openedx.core.djangoapps.ccxcon.apps.CCXConnectorConfig")
+
+# Partner support link for CMS footer
+PARTNER_SUPPORT_EMAIL = config("PARTNER_SUPPORT_EMAIL", default=PARTNER_SUPPORT_EMAIL)
+
+# Affiliate cookie tracking
+AFFILIATE_COOKIE_NAME = config("AFFILIATE_COOKIE_NAME", default=AFFILIATE_COOKIE_NAME)
+
+############## Settings for Studio Context Sensitive Help ##############
+
+HELP_TOKENS_BOOKS = config(
+    "HELP_TOKENS_BOOKS", default=HELP_TOKENS_BOOKS, formatter=json.loads
+)
+
+############## Settings for CourseGraph ############################
+COURSEGRAPH_JOB_QUEUE = config("COURSEGRAPH_JOB_QUEUE", default=LOW_PRIORITY_QUEUE)
+
+########## Settings for video transcript migration tasks ############
+VIDEO_TRANSCRIPT_MIGRATIONS_JOB_QUEUE = config(
+    "VIDEO_TRANSCRIPT_MIGRATIONS_JOB_QUEUE", default=LOW_PRIORITY_QUEUE
+)
+
+########################## Parental controls config  #######################
+
+# The age at which a learner no longer requires parental consent, or None
+# if parental consent is never required.
+PARENTAL_CONSENT_AGE_LIMIT = config(
+    "PARENTAL_CONSENT_AGE_LIMIT", default=PARENTAL_CONSENT_AGE_LIMIT, formatter=int
+)
+
+########################## Extra middleware classes  #######################
+
+# Allow extra middleware classes to be added to the app through configuration.
+MIDDLEWARE_CLASSES.extend(
+    config("EXTRA_MIDDLEWARE_CLASSES", default=[], formatter=json.loads)
+)
+
+########################## Settings for Completion API #####################
+
+# Once a user has watched this percentage of a video, mark it as complete:
+# (0.0 = 0%, 1.0 = 100%)
+COMPLETION_VIDEO_COMPLETE_PERCENTAGE = config(
+    "COMPLETION_VIDEO_COMPLETE_PERCENTAGE",
+    default=COMPLETION_VIDEO_COMPLETE_PERCENTAGE,
+    formatter=float,
+)
+
+####################### Enterprise Settings ######################
+# A shared secret to be used for encrypting passwords passed from the enterprise api
+# to the enteprise reporting script.
+ENTERPRISE_REPORTING_SECRET = config(
+    "ENTERPRISE_REPORTING_SECRET", default=ENTERPRISE_REPORTING_SECRET
+)
+
+# A default dictionary to be used for filtering out enterprise customer catalog.
+ENTERPRISE_CUSTOMER_CATALOG_DEFAULT_CONTENT_FILTER = config(
+    "ENTERPRISE_CUSTOMER_CATALOG_DEFAULT_CONTENT_FILTER",
+    default=ENTERPRISE_CUSTOMER_CATALOG_DEFAULT_CONTENT_FILTER,
+)
+
+############### Settings for Retirement #####################
+RETIRED_USERNAME_PREFIX = config(
+    "RETIRED_USERNAME_PREFIX", default=RETIRED_USERNAME_PREFIX
+)
+RETIRED_EMAIL_PREFIX = config("RETIRED_EMAIL_PREFIX", default=RETIRED_EMAIL_PREFIX)
+RETIRED_EMAIL_DOMAIN = config("RETIRED_EMAIL_DOMAIN", default=RETIRED_EMAIL_DOMAIN)
+RETIREMENT_SERVICE_WORKER_USERNAME = config(
+    "RETIREMENT_SERVICE_WORKER_USERNAME", default=RETIREMENT_SERVICE_WORKER_USERNAME
+)
+RETIREMENT_STATES = config(
+    "RETIREMENT_STATES", default=RETIREMENT_STATES, formatter=json.loads
+)
+
+####################### Plugin Settings ##########################
+
+from openedx.core.djangoapps.plugins import (
+    plugin_settings,
+    constants as plugin_constants,
+)
+
+plugin_settings.add_plugins(
+    __name__, plugin_constants.ProjectType.CMS, plugin_constants.SettingsType.AWS
+)
+
+########################## Derive Any Derived Settings  #######################
+
+derive_settings(__name__)

--- a/releases/ironwood/2/bare/config/cms/docker_run_production.py
+++ b/releases/ironwood/2/bare/config/cms/docker_run_production.py
@@ -63,7 +63,6 @@ DEFAULT_PRIORITY_QUEUE = config(
     "DEFAULT_PRIORITY_QUEUE", default="edx.cms.core.default"
 )
 HIGH_PRIORITY_QUEUE = config("HIGH_PRIORITY_QUEUE", default="edx.cms.core.high")
-LOW_PRIORITY_QUEUE = config("LOW_PRIORITY_QUEUE", default="edx.cms.core.low")
 
 CELERY_DEFAULT_QUEUE = DEFAULT_PRIORITY_QUEUE
 CELERY_DEFAULT_ROUTING_KEY = DEFAULT_PRIORITY_QUEUE
@@ -73,7 +72,6 @@ CELERY_QUEUES = config(
     default={
         DEFAULT_PRIORITY_QUEUE: {},
         HIGH_PRIORITY_QUEUE: {},
-        LOW_PRIORITY_QUEUE: {},
     },
     formatter=json.loads,
 )
@@ -138,6 +136,12 @@ ENTERPRISE_API_URL = config(
 )
 ENTERPRISE_CONSENT_API_URL = config(
     "ENTERPRISE_CONSENT_API_URL", default=LMS_INTERNAL_ROOT_URL + "/consent/api/v1/"
+)
+
+# List of logout URIs for each IDA that the learner should be logged out of when they logout of the LMS. Only applies to
+# IDA for which the social auth flow uses DOT (Django OAuth Toolkit).
+IDA_LOGOUT_URI_LIST = config(
+    "IDA_LOGOUT_URI_LIST", default=[], formatter=json.loads
 )
 
 SITE_NAME = config("SITE_NAME", default=CMS_BASE)
@@ -375,13 +379,17 @@ if SENTRY_DSN:
 # strings but edX tries to serialize them with a default json serializer which breaks. We should
 # submit a PR to fix it in edx-platform
 PLATFORM_NAME = config("PLATFORM_NAME", default="Your Platform Name Here")
-PLATFORM_DESCRIPTION = config("PLATFORM_DESCRIPTION", default="Your Platform Description Here")
+PLATFORM_DESCRIPTION = config(
+    "PLATFORM_DESCRIPTION", default="Your Platform Description Here"
+)
 STUDIO_NAME = config("STUDIO_NAME", default=STUDIO_NAME)
 STUDIO_SHORT_NAME = config("STUDIO_SHORT_NAME", default=STUDIO_SHORT_NAME)
 
 # Event Tracking
 TRACKING_IGNORE_URL_PATTERNS = config(
-    "TRACKING_IGNORE_URL_PATTERNS", default=TRACKING_IGNORE_URL_PATTERNS, formatter=json.loads
+    "TRACKING_IGNORE_URL_PATTERNS",
+    default=TRACKING_IGNORE_URL_PATTERNS,
+    formatter=json.loads,
 )
 
 # Heartbeat
@@ -558,7 +566,7 @@ CELERY_EVENT_QUEUE_TTL = config("CELERY_EVENT_QUEUE_TTL", default=None, formatte
 
 # Queue to use for updating grades due to grading policy change
 POLICY_CHANGE_GRADES_ROUTING_KEY = config(
-    "POLICY_CHANGE_GRADES_ROUTING_KEY", default=LOW_PRIORITY_QUEUE
+    "POLICY_CHANGE_GRADES_ROUTING_KEY", default=DEFAULT_PRIORITY_QUEUE
 )
 
 # Event tracking
@@ -581,20 +589,9 @@ MAX_FAILED_LOGIN_ATTEMPTS_LOCKOUT_PERIOD_SECS = config(
 )
 
 #### PASSWORD POLICY SETTINGS #####
-PASSWORD_MIN_LENGTH = config("PASSWORD_MIN_LENGTH", default=12, formatter=int)
-PASSWORD_MAX_LENGTH = config("PASSWORD_MAX_LENGTH", default=None, formatter=int)
-
-PASSWORD_COMPLEXITY = config(
-    "PASSWORD_COMPLEXITY",
-    default={"UPPER": 1, "LOWER": 1, "DIGITS": 1},
-    formatter=json.loads,
+AUTH_PASSWORD_VALIDATORS = config(
+    "AUTH_PASSWORD_VALIDATORS", default=AUTH_PASSWORD_VALIDATORS
 )
-PASSWORD_DICTIONARY_EDIT_DISTANCE_THRESHOLD = config(
-    "PASSWORD_DICTIONARY_EDIT_DISTANCE_THRESHOLD",
-    default=PASSWORD_DICTIONARY_EDIT_DISTANCE_THRESHOLD,
-    formatter=int,
-)
-PASSWORD_DICTIONARY = config("PASSWORD_DICTIONARY", default=[], formatter=json.loads)
 
 ### INACTIVITY SETTINGS ####
 SESSION_INACTIVITY_TIMEOUT_IN_SECONDS = config(
@@ -603,11 +600,6 @@ SESSION_INACTIVITY_TIMEOUT_IN_SECONDS = config(
 
 ##### X-Frame-Options response header settings #####
 X_FRAME_OPTIONS = config("X_FRAME_OPTIONS", default=X_FRAME_OPTIONS)
-
-##### ADVANCED_SECURITY_CONFIG #####
-ADVANCED_SECURITY_CONFIG = config(
-    "ADVANCED_SECURITY_CONFIG", default={}, formatter=json.loads
-)
 
 ################ ADVANCED COMPONENT/PROBLEM TYPES ###############
 
@@ -660,15 +652,6 @@ XBLOCK_SETTINGS.setdefault("VideoModule", {})["YOUTUBE_API_KEY"] = config(
     "YOUTUBE_API_KEY", default=YOUTUBE_API_KEY
 )
 
-################# PROCTORING CONFIGURATION ##################
-
-PROCTORING_BACKEND_PROVIDER = config(
-    "PROCTORING_BACKEND_PROVIDER", default=PROCTORING_BACKEND_PROVIDER
-)
-PROCTORING_SETTINGS = config(
-    "PROCTORING_SETTINGS", default=PROCTORING_SETTINGS, formatter=json.loads
-)
-
 ################# MICROSITE ####################
 # microsite specific configurations.
 MICROSITE_CONFIGURATION = config(
@@ -713,11 +696,16 @@ HELP_TOKENS_BOOKS = config(
 )
 
 ############## Settings for CourseGraph ############################
-COURSEGRAPH_JOB_QUEUE = config("COURSEGRAPH_JOB_QUEUE", default=LOW_PRIORITY_QUEUE)
+COURSEGRAPH_JOB_QUEUE = config("COURSEGRAPH_JOB_QUEUE", default=DEFAULT_PRIORITY_QUEUE)
 
 ########## Settings for video transcript migration tasks ############
 VIDEO_TRANSCRIPT_MIGRATIONS_JOB_QUEUE = config(
-    "VIDEO_TRANSCRIPT_MIGRATIONS_JOB_QUEUE", default=LOW_PRIORITY_QUEUE
+    "VIDEO_TRANSCRIPT_MIGRATIONS_JOB_QUEUE", default=DEFAULT_PRIORITY_QUEUE
+)
+
+########## Settings youtube thumbnails scraper tasks ############
+SCRAPE_YOUTUBE_THUMBNAILS_JOB_QUEUE = config(
+    "SCRAPE_YOUTUBE_THUMBNAILS_JOB_QUEUE", default=DEFAULT_PRIORITY_QUEUE
 )
 
 ########################## Parental controls config  #######################
@@ -767,8 +755,14 @@ RETIRED_EMAIL_DOMAIN = config("RETIRED_EMAIL_DOMAIN", default=RETIRED_EMAIL_DOMA
 RETIREMENT_SERVICE_WORKER_USERNAME = config(
     "RETIREMENT_SERVICE_WORKER_USERNAME", default=RETIREMENT_SERVICE_WORKER_USERNAME
 )
+RETIRED_USER_SALTS = config("RETIRED_USER_SALTS", default=RETIRED_USER_SALTS)
 RETIREMENT_STATES = config(
     "RETIREMENT_STATES", default=RETIREMENT_STATES, formatter=json.loads
+)
+
+############## Settings for Course Enrollment Modes ######################
+COURSE_ENROLLMENT_MODES = config(
+    "COURSE_ENROLLMENT_MODES", default=COURSE_ENROLLMENT_MODES
 )
 
 ####################### Plugin Settings ##########################

--- a/releases/ironwood/2/bare/config/cms/docker_run_staging.py
+++ b/releases/ironwood/2/bare/config/cms/docker_run_staging.py
@@ -1,0 +1,14 @@
+# This file includes overrides to build the `staging` environment for the CMS starting from the
+# settings of the `production` environment
+
+from docker_run_production import *
+from lms.envs.fun.utils import Configuration
+
+# Load custom configuration parameters from yaml files
+config = Configuration(os.path.dirname(__file__))
+
+LOGGING["handlers"]["sentry"]["environment"] = "staging"
+
+EMAIL_BACKEND = config(
+    "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"
+)

--- a/releases/ironwood/2/bare/config/lms/backends.py
+++ b/releases/ironwood/2/bare/config/lms/backends.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+from ratelimitbackend.backends import RateLimitModelBackend
+
+
+class ProxyRateLimitModelBackend(RateLimitModelBackend):
+    """A rate limiting Backend that works behind a proxy."""
+
+    def get_ip(self, request):
+        """Return the end user address string as set by proxies."""
+        return request.META['HTTP_X_FORWARDED_FOR']

--- a/releases/ironwood/2/bare/config/lms/docker_build_development.py
+++ b/releases/ironwood/2/bare/config/lms/docker_build_development.py
@@ -1,0 +1,9 @@
+# This is a minimal settings file allowing us to run "update_assets"
+# in the Dockerfile for the development image of the edxapp LMS
+
+from .docker_build_production import *
+
+DEBUG = True
+REQUIRE_DEBUG = True
+
+WEBPACK_CONFIG_PATH = "webpack.dev.config.js"

--- a/releases/ironwood/2/bare/config/lms/docker_build_production.py
+++ b/releases/ironwood/2/bare/config/lms/docker_build_production.py
@@ -1,0 +1,24 @@
+# This is a minimal settings file allowing us to run "update_assets"
+# in the Dockerfile for the production image of the edxapp LMS
+
+from openedx.core.lib.derived import derive_settings
+from path import Path as path
+
+from .docker_run_production import *
+from .utils import Configuration
+
+# Load custom configuration parameters
+config = Configuration()
+
+DATABASES = {"default": {}}
+
+XQUEUE_INTERFACE = {"url": None, "django_auth": None}
+
+STATIC_ROOT = path("/edx/app/edxapp/staticfiles")
+
+# Allow setting a custom theme
+DEFAULT_SITE_THEME = config("DEFAULT_SITE_THEME", default=None)
+
+########################## Derive Any Derived Settings  #######################
+
+derive_settings(__name__)

--- a/releases/ironwood/2/bare/config/lms/docker_run.py
+++ b/releases/ironwood/2/bare/config/lms/docker_run.py
@@ -1,0 +1,3 @@
+# This file is meant to import the environment related settings file
+
+from docker_run_production import *

--- a/releases/ironwood/2/bare/config/lms/docker_run_ci.py
+++ b/releases/ironwood/2/bare/config/lms/docker_run_ci.py
@@ -1,0 +1,14 @@
+# This file includes overrides to build the `CI` environment for the LMS starting from the
+# settings of the `production` environment
+
+from docker_run_production import *
+
+
+DEBUG = True
+
+EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+
+PIPELINE_ENABLED = False
+STATICFILES_STORAGE = "openedx.core.storage.DevelopmentStorage"
+
+ALLOWED_HOSTS = ["*"]

--- a/releases/ironwood/2/bare/config/lms/docker_run_development.py
+++ b/releases/ironwood/2/bare/config/lms/docker_run_development.py
@@ -1,0 +1,33 @@
+# This file includes overrides to build the `development` environment for the LMS starting from the
+# settings of the `production` environment
+
+import json
+
+from docker_run_production import *
+from .utils import Configuration
+
+# Load custom configuration parameters from yaml files
+config = Configuration(os.path.dirname(__file__))
+
+if "sentry" in LOGGING.get("handlers"):
+    LOGGING["handlers"]["sentry"]["environment"] = "development"
+
+DEBUG = True
+REQUIRE_DEBUG = True
+
+EMAIL_BACKEND = config(
+    "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"
+)
+
+PIPELINE_ENABLED = False
+STATICFILES_STORAGE = "openedx.core.storage.DevelopmentStorage"
+
+ALLOWED_HOSTS = ["*"]
+
+WEBPACK_CONFIG_PATH = "webpack.dev.config.js"
+
+AUTHENTICATION_BACKENDS = config(
+    "AUTHENTICATION_BACKENDS",
+    default=["django.contrib.auth.backends.ModelBackend"],
+    formatter=json.loads
+)

--- a/releases/ironwood/2/bare/config/lms/docker_run_feature.py
+++ b/releases/ironwood/2/bare/config/lms/docker_run_feature.py
@@ -1,0 +1,14 @@
+# This file includes overrides to build the `feature` environment for the LMS starting from the
+# settings of the `production` environment
+
+from docker_run_production import *
+from .utils import Configuration
+
+# Load custom configuration parameters from yaml files
+config = Configuration(os.path.dirname(__file__))
+
+LOGGING["handlers"]["sentry"]["environment"] = "feature"
+
+EMAIL_BACKEND = config(
+    "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"
+)

--- a/releases/ironwood/2/bare/config/lms/docker_run_preprod.py
+++ b/releases/ironwood/2/bare/config/lms/docker_run_preprod.py
@@ -1,0 +1,14 @@
+# This file includes overrides to build the `preprod` environment for the LMS starting from the
+# settings of the `production` environment
+
+from docker_run_production import *
+from .utils import Configuration
+
+# Load custom configuration parameters from yaml files
+config = Configuration(os.path.dirname(__file__))
+
+LOGGING["handlers"]["sentry"]["environment"] = "preprod"
+
+EMAIL_BACKEND = config(
+    "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"
+)

--- a/releases/ironwood/2/bare/config/lms/docker_run_production.py
+++ b/releases/ironwood/2/bare/config/lms/docker_run_production.py
@@ -1,0 +1,1493 @@
+# -*- coding: utf-8 -*-
+
+"""
+This is the settings to run Open edX with Docker the FUN way.
+"""
+
+import datetime
+import dateutil
+import json
+import os
+import platform
+
+from openedx.core.lib.derived import derive_settings
+from path import Path as path
+from xmodule.modulestore.modulestore_settings import (
+    convert_module_store_setting_if_needed,
+)
+
+from ..common import *
+from .utils import Configuration
+
+# Load custom configuration parameters from yaml files
+config = Configuration(os.path.dirname(__file__))
+
+# edX has now started using "settings.ENV_TOKENS" and "settings.AUTH_TOKENS" everywhere in the
+# project, not just in the settings. Let's make sure our settings still work in this case
+ENV_TOKENS = config
+AUTH_TOKENS = config
+
+################################ ALWAYS THE SAME ##############################
+
+RELEASE = config("RELEASE", default=None)
+DEBUG = False
+DEFAULT_TEMPLATE_ENGINE["OPTIONS"]["debug"] = False
+
+SESSION_ENGINE = config(
+    "SESSION_ENGINE", default="django.contrib.sessions.backends.cache"
+)
+
+# IMPORTANT: With this enabled, the server must always be behind a proxy that
+# strips the header HTTP_X_FORWARDED_PROTO from client requests. Otherwise,
+# a user can fool our server into thinking it was an https connection.
+# See
+# https://docs.djangoproject.com/en/dev/ref/settings/#secure-proxy-ssl-header
+# for other warnings.
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
+###################################### CELERY  ################################
+
+CELERY_ALWAYS_EAGER = config("CELERY_ALWAYS_EAGER", default=False, formatter=bool)
+
+# Don't use a connection pool, since connections are dropped by ELB.
+BROKER_POOL_LIMIT = 0
+BROKER_CONNECTION_TIMEOUT = 1
+
+# For the Result Store, use the django cache named 'celery'
+CELERY_RESULT_BACKEND = config(
+    "CELERY_RESULT_BACKEND", default="djcelery.backends.cache:CacheBackend"
+)
+
+# When the broker is behind an ELB, use a heartbeat to refresh the
+# connection and to detect if it has been dropped.
+BROKER_HEARTBEAT = 60.0
+BROKER_HEARTBEAT_CHECKRATE = 2
+
+# Each worker should only fetch one message at a time
+CELERYD_PREFETCH_MULTIPLIER = 1
+
+# Celery queues
+
+DEFAULT_PRIORITY_QUEUE = config(
+    "DEFAULT_PRIORITY_QUEUE", default="edx.lms.core.default"
+)
+HIGH_PRIORITY_QUEUE = config("HIGH_PRIORITY_QUEUE", default="edx.lms.core.high")
+LOW_PRIORITY_QUEUE = config("LOW_PRIORITY_QUEUE", default="edx.lms.core.low")
+HIGH_MEM_QUEUE = config("HIGH_MEM_QUEUE", default="edx.lms.core.high_mem")
+
+CELERY_DEFAULT_QUEUE = DEFAULT_PRIORITY_QUEUE
+CELERY_DEFAULT_ROUTING_KEY = DEFAULT_PRIORITY_QUEUE
+
+CELERY_QUEUES = config(
+    "CELERY_QUEUES",
+    default={
+        DEFAULT_PRIORITY_QUEUE: {},
+        HIGH_PRIORITY_QUEUE: {},
+        LOW_PRIORITY_QUEUE: {},
+        HIGH_MEM_QUEUE: {},
+    },
+    formatter=json.loads,
+)
+
+CELERY_ROUTES = "lms.celery.Router"
+
+# Force accepted content to "json" only. If we also accept pickle-serialized
+# messages, the worker will crash when it's running with a privileged user (even
+# if it's not the root user but a user belonging to the root group, which is our
+# case with OpenShift).
+CELERY_ACCEPT_CONTENT = ["json"]
+
+CELERYBEAT_SCHEDULE = {}  # For scheduling tasks, entries can be added to this dict
+
+########################## NON-SECURE ENV CONFIG ##############################
+# Things like server locations, ports, etc.
+
+STATIC_ROOT_BASE = path("/edx/app/edxapp/staticfiles")
+STATIC_ROOT = STATIC_ROOT_BASE
+STATIC_URL = "/static/"
+STATICFILES_STORAGE = config(
+    "STATICFILES_STORAGE", default="lms.envs.fun.storage.CDNProductionStorage"
+)
+CDN_BASE_URL = config("CDN_BASE_URL", default=None)
+
+WEBPACK_LOADER["DEFAULT"]["STATS_FILE"] = STATIC_ROOT / "webpack-stats.json"
+
+MEDIA_ROOT = path("/edx/var/edxapp/media/")
+MEDIA_URL = "/media/"
+
+LOG_DIR = config("LOG_DIR", default=path("/edx/var/logs/edx"), formatter=path)
+DATA_DIR = config("DATA_DIR", default=path("/edx/app/edxapp/data"), formatter=path)
+
+# DEFAULT_COURSE_ABOUT_IMAGE_URL specifies the default image to show for courses that don't provide one
+DEFAULT_COURSE_ABOUT_IMAGE_URL = config(
+    "DEFAULT_COURSE_ABOUT_IMAGE_URL", default=DEFAULT_COURSE_ABOUT_IMAGE_URL
+)
+
+# COURSE_MODE_DEFAULTS specifies the course mode to use for courses that do not set one
+COURSE_MODE_DEFAULTS = config(
+    "COURSE_MODE_DEFAULTS", default=COURSE_MODE_DEFAULTS, formatter=json.loads
+)
+
+# FIXME: the PLATFORM_NAME and PLATFORM_DESCRIPTION settings should be set to lazy translatable
+# strings but edX tries to serialize them with a default json serializer which breaks. We should
+# submit a PR to fix it in edx-platform
+PLATFORM_NAME = config("PLATFORM_NAME", default="Your Platform Name Here")
+PLATFORM_DESCRIPTION = config(
+    "PLATFORM_DESCRIPTION", default="Your Platform Description Here"
+)
+PLATFORM_TWITTER_ACCOUNT = config(
+    "PLATFORM_TWITTER_ACCOUNT", default=PLATFORM_TWITTER_ACCOUNT
+)
+PLATFORM_FACEBOOK_ACCOUNT = config(
+    "PLATFORM_FACEBOOK_ACCOUNT", default=PLATFORM_FACEBOOK_ACCOUNT
+)
+SOCIAL_SHARING_SETTINGS = config(
+    "SOCIAL_SHARING_SETTINGS", default=SOCIAL_SHARING_SETTINGS, formatter=json.loads
+)
+
+# Social media links for the page footer
+SOCIAL_MEDIA_FOOTER_URLS = config(
+    "SOCIAL_MEDIA_FOOTER_URLS", default=SOCIAL_MEDIA_FOOTER_URLS, formatter=json.loads
+)
+
+CC_MERCHANT_NAME = config("CC_MERCHANT_NAME", default=PLATFORM_NAME)
+EMAIL_BACKEND = config(
+    "EMAIL_BACKEND", default="django.core.mail.backends.smtp.EmailBackend"
+)
+EMAIL_FILE_PATH = config("EMAIL_FILE_PATH", default=None)
+EMAIL_HOST = config("EMAIL_HOST", default="localhost")
+EMAIL_PORT = config("EMAIL_PORT", default=25, formatter=int)
+EMAIL_USE_TLS = config("EMAIL_USE_TLS", default=False, formatter=bool)
+HTTPS = config("HTTPS", default=HTTPS)
+SESSION_COOKIE_DOMAIN = config("SESSION_COOKIE_DOMAIN", default=None)
+SESSION_COOKIE_HTTPONLY = config(
+    "SESSION_COOKIE_HTTPONLY", default=True, formatter=bool
+)
+SESSION_COOKIE_SECURE = config(
+    "SESSION_COOKIE_SECURE", default=SESSION_COOKIE_SECURE, formatter=bool
+)
+SESSION_SAVE_EVERY_REQUEST = config(
+    "SESSION_SAVE_EVERY_REQUEST", default=SESSION_SAVE_EVERY_REQUEST, formatter=bool
+)
+
+REGISTRATION_EXTRA_FIELDS = config(
+    "REGISTRATION_EXTRA_FIELDS", default=REGISTRATION_EXTRA_FIELDS, formatter=json.loads
+)
+REGISTRATION_EXTENSION_FORM = config(
+    "REGISTRATION_EXTENSION_FORM", default=REGISTRATION_EXTENSION_FORM
+)
+REGISTRATION_EMAIL_PATTERNS_ALLOWED = config(
+    "REGISTRATION_EMAIL_PATTERNS_ALLOWED", default=None, formatter=json.loads
+)
+REGISTRATION_FIELD_ORDER = config(
+    "REGISTRATION_FIELD_ORDER", default=REGISTRATION_FIELD_ORDER, formatter=json.loads
+)
+
+# Set the names of cookies shared with the marketing site
+# These have the same cookie domain as the session, which in production
+# usually includes subdomains.
+EDXMKTG_LOGGED_IN_COOKIE_NAME = config(
+    "EDXMKTG_LOGGED_IN_COOKIE_NAME", default=EDXMKTG_LOGGED_IN_COOKIE_NAME
+)
+EDXMKTG_USER_INFO_COOKIE_NAME = config(
+    "EDXMKTG_USER_INFO_COOKIE_NAME", default=EDXMKTG_USER_INFO_COOKIE_NAME
+)
+
+# Override feature by feature by whatever is being redefined in the settings.yaml file
+CONFIG_FEATURES = config("FEATURES", default={}, formatter=json.loads)
+FEATURES.update(CONFIG_FEATURES)
+
+LMS_BASE = config("LMS_BASE", default="localhost:8072")
+CMS_BASE = config("CMS_BASE", default="localhost:8082")
+
+LMS_ROOT_URL = config("LMS_ROOT_URL", default="http://{:s}".format(LMS_BASE))
+LMS_INTERNAL_ROOT_URL = config("LMS_INTERNAL_ROOT_URL", default=LMS_ROOT_URL)
+
+SITE_NAME = config("SITE_NAME", default=LMS_BASE)
+
+ALLOWED_HOSTS = config(
+    "ALLOWED_HOSTS", default=[LMS_BASE.split(":")[0]], formatter=json.loads
+)
+if FEATURES.get("PREVIEW_LMS_BASE"):
+    ALLOWED_HOSTS.append(FEATURES["PREVIEW_LMS_BASE"])
+
+# allow for environments to specify what cookie name our login subsystem should use
+# this is to fix a bug regarding simultaneous logins between edx.org and edge.edx.org which can
+# happen with some browsers (e.g. Firefox)
+if config("SESSION_COOKIE_NAME", default=None):
+    # NOTE, there's a bug in Django (http://bugs.python.org/issue18012) which necessitates this
+    # being a str()
+    SESSION_COOKIE_NAME = str(config("SESSION_COOKIE_NAME"))
+
+MEMCACHED_HOST = config("MEMCACHED_HOST", default="memcached")
+MEMCACHED_PORT = config("MEMCACHED_PORT", default=11211, formatter=int)
+
+CACHES = config(
+    "CACHES",
+    default={
+        "default": {
+            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
+            "KEY_FUNCTION": "util.memcache.safe_key",
+        },
+        "general": {
+            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
+            "KEY_FUNCTION": "util.memcache.safe_key",
+        },
+        "loc_cache": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "edx_location_mem_cache",
+        },
+        "celery": {
+            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
+            "KEY_FUNCTION": "util.memcache.safe_key",
+            "KEY_PREFIX": "celery",
+        },
+        "mongo_metadata_inheritance": {
+            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
+            "KEY_FUNCTION": "util.memcache.safe_key",
+            "KEY_PREFIX": "mongo_metadata_inheritance",
+        },
+        "openassessment_submissions": {
+            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
+            "KEY_FUNCTION": "util.memcache.safe_key",
+            "KEY_PREFIX": "openassessment_submissions",
+        },
+        "staticfiles": {
+            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
+            "KEY_FUNCTION": "util.memcache.safe_key",
+            "KEY_PREFIX": "staticfiles",
+        },
+        "openassessment_submissions": {
+            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "LOCATION": "{}:{}".format(MEMCACHED_HOST, MEMCACHED_PORT),
+            "KEY_FUNCTION": "util.memcache.safe_key",
+            "KEY_PREFIX": "openassessment_submissions",
+        },
+    },
+    formatter=json.loads,
+)
+
+# Email overrides
+DEFAULT_FROM_EMAIL = config("DEFAULT_FROM_EMAIL", default=DEFAULT_FROM_EMAIL)
+DEFAULT_FEEDBACK_EMAIL = config(
+    "DEFAULT_FEEDBACK_EMAIL", default=DEFAULT_FEEDBACK_EMAIL
+)
+ADMINS = config("ADMINS", default=ADMINS, formatter=json.loads)
+SERVER_EMAIL = config("SERVER_EMAIL", default=SERVER_EMAIL)
+TECH_SUPPORT_EMAIL = config("TECH_SUPPORT_EMAIL", default=TECH_SUPPORT_EMAIL)
+CONTACT_EMAIL = config("CONTACT_EMAIL", default=CONTACT_EMAIL)
+BUGS_EMAIL = config("BUGS_EMAIL", default=BUGS_EMAIL)
+PAYMENT_SUPPORT_EMAIL = config("PAYMENT_SUPPORT_EMAIL", default=PAYMENT_SUPPORT_EMAIL)
+FINANCE_EMAIL = config("FINANCE_EMAIL", default=FINANCE_EMAIL)
+UNIVERSITY_EMAIL = config("UNIVERSITY_EMAIL", default=UNIVERSITY_EMAIL)
+PRESS_EMAIL = config("PRESS_EMAIL", default=PRESS_EMAIL)
+
+CONTACT_MAILING_ADDRESS = config(
+    "CONTACT_MAILING_ADDRESS", default=CONTACT_MAILING_ADDRESS
+)
+
+# Account activation email sender address
+ACTIVATION_EMAIL_FROM_ADDRESS = config(
+    "ACTIVATION_EMAIL_FROM_ADDRESS", default=DEFAULT_FROM_EMAIL
+)
+
+# Currency
+PAID_COURSE_REGISTRATION_CURRENCY = config(
+    "PAID_COURSE_REGISTRATION_CURRENCY", default=PAID_COURSE_REGISTRATION_CURRENCY
+)
+
+# Payment Report Settings
+PAYMENT_REPORT_GENERATOR_GROUP = config(
+    "PAYMENT_REPORT_GENERATOR_GROUP", default=PAYMENT_REPORT_GENERATOR_GROUP
+)
+
+# Bulk Email overrides
+BULK_EMAIL_DEFAULT_FROM_EMAIL = config(
+    "BULK_EMAIL_DEFAULT_FROM_EMAIL", default=BULK_EMAIL_DEFAULT_FROM_EMAIL
+)
+BULK_EMAIL_EMAILS_PER_TASK = config(
+    "BULK_EMAIL_EMAILS_PER_TASK", default=BULK_EMAIL_EMAILS_PER_TASK, formatter=int
+)
+BULK_EMAIL_DEFAULT_RETRY_DELAY = config(
+    "BULK_EMAIL_DEFAULT_RETRY_DELAY",
+    default=BULK_EMAIL_DEFAULT_RETRY_DELAY,
+    formatter=int,
+)
+BULK_EMAIL_MAX_RETRIES = config(
+    "BULK_EMAIL_MAX_RETRIES", default=BULK_EMAIL_MAX_RETRIES, formatter=int
+)
+BULK_EMAIL_INFINITE_RETRY_CAP = config(
+    "BULK_EMAIL_INFINITE_RETRY_CAP",
+    default=BULK_EMAIL_INFINITE_RETRY_CAP,
+    formatter=int,
+)
+BULK_EMAIL_LOG_SENT_EMAILS = config(
+    "BULK_EMAIL_LOG_SENT_EMAILS", default=BULK_EMAIL_LOG_SENT_EMAILS, formatter=bool
+)
+BULK_EMAIL_RETRY_DELAY_BETWEEN_SENDS = config(
+    "BULK_EMAIL_RETRY_DELAY_BETWEEN_SENDS",
+    default=BULK_EMAIL_RETRY_DELAY_BETWEEN_SENDS,
+    formatter=int,
+)
+# We want Bulk Email running on the high-priority queue, so we define the
+# routing key that points to it. At the moment, the name is the same.
+# We have to reset the value here, since we have changed the value of the queue name.
+BULK_EMAIL_ROUTING_KEY = config("BULK_EMAIL_ROUTING_KEY", default=HIGH_PRIORITY_QUEUE)
+
+# We can run smaller jobs on the low priority queue. See note above for why
+# we have to reset the value here.
+BULK_EMAIL_ROUTING_KEY_SMALL_JOBS = config(
+    "BULK_EMAIL_ROUTING_KEY_SMALL_JOBS", default=LOW_PRIORITY_QUEUE
+)
+
+# Queue to use for expiring old entitlements
+ENTITLEMENTS_EXPIRATION_ROUTING_KEY = config(
+    "ENTITLEMENTS_EXPIRATION_ROUTING_KEY", default=LOW_PRIORITY_QUEUE
+)
+
+# Message expiry time in seconds
+CELERY_EVENT_QUEUE_TTL = config("CELERY_EVENT_QUEUE_TTL", default=None, formatter=int)
+
+# following setting is for backward compatibility
+if config("COMPREHENSIVE_THEME_DIR", default=None):
+    COMPREHENSIVE_THEME_DIR = config("COMPREHENSIVE_THEME_DIR")
+
+COMPREHENSIVE_THEME_DIRS = (
+    config(
+        "COMPREHENSIVE_THEME_DIRS",
+        default=COMPREHENSIVE_THEME_DIRS,
+        formatter=json.loads,
+    )
+    or []
+)
+
+LOCALE_PATHS = config(
+    "LOCALE_PATHS", default=(REPO_ROOT + "/conf/locale",), formatter=json.loads
+)
+
+# COMPREHENSIVE_THEME_LOCALE_PATHS contain the paths to themes locale directories e.g.
+# "COMPREHENSIVE_THEME_LOCALE_PATHS" : [
+#        "/edx/src/edx-themes/conf/locale"
+#    ],
+COMPREHENSIVE_THEME_LOCALE_PATHS = config(
+    "COMPREHENSIVE_THEME_LOCALE_PATHS", default=[], formatter=json.loads
+)
+
+DEFAULT_SITE_THEME = config("DEFAULT_SITE_THEME", default=DEFAULT_SITE_THEME)
+ENABLE_COMPREHENSIVE_THEMING = config(
+    "ENABLE_COMPREHENSIVE_THEMING", default=ENABLE_COMPREHENSIVE_THEMING, formatter=bool
+)
+
+# Marketing link overrides
+MKTG_URL_LINK_MAP = config("MKTG_URL_LINK_MAP", default={}, formatter=json.loads)
+
+# Intentional defaults.
+SUPPORT_SITE_LINK = config("SUPPORT_SITE_LINK", default=SUPPORT_SITE_LINK)
+ID_VERIFICATION_SUPPORT_LINK = config(
+    "ID_VERIFICATION_SUPPORT_LINK", default=SUPPORT_SITE_LINK
+)
+PASSWORD_RESET_SUPPORT_LINK = config(
+    "PASSWORD_RESET_SUPPORT_LINK", default=SUPPORT_SITE_LINK
+)
+ACTIVATION_EMAIL_SUPPORT_LINK = config(
+    "ACTIVATION_EMAIL_SUPPORT_LINK", default=SUPPORT_SITE_LINK
+)
+
+# Mobile store URL overrides
+MOBILE_STORE_URLS = config(
+    "MOBILE_STORE_URLS", default=MOBILE_STORE_URLS, formatter=json.loads
+)
+
+# Timezone overrides
+TIME_ZONE = config("TIME_ZONE", default=TIME_ZONE)
+
+# Translation overrides
+LANGUAGES = config("LANGUAGES", default=LANGUAGES, formatter=json.loads)
+CERTIFICATE_TEMPLATE_LANGUAGES = config(
+    "CERTIFICATE_TEMPLATE_LANGUAGES",
+    default=CERTIFICATE_TEMPLATE_LANGUAGES,
+    formatter=json.loads,
+)
+LANGUAGE_DICT = dict(LANGUAGES)
+LANGUAGE_CODE = config("LANGUAGE_CODE", default=LANGUAGE_CODE)
+LANGUAGE_COOKIE = config("LANGUAGE_COOKIE", default=LANGUAGE_COOKIE)
+ALL_LANGUAGES = config("ALL_LANGUAGES", default=ALL_LANGUAGES, formatter=json.loads)
+
+USE_I18N = config("USE_I18N", default=USE_I18N, formatter=bool)
+
+# Additional installed apps
+for app in config("ADDL_INSTALLED_APPS", default=[], formatter=json.loads):
+    INSTALLED_APPS.append(app)
+
+WIKI_ENABLED = config("WIKI_ENABLED", default=WIKI_ENABLED, formatter=bool)
+local_loglevel = config("LOCAL_LOGLEVEL", default="INFO")
+
+# Default format for syslog logging
+standard_format = "%(asctime)s %(levelname)s %(process)d [%(name)s] %(filename)s:%(lineno)d - %(message)s"
+syslog_format = (
+    "[variant:lms][%(name)s][env:sandbox] %(levelname)s "
+    "[{hostname}  %(process)d] [%(filename)s:%(lineno)d] - %(message)s"
+).format(hostname=platform.node().split(".")[0])
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "local": {
+            "formatter": "syslog_format",
+            "class": "logging.StreamHandler",
+            "level": "INFO",
+        },
+        "tracking": {
+            "formatter": "raw",
+            "class": "logging.StreamHandler",
+            "level": "DEBUG",
+        },
+        "console": {
+            "formatter": "standard",
+            "class": "logging.StreamHandler",
+            "level": "INFO",
+        },
+    },
+    "formatters": {
+        "raw": {"format": "%(message)s"},
+        "syslog_format": {"format": syslog_format},
+        "standard": {"format": standard_format},
+    },
+    "filters": {"require_debug_false": {"()": "django.utils.log.RequireDebugFalse"}},
+    "loggers": {
+        "": {"level": "INFO", "propagate": False, "handlers": ["console", "local"]},
+        "tracking": {"level": "DEBUG", "propagate": False, "handlers": ["tracking"]},
+    },
+}
+
+SENTRY_DSN = config("SENTRY_DSN", default=None)
+if SENTRY_DSN:
+    LOGGING["loggers"][""]["handlers"].append("sentry")
+    LOGGING["handlers"]["sentry"] = {
+        "class": "raven.handlers.logging.SentryHandler",
+        "dsn": SENTRY_DSN,
+        "level": "ERROR",
+        "environment": "production",
+        "release": RELEASE,
+    }
+
+
+COURSE_LISTINGS = config("COURSE_LISTINGS", default={}, formatter=json.loads)
+COMMENTS_SERVICE_URL = config("COMMENTS_SERVICE_URL", default="")
+COMMENTS_SERVICE_KEY = config("COMMENTS_SERVICE_KEY", default="")
+CERT_NAME_SHORT = config("CERT_NAME_SHORT", default=CERT_NAME_SHORT)
+CERT_NAME_LONG = config("CERT_NAME_LONG", default=CERT_NAME_LONG)
+CERT_QUEUE = config("CERT_QUEUE", default="test-pull")
+
+FEEDBACK_SUBMISSION_EMAIL = config("FEEDBACK_SUBMISSION_EMAIL", default=None)
+MKTG_URLS = config("MKTG_URLS", default=MKTG_URLS, formatter=json.loads)
+
+# Badgr API
+BADGR_API_TOKEN = config("BADGR_API_TOKEN", default=BADGR_API_TOKEN)
+BADGR_BASE_URL = config("BADGR_BASE_URL", default=BADGR_BASE_URL)
+BADGR_ISSUER_SLUG = config("BADGR_ISSUER_SLUG", default=BADGR_ISSUER_SLUG)
+BADGR_TIMEOUT = config("BADGR_TIMEOUT", default=BADGR_TIMEOUT, formatter=int)
+
+# git repo loading  environment
+GIT_REPO_DIR = config(
+    "GIT_REPO_DIR", default=path("/edx/var/edxapp/course_repos"), formatter=path
+)
+GIT_IMPORT_STATIC = config("GIT_IMPORT_STATIC", default=True, formatter=bool)
+GIT_IMPORT_PYTHON_LIB = config("GIT_IMPORT_PYTHON_LIB", default=True, formatter=bool)
+PYTHON_LIB_FILENAME = config("PYTHON_LIB_FILENAME", default="python_lib.zip")
+
+for name, value in config("CODE_JAIL", default={}, formatter=json.loads).items():
+    oldvalue = CODE_JAIL.get(name)
+    if isinstance(oldvalue, dict):
+        for subname, subvalue in value.items():
+            oldvalue[subname] = subvalue
+    else:
+        CODE_JAIL[name] = value
+
+COURSES_WITH_UNSAFE_CODE = config(
+    "COURSES_WITH_UNSAFE_CODE", default=[], formatter=json.loads
+)
+
+ASSET_IGNORE_REGEX = config("ASSET_IGNORE_REGEX", default=ASSET_IGNORE_REGEX)
+
+# Event Tracking
+TRACKING_IGNORE_URL_PATTERNS = config(
+    "TRACKING_IGNORE_URL_PATTERNS",
+    default=TRACKING_IGNORE_URL_PATTERNS,
+    formatter=json.loads,
+)
+
+# SSL external authentication settings
+SSL_AUTH_EMAIL_DOMAIN = config("SSL_AUTH_EMAIL_DOMAIN", default="MIT.EDU")
+SSL_AUTH_DN_FORMAT_STRING = config("SSL_AUTH_DN_FORMAT_STRING", default=None)
+
+# Django CAS external authentication settings
+CAS_EXTRA_LOGIN_PARAMS = config(
+    "CAS_EXTRA_LOGIN_PARAMS", default=None, formatter=json.loads
+)
+if FEATURES.get("AUTH_USE_CAS"):
+    CAS_SERVER_URL = config("CAS_SERVER_URL", default=None)
+    INSTALLED_APPS.append("django_cas")
+    MIDDLEWARE_CLASSES.append("django_cas.middleware.CASMiddleware")
+    CAS_ATTRIBUTE_CALLBACK = config(
+        "CAS_ATTRIBUTE_CALLBACK", default=None, formatter=json.loads
+    )
+    if CAS_ATTRIBUTE_CALLBACK:
+        import importlib
+
+        CAS_USER_DETAILS_RESOLVER = getattr(
+            importlib.import_module(CAS_ATTRIBUTE_CALLBACK["module"]),
+            CAS_ATTRIBUTE_CALLBACK["function"],
+        )
+
+# Video Caching. Pairing country codes with CDN URLs.
+# Example: {'CN': 'http://api.xuetangx.com/edx/video?s3_url='}
+VIDEO_CDN_URL = config("VIDEO_CDN_URL", default={})
+
+# Branded footer
+FOOTER_OPENEDX_URL = config("FOOTER_OPENEDX_URL", default=FOOTER_OPENEDX_URL)
+FOOTER_OPENEDX_LOGO_IMAGE = config(
+    "FOOTER_OPENEDX_LOGO_IMAGE", default=FOOTER_OPENEDX_LOGO_IMAGE
+)
+FOOTER_ORGANIZATION_IMAGE = config(
+    "FOOTER_ORGANIZATION_IMAGE", default=FOOTER_ORGANIZATION_IMAGE
+)
+FOOTER_CACHE_TIMEOUT = config(
+    "FOOTER_CACHE_TIMEOUT", default=FOOTER_CACHE_TIMEOUT, formatter=int
+)
+FOOTER_BROWSER_CACHE_MAX_AGE = config(
+    "FOOTER_BROWSER_CACHE_MAX_AGE", default=FOOTER_BROWSER_CACHE_MAX_AGE, formatter=int
+)
+
+# Credit notifications settings
+NOTIFICATION_EMAIL_CSS = config(
+    "NOTIFICATION_EMAIL_CSS", default=NOTIFICATION_EMAIL_CSS
+)
+NOTIFICATION_EMAIL_EDX_LOGO = config(
+    "NOTIFICATION_EMAIL_EDX_LOGO", default=NOTIFICATION_EMAIL_EDX_LOGO
+)
+SECRET_KEY = config("SECRET_KEY", default="ThisIsAnExampleKeyForDevPurposeOnly")
+
+# Authentication backends
+# - behind a proxy, use: "lms.envs.fun.backends.ProxyRateLimitModelBackend"
+# - for LTI provider, add: "lti_provider.users.LtiBackend"
+# - for CAS, add: "django_cas.backends.CASBackend"
+AUTHENTICATION_BACKENDS = config(
+    "AUTHENTICATION_BACKENDS", default=AUTHENTICATION_BACKENDS
+)
+
+# Determines whether the CSRF token can be transported on
+# unencrypted channels. It is set to False here for backward compatibility,
+# but it is highly recommended that this is True for enviroments accessed
+# by end users.
+CSRF_COOKIE_SECURE = config("CSRF_COOKIE_SECURE", default=False, formatter=bool)
+
+############# CORS headers for cross-domain requests #################
+
+if FEATURES.get("ENABLE_CORS_HEADERS") or FEATURES.get(
+    "ENABLE_CROSS_DOMAIN_CSRF_COOKIE"
+):
+    CORS_ALLOW_CREDENTIALS = True
+    CORS_ORIGIN_WHITELIST = config(
+        "CORS_ORIGIN_WHITELIST", default=(), formatter=json.loads
+    )
+    CORS_ORIGIN_ALLOW_ALL = config(
+        "CORS_ORIGIN_ALLOW_ALL", default=False, formatter=bool
+    )
+    CORS_ALLOW_INSECURE = config("CORS_ALLOW_INSECURE", default=False, formatter=bool)
+
+    # If setting a cross-domain cookie, it's really important to choose
+    # a name for the cookie that is DIFFERENT than the cookies used
+    # by each subdomain.  For example, suppose the applications
+    # at these subdomains are configured to use the following cookie names:
+    #
+    # 1) foo.example.com --> "csrftoken"
+    # 2) baz.example.com --> "csrftoken"
+    # 3) bar.example.com --> "csrftoken"
+    #
+    # For the cross-domain version of the CSRF cookie, you need to choose
+    # a name DIFFERENT than "csrftoken"; otherwise, the new token configured
+    # for ".example.com" could conflict with the other cookies,
+    # non-deterministically causing 403 responses.
+    #
+    # Because of the way Django stores cookies, the cookie name MUST
+    # be a `str`, not unicode.  Otherwise there will `TypeError`s will be raised
+    # when Django tries to call the unicode `translate()` method with the wrong
+    # number of parameters.
+    CROSS_DOMAIN_CSRF_COOKIE_NAME = str(config("CROSS_DOMAIN_CSRF_COOKIE_NAME"))
+
+    # When setting the domain for the "cross-domain" version of the CSRF
+    # cookie, you should choose something like: ".example.com"
+    # (note the leading dot), where both the referer and the host
+    # are subdomains of "example.com".
+    #
+    # Browser security rules require that
+    # the cookie domain matches the domain of the server; otherwise
+    # the cookie won't get set.  And once the cookie gets set, the client
+    # needs to be on a domain that matches the cookie domain, otherwise
+    # the client won't be able to read the cookie.
+    CROSS_DOMAIN_CSRF_COOKIE_DOMAIN = config("CROSS_DOMAIN_CSRF_COOKIE_DOMAIN")
+
+
+# Field overrides. To use the IDDE feature, add
+# 'courseware.student_field_overrides.IndividualStudentOverrideProvider'.
+FIELD_OVERRIDE_PROVIDERS = tuple(
+    config("FIELD_OVERRIDE_PROVIDERS", default=[], formatter=json.loads)
+)
+
+############################## SECURE AUTH ITEMS ###############
+
+############### XBlock filesystem field config ##########
+DJFS = config("DJFS", default=None, formatter=json.loads)
+
+############### Module Store Items ##########
+HOSTNAME_MODULESTORE_DEFAULT_MAPPINGS = config(
+    "HOSTNAME_MODULESTORE_DEFAULT_MAPPINGS", default={}, formatter=json.loads
+)
+# PREVIEW DOMAIN must be present in HOSTNAME_MODULESTORE_DEFAULT_MAPPINGS for the preview to show
+# draft changes
+if "PREVIEW_LMS_BASE" in FEATURES and FEATURES["PREVIEW_LMS_BASE"] != "":
+    PREVIEW_DOMAIN = FEATURES["PREVIEW_LMS_BASE"].split(":")[0]
+    # update dictionary with preview domain regex
+    HOSTNAME_MODULESTORE_DEFAULT_MAPPINGS.update({PREVIEW_DOMAIN: "draft-preferred"})
+
+MODULESTORE_FIELD_OVERRIDE_PROVIDERS = config(
+    "MODULESTORE_FIELD_OVERRIDE_PROVIDERS",
+    default=MODULESTORE_FIELD_OVERRIDE_PROVIDERS,
+    formatter=json.loads,
+)
+
+XBLOCK_FIELD_DATA_WRAPPERS = config(
+    "XBLOCK_FIELD_DATA_WRAPPERS",
+    default=XBLOCK_FIELD_DATA_WRAPPERS,
+    formatter=json.loads,
+)
+
+############### Mixed Related(Secure/Not-Secure) Items ##########
+LMS_SEGMENT_KEY = config("LMS_SEGMENT_KEY", default=None)
+
+CC_PROCESSOR_NAME = config("CC_PROCESSOR_NAME", default=CC_PROCESSOR_NAME)
+CC_PROCESSOR = config("CC_PROCESSOR", default=CC_PROCESSOR, formatter=json.loads)
+
+
+DEFAULT_FILE_STORAGE = config(
+    "DEFAULT_FILE_STORAGE", default="django.core.files.storage.FileSystemStorage"
+)
+
+# Specific setting for the File Upload Service to store media in a bucket.
+FILE_UPLOAD_STORAGE_BUCKET_NAME = config(
+    "FILE_UPLOAD_STORAGE_BUCKET_NAME", default="uploads"
+)
+FILE_UPLOAD_STORAGE_PREFIX = config(
+    "FILE_UPLOAD_STORAGE_PREFIX", default=FILE_UPLOAD_STORAGE_PREFIX
+)
+
+# Databases
+
+# If there is a database called 'read_replica', you can use the use_read_replica_if_available
+# function in util/query.py, which is useful for very large database reads
+
+DATABASE_ENGINE = config("DATABASE_ENGINE", default="django.db.backends.mysql")
+DATABASE_HOST = config("DATABASE_HOST", default="mysql")
+DATABASE_PORT = config("DATABASE_PORT", default=3306, formatter=int)
+DATABASE_NAME = config("DATABASE_NAME", default="edxapp")
+DATABASE_USER = config("DATABASE_USER", default="edxapp_user")
+DATABASE_PASSWORD = config("DATABASE_PASSWORD", default="password")
+
+DATABASES = config(
+    "DATABASES",
+    default={
+        "default": {
+            "ENGINE": DATABASE_ENGINE,
+            "HOST": DATABASE_HOST,
+            "PORT": DATABASE_PORT,
+            "NAME": DATABASE_NAME,
+            "USER": DATABASE_USER,
+            "PASSWORD": DATABASE_PASSWORD,
+        }
+    },
+    formatter=json.loads,
+)
+
+XQUEUE_INTERFACE = config(
+    "XQUEUE_INTERFACE",
+    default={"url": None, "basic_auth": None, "django_auth": None},
+    formatter=json.loads,
+)
+
+# Configure the MODULESTORE
+MODULESTORE = convert_module_store_setting_if_needed(
+    config("MODULESTORE", default=MODULESTORE, formatter=json.loads)
+)
+
+MONGODB_PASSWORD = config("MONGODB_PASSWORD", default="")
+MONGODB_HOST = config("MONGODB_HOST", default="mongodb")
+MONGODB_PORT = config("MONGODB_PORT", default=27017, formatter=int)
+MONGODB_NAME = config("MONGODB_NAME", default="edxapp")
+MONGODB_USER = config("MONGODB_USER", default=None)
+MONGODB_SSL = config("MONGODB_SSL", default=False, formatter=bool)
+MONGODB_REPLICASET = config("MONGODB_REPLICASET", default=None)
+# Accepted read_preference value can be found here https://github.com/mongodb/mongo-python-driver/blob/2.9.1/pymongo/read_preferences.py#L54
+MONGODB_READ_PREFERENCE = config("MONGODB_READ_PREFERENCE", default="PRIMARY")
+
+DOC_STORE_CONFIG = config(
+    "DOC_STORE_CONFIG",
+    default={
+        "collection": "modulestore",
+        "host": MONGODB_HOST,
+        "port": MONGODB_PORT,
+        "db": MONGODB_NAME,
+        "user": MONGODB_USER,
+        "password": MONGODB_PASSWORD,
+        "ssl": MONGODB_SSL,
+        "replicaSet": MONGODB_REPLICASET,
+        "read_preference": MONGODB_READ_PREFERENCE,
+    },
+    formatter=json.loads,
+)
+
+MONGODB_LOG = config("MONGODB_LOG", default={}, formatter=json.loads)
+
+CONTENTSTORE = config(
+    "CONTENTSTORE",
+    default={
+        "DOC_STORE_CONFIG": DOC_STORE_CONFIG,
+        "ENGINE": "xmodule.contentstore.mongo.MongoContentStore",
+    },
+    formatter=json.loads,
+)
+
+update_module_store_settings(MODULESTORE, doc_store_settings=DOC_STORE_CONFIG)
+
+EMAIL_HOST_USER = config("EMAIL_HOST_USER", default="")  # django default is ''
+EMAIL_HOST_PASSWORD = config("EMAIL_HOST_PASSWORD", default="")  # django default is ''
+
+# Datadog for events!
+DATADOG = config("DATADOG", default={}, formatter=json.loads)
+
+# TODO: deprecated (compatibility with previous settings)
+DATADOG_API = config("DATADOG_API", default=None)
+
+# Analytics API
+ANALYTICS_API_KEY = config("ANALYTICS_API_KEY", default=ANALYTICS_API_KEY)
+ANALYTICS_API_URL = config("ANALYTICS_API_URL", default=ANALYTICS_API_URL)
+
+# Mailchimp New User List
+MAILCHIMP_NEW_USER_LIST_ID = config("MAILCHIMP_NEW_USER_LIST_ID", default=None)
+
+# Zendesk
+ZENDESK_URL = config("ZENDESK_URL", default=None)
+ZENDESK_USER = config("ZENDESK_USER", default=None)
+ZENDESK_API_KEY = config("ZENDESK_API_KEY", default=None)
+ZENDESK_CUSTOM_FIELDS = config(
+    "ZENDESK_CUSTOM_FIELDS", default={}, formatter=json.loads
+)
+
+# API Key for inbound requests from Notifier service
+EDX_API_KEY = config("EDX_API_KEY", default=None)
+
+# Celery Broker
+CELERY_BROKER_TRANSPORT = config("CELERY_BROKER_TRANSPORT", default="redis")
+CELERY_BROKER_USER = config("CELERY_BROKER_USER", default="")
+CELERY_BROKER_PASSWORD = config("CELERY_BROKER_PASSWORD", default="")
+CELERY_BROKER_HOST = config("CELERY_BROKER_HOST", default="redis")
+CELERY_BROKER_PORT = config("CELERY_BROKER_PORT", default=6379, formatter=int)
+CELERY_BROKER_VHOST = config("CELERY_BROKER_VHOST", default=0, formatter=int)
+
+BROKER_URL = "{transport}://{user}:{password}@{host}:{port}/{vhost}".format(
+    transport=CELERY_BROKER_TRANSPORT,
+    user=CELERY_BROKER_USER,
+    password=CELERY_BROKER_PASSWORD,
+    host=CELERY_BROKER_HOST,
+    port=CELERY_BROKER_PORT,
+    vhost=CELERY_BROKER_VHOST,
+)
+BROKER_USE_SSL = config("CELERY_BROKER_USE_SSL", default=False, formatter=bool)
+
+# Block Structures
+BLOCK_STRUCTURES_SETTINGS = config(
+    "BLOCK_STRUCTURES_SETTINGS", default=BLOCK_STRUCTURES_SETTINGS, formatter=json.loads
+)
+
+# upload limits
+STUDENT_FILEUPLOAD_MAX_SIZE = config(
+    "STUDENT_FILEUPLOAD_MAX_SIZE", default=STUDENT_FILEUPLOAD_MAX_SIZE, formatter=int
+)
+
+# Event tracking
+TRACKING_BACKENDS.update(config("TRACKING_BACKENDS", default={}, formatter=json.loads))
+EVENT_TRACKING_BACKENDS["tracking_logs"]["OPTIONS"]["backends"].update(
+    config("EVENT_TRACKING_BACKENDS", default={}, formatter=json.loads)
+)
+EVENT_TRACKING_BACKENDS["segmentio"]["OPTIONS"]["processors"][0]["OPTIONS"][
+    "whitelist"
+].extend(
+    config("EVENT_TRACKING_SEGMENTIO_EMIT_WHITELIST", default=[], formatter=json.loads)
+)
+TRACKING_SEGMENTIO_WEBHOOK_SECRET = config(
+    "TRACKING_SEGMENTIO_WEBHOOK_SECRET", default=TRACKING_SEGMENTIO_WEBHOOK_SECRET
+)
+TRACKING_SEGMENTIO_ALLOWED_TYPES = config(
+    "TRACKING_SEGMENTIO_ALLOWED_TYPES",
+    default=TRACKING_SEGMENTIO_ALLOWED_TYPES,
+    formatter=json.loads,
+)
+TRACKING_SEGMENTIO_DISALLOWED_SUBSTRING_NAMES = config(
+    "TRACKING_SEGMENTIO_DISALLOWED_SUBSTRING_NAMES",
+    default=TRACKING_SEGMENTIO_DISALLOWED_SUBSTRING_NAMES,
+    formatter=json.loads,
+)
+TRACKING_SEGMENTIO_SOURCE_MAP = config(
+    "TRACKING_SEGMENTIO_SOURCE_MAP",
+    default=TRACKING_SEGMENTIO_SOURCE_MAP,
+    formatter=json.loads,
+)
+
+# Heartbeat
+HEARTBEAT_CHECKS = config(
+    "HEARTBEAT_CHECKS", default=HEARTBEAT_CHECKS, formatter=json.loads
+)
+HEARTBEAT_EXTENDED_CHECKS = config(
+    "HEARTBEAT_EXTENDED_CHECKS", default=HEARTBEAT_EXTENDED_CHECKS, formatter=json.loads
+)
+HEARTBEAT_CELERY_TIMEOUT = config(
+    "HEARTBEAT_CELERY_TIMEOUT", default=HEARTBEAT_CELERY_TIMEOUT, formatter=int
+)
+
+# Student identity verification settings
+VERIFY_STUDENT = config("VERIFY_STUDENT", default=VERIFY_STUDENT, formatter=json.loads)
+DISABLE_ACCOUNT_ACTIVATION_REQUIREMENT_SWITCH = config(
+    "DISABLE_ACCOUNT_ACTIVATION_REQUIREMENT_SWITCH",
+    default=DISABLE_ACCOUNT_ACTIVATION_REQUIREMENT_SWITCH,
+)
+
+# Grades download
+GRADES_DOWNLOAD_ROUTING_KEY = config(
+    "GRADES_DOWNLOAD_ROUTING_KEY", default=HIGH_MEM_QUEUE
+)
+
+GRADES_DOWNLOAD = config(
+    "GRADES_DOWNLOAD", default=GRADES_DOWNLOAD, formatter=json.loads
+)
+
+# Rate limit for regrading tasks that a grading policy change can kick off
+POLICY_CHANGE_TASK_RATE_LIMIT = config(
+    "POLICY_CHANGE_TASK_RATE_LIMIT", default=POLICY_CHANGE_TASK_RATE_LIMIT
+)
+
+# financial reports
+FINANCIAL_REPORTS = config(
+    "FINANCIAL_REPORTS", default=FINANCIAL_REPORTS, formatter=json.loads
+)
+
+##### ORA2 ######
+ORA2_FILEUPLOAD_BACKEND = config("ORA2_FILEUPLOAD_BACKEND", default="filesystem")
+
+# Prefix for uploads of example-based assessment AI classifiers
+# This can be used to separate uploads for different environments
+ORA2_FILE_PREFIX = config("ORA2_FILE_PREFIX", default=ORA2_FILE_PREFIX)
+
+# If backend is "filesystem"
+ORA2_FILEUPLOAD_ROOT = DATA_DIR / "openassessment_submissions"
+ORA2_FILEUPLOAD_CACHE_NAME = config(
+    "ORA2_FILEUPLOAD_CACHE_NAME", default="openassessment_submissions"
+)
+
+# If backend is "swift"
+ORA2_SWIFT_KEY = config("ORA2_SWIFT_KEY", default="")
+ORA2_SWIFT_URL = config("ORA2_SWIFT_URL", default="")
+
+##### ACCOUNT LOCKOUT DEFAULT PARAMETERS #####
+MAX_FAILED_LOGIN_ATTEMPTS_ALLOWED = config(
+    "MAX_FAILED_LOGIN_ATTEMPTS_ALLOWED", default=5, formatter=int
+)
+MAX_FAILED_LOGIN_ATTEMPTS_LOCKOUT_PERIOD_SECS = config(
+    "MAX_FAILED_LOGIN_ATTEMPTS_LOCKOUT_PERIOD_SECS", default=15 * 60, formatter=int
+)
+
+#### PASSWORD POLICY SETTINGS #####
+PASSWORD_MIN_LENGTH = config("PASSWORD_MIN_LENGTH", default=12, formatter=int)
+PASSWORD_MAX_LENGTH = config("PASSWORD_MAX_LENGTH", default=None, formatter=int)
+
+PASSWORD_COMPLEXITY = config(
+    "PASSWORD_COMPLEXITY",
+    default={"UPPER": 1, "LOWER": 1, "DIGITS": 1},
+    formatter=json.loads,
+)
+PASSWORD_DICTIONARY_EDIT_DISTANCE_THRESHOLD = config(
+    "PASSWORD_DICTIONARY_EDIT_DISTANCE_THRESHOLD",
+    default=PASSWORD_DICTIONARY_EDIT_DISTANCE_THRESHOLD,
+    formatter=int,
+)
+PASSWORD_DICTIONARY = config("PASSWORD_DICTIONARY", default=[], formatter=json.loads)
+
+### INACTIVITY SETTINGS ####
+SESSION_INACTIVITY_TIMEOUT_IN_SECONDS = config(
+    "SESSION_INACTIVITY_TIMEOUT_IN_SECONDS", default=None, formatter=int
+)
+
+##### LMS DEADLINE DISPLAY TIME_ZONE #######
+TIME_ZONE_DISPLAYED_FOR_DEADLINES = config(
+    "TIME_ZONE_DISPLAYED_FOR_DEADLINES", default=TIME_ZONE_DISPLAYED_FOR_DEADLINES
+)
+
+##### X-Frame-Options response header settings #####
+X_FRAME_OPTIONS = config("X_FRAME_OPTIONS", default=X_FRAME_OPTIONS)
+
+##### Third-party auth options ################################################
+if FEATURES.get("ENABLE_THIRD_PARTY_AUTH"):
+    # The reduced session expiry time during the third party login pipeline. (Value in seconds)
+    SOCIAL_AUTH_PIPELINE_TIMEOUT = config(
+        "SOCIAL_AUTH_PIPELINE_TIMEOUT", default=600, formatter=int
+    )
+
+    # The SAML private/public key values do not need the delimiter lines (such as
+    # "-----BEGIN PRIVATE KEY-----", "-----END PRIVATE KEY-----" etc.) but they may be included
+    # if you want (though it's easier to format the key values as JSON without the delimiters).
+    SOCIAL_AUTH_SAML_SP_PRIVATE_KEY = config(
+        "SOCIAL_AUTH_SAML_SP_PRIVATE_KEY", default={}, formatter=json.loads
+    )
+    SOCIAL_AUTH_SAML_SP_PUBLIC_CERT = config(
+        "SOCIAL_AUTH_SAML_SP_PUBLIC_CERT", default={}, formatter=json.loads
+    )
+    SOCIAL_AUTH_OAUTH_SECRETS = config("SOCIAL_AUTH_OAUTH_SECRETS", default={})
+    SOCIAL_AUTH_LTI_CONSUMER_SECRETS = config(
+        "SOCIAL_AUTH_LTI_CONSUMER_SECRETS", default={}, formatter=json.loads
+    )
+
+    # third_party_auth config moved to ConfigurationModels. This is for data migration only:
+    THIRD_PARTY_AUTH_OLD_CONFIG = config("THIRD_PARTY_AUTH", default=None)
+
+    if (
+        config("THIRD_PARTY_AUTH_SAML_FETCH_PERIOD_HOURS", default=24, formatter=int)
+        is not None
+    ):
+        CELERYBEAT_SCHEDULE["refresh-saml-metadata"] = {
+            "task": "third_party_auth.fetch_saml_metadata",
+            "schedule": datetime.timedelta(
+                hours=config(
+                    "THIRD_PARTY_AUTH_SAML_FETCH_PERIOD_HOURS",
+                    default=24,
+                    formatter=int,
+                )
+            ),
+        }
+
+    # The following can be used to integrate a custom login form with third_party_auth.
+    # It should be a dict where the key is a word passed via ?auth_entry=, and the value is a
+    # dict with an arbitrary 'secret_key' and a 'url'.
+    THIRD_PARTY_AUTH_CUSTOM_AUTH_FORMS = config(
+        "THIRD_PARTY_AUTH_CUSTOM_AUTH_FORMS", default={}, formatter=json.loads
+    )
+
+##### OAUTH2 Provider ##############
+if FEATURES.get("ENABLE_OAUTH2_PROVIDER"):
+    OAUTH_OIDC_ISSUER = config("OAUTH_OIDC_ISSUER")
+    OAUTH_ENFORCE_SECURE = config("OAUTH_ENFORCE_SECURE", default=True, formatter=bool)
+    OAUTH_ENFORCE_CLIENT_SECURE = config(
+        "OAUTH_ENFORCE_CLIENT_SECURE", default=True, formatter=bool
+    )
+    # Defaults for the following are defined in lms.envs.common
+    OAUTH_EXPIRE_DELTA = datetime.timedelta(
+        days=config(
+            "OAUTH_EXPIRE_CONFIDENTIAL_CLIENT_DAYS",
+            default=OAUTH_EXPIRE_CONFIDENTIAL_CLIENT_DAYS,
+            formatter=int,
+        )
+    )
+    OAUTH_EXPIRE_DELTA_PUBLIC = datetime.timedelta(
+        days=config(
+            "OAUTH_EXPIRE_PUBLIC_CLIENT_DAYS",
+            default=OAUTH_EXPIRE_PUBLIC_CLIENT_DAYS,
+            formatter=int,
+        )
+    )
+    OAUTH_ID_TOKEN_EXPIRATION = config(
+        "OAUTH_ID_TOKEN_EXPIRATION", default=OAUTH_ID_TOKEN_EXPIRATION, formatter=int
+    )
+    OAUTH_DELETE_EXPIRED = config(
+        "OAUTH_DELETE_EXPIRED", default=OAUTH_DELETE_EXPIRED, formatter=bool
+    )
+
+##### ADVANCED_SECURITY_CONFIG #####
+ADVANCED_SECURITY_CONFIG = config(
+    "ADVANCED_SECURITY_CONFIG", default={}, formatter=json.loads
+)
+
+##### GOOGLE ANALYTICS IDS #####
+GOOGLE_ANALYTICS_ACCOUNT = config("GOOGLE_ANALYTICS_ACCOUNT", default=None)
+GOOGLE_ANALYTICS_TRACKING_ID = config("GOOGLE_ANALYTICS_TRACKING_ID", default=None)
+GOOGLE_ANALYTICS_LINKEDIN = config("GOOGLE_ANALYTICS_LINKEDIN", default=None)
+GOOGLE_SITE_VERIFICATION_ID = config("GOOGLE_SITE_VERIFICATION_ID", default=None)
+
+##### BRANCH.IO KEY #####
+BRANCH_IO_KEY = config("BRANCH_IO_KEY", default=None)
+
+##### OPTIMIZELY PROJECT ID #####
+OPTIMIZELY_PROJECT_ID = config("OPTIMIZELY_PROJECT_ID", default=OPTIMIZELY_PROJECT_ID)
+
+#### Course Registration Code length ####
+REGISTRATION_CODE_LENGTH = config("REGISTRATION_CODE_LENGTH", default=8, formatter=int)
+
+# REGISTRATION CODES DISPLAY INFORMATION
+INVOICE_CORP_ADDRESS = config("INVOICE_CORP_ADDRESS", default=INVOICE_CORP_ADDRESS)
+INVOICE_PAYMENT_INSTRUCTIONS = config(
+    "INVOICE_PAYMENT_INSTRUCTIONS", default=INVOICE_PAYMENT_INSTRUCTIONS
+)
+
+# Which access.py permission names to check;
+# We default this to the legacy permission 'see_exists'.
+COURSE_CATALOG_VISIBILITY_PERMISSION = config(
+    "COURSE_CATALOG_VISIBILITY_PERMISSION", default=COURSE_CATALOG_VISIBILITY_PERMISSION
+)
+COURSE_ABOUT_VISIBILITY_PERMISSION = config(
+    "COURSE_ABOUT_VISIBILITY_PERMISSION", default=COURSE_ABOUT_VISIBILITY_PERMISSION
+)
+
+DEFAULT_COURSE_VISIBILITY_IN_CATALOG = config(
+    "DEFAULT_COURSE_VISIBILITY_IN_CATALOG", default=DEFAULT_COURSE_VISIBILITY_IN_CATALOG
+)
+
+DEFAULT_MOBILE_AVAILABLE = config(
+    "DEFAULT_MOBILE_AVAILABLE", default=DEFAULT_MOBILE_AVAILABLE, formatter=bool
+)
+
+# Enrollment API Cache Timeout
+ENROLLMENT_COURSE_DETAILS_CACHE_TIMEOUT = config(
+    "ENROLLMENT_COURSE_DETAILS_CACHE_TIMEOUT", default=60, formatter=int
+)
+
+# PDF RECEIPT/INVOICE OVERRIDES
+PDF_RECEIPT_TAX_ID = config("PDF_RECEIPT_TAX_ID", default=PDF_RECEIPT_TAX_ID)
+PDF_RECEIPT_FOOTER_TEXT = config(
+    "PDF_RECEIPT_FOOTER_TEXT", default=PDF_RECEIPT_FOOTER_TEXT
+)
+PDF_RECEIPT_DISCLAIMER_TEXT = config(
+    "PDF_RECEIPT_DISCLAIMER_TEXT", default=PDF_RECEIPT_DISCLAIMER_TEXT
+)
+PDF_RECEIPT_BILLING_ADDRESS = config(
+    "PDF_RECEIPT_BILLING_ADDRESS", default=PDF_RECEIPT_BILLING_ADDRESS
+)
+PDF_RECEIPT_TERMS_AND_CONDITIONS = config(
+    "PDF_RECEIPT_TERMS_AND_CONDITIONS", default=PDF_RECEIPT_TERMS_AND_CONDITIONS
+)
+PDF_RECEIPT_TAX_ID_LABEL = config(
+    "PDF_RECEIPT_TAX_ID_LABEL", default=PDF_RECEIPT_TAX_ID_LABEL
+)
+PDF_RECEIPT_LOGO_PATH = config("PDF_RECEIPT_LOGO_PATH", default=PDF_RECEIPT_LOGO_PATH)
+PDF_RECEIPT_COBRAND_LOGO_PATH = config(
+    "PDF_RECEIPT_COBRAND_LOGO_PATH", default=PDF_RECEIPT_COBRAND_LOGO_PATH
+)
+PDF_RECEIPT_LOGO_HEIGHT_MM = config(
+    "PDF_RECEIPT_LOGO_HEIGHT_MM", default=PDF_RECEIPT_LOGO_HEIGHT_MM, formatter=int
+)
+PDF_RECEIPT_COBRAND_LOGO_HEIGHT_MM = config(
+    "PDF_RECEIPT_COBRAND_LOGO_HEIGHT_MM",
+    default=PDF_RECEIPT_COBRAND_LOGO_HEIGHT_MM,
+    formatter=int,
+)
+
+if (
+    FEATURES.get("ENABLE_COURSEWARE_SEARCH")
+    or FEATURES.get("ENABLE_DASHBOARD_SEARCH")
+    or FEATURES.get("ENABLE_COURSE_DISCOVERY")
+    or FEATURES.get("ENABLE_TEAMS")
+):
+    # Use ElasticSearch as the search engine herein
+    SEARCH_ENGINE = "search.elastic.ElasticSearchEngine"
+
+ELASTIC_SEARCH_CONFIG = config(
+    "ELASTIC_SEARCH_CONFIG", default=[{}], formatter=json.loads
+)
+
+# Facebook app
+FACEBOOK_API_VERSION = config("FACEBOOK_API_VERSION", default=None)
+FACEBOOK_APP_SECRET = config(
+    "FACEBOOK_APP_SECRET", default="ThisIsAnExampleKeyForDevPurposeOnly"
+)
+FACEBOOK_APP_ID = config("FACEBOOK_APP_ID", default=None)
+
+XBLOCK_SETTINGS = config("XBLOCK_SETTINGS", default={}, formatter=json.loads)
+XBLOCK_SETTINGS.setdefault("VideoDescriptor", {})["licensing_enabled"] = FEATURES.get(
+    "LICENSING", False
+)
+XBLOCK_SETTINGS.setdefault("VideoModule", {})["YOUTUBE_API_KEY"] = config(
+    "YOUTUBE_API_KEY", default=YOUTUBE_API_KEY
+)
+
+##### VIDEO IMAGE STORAGE #####
+VIDEO_IMAGE_SETTINGS = config(
+    "VIDEO_IMAGE_SETTINGS", default=VIDEO_IMAGE_SETTINGS, formatter=json.loads
+)
+
+##### VIDEO TRANSCRIPTS STORAGE #####
+VIDEO_TRANSCRIPTS_SETTINGS = config(
+    "VIDEO_TRANSCRIPTS_SETTINGS",
+    default=VIDEO_TRANSCRIPTS_SETTINGS,
+    formatter=json.loads,
+)
+
+##### ECOMMERCE API CONFIGURATION SETTINGS #####
+ECOMMERCE_PUBLIC_URL_ROOT = config(
+    "ECOMMERCE_PUBLIC_URL_ROOT", default=ECOMMERCE_PUBLIC_URL_ROOT
+)
+ECOMMERCE_API_URL = config("ECOMMERCE_API_URL", default=ECOMMERCE_API_URL)
+ECOMMERCE_API_TIMEOUT = config(
+    "ECOMMERCE_API_TIMEOUT", default=ECOMMERCE_API_TIMEOUT, formatter=int
+)
+
+COURSE_CATALOG_API_URL = config(
+    "COURSE_CATALOG_API_URL", default=COURSE_CATALOG_API_URL
+)
+
+ECOMMERCE_SERVICE_WORKER_USERNAME = config(
+    "ECOMMERCE_SERVICE_WORKER_USERNAME", default=ECOMMERCE_SERVICE_WORKER_USERNAME
+)
+
+##### Custom Courses for EdX #####
+if FEATURES.get("CUSTOM_COURSES_EDX"):
+    INSTALLED_APPS += [
+        "lms.djangoapps.ccx",
+        "openedx.core.djangoapps.ccxcon.apps.CCXConnectorConfig",
+    ]
+    MODULESTORE_FIELD_OVERRIDE_PROVIDERS += (
+        "lms.djangoapps.ccx.overrides.CustomCoursesForEdxOverrideProvider",
+    )
+CCX_MAX_STUDENTS_ALLOWED = config(
+    "CCX_MAX_STUDENTS_ALLOWED", default=CCX_MAX_STUDENTS_ALLOWED, formatter=int
+)
+
+##### Individual Due Date Extensions #####
+if FEATURES.get("INDIVIDUAL_DUE_DATES"):
+    FIELD_OVERRIDE_PROVIDERS += (
+        "courseware.student_field_overrides.IndividualStudentOverrideProvider",
+    )
+
+##### Self-Paced Course Due Dates #####
+XBLOCK_FIELD_DATA_WRAPPERS += (
+    "lms.djangoapps.courseware.field_overrides:OverrideModulestoreFieldData.wrap",
+)
+
+MODULESTORE_FIELD_OVERRIDE_PROVIDERS += (
+    "courseware.self_paced_overrides.SelfPacedDateOverrideProvider",
+)
+
+# PROFILE IMAGE CONFIG
+PROFILE_IMAGE_BACKEND = config("PROFILE_IMAGE_BACKEND", default=PROFILE_IMAGE_BACKEND)
+PROFILE_IMAGE_SECRET_KEY = config(
+    "PROFILE_IMAGE_SECRET_KEY", default=PROFILE_IMAGE_SECRET_KEY
+)
+PROFILE_IMAGE_MAX_BYTES = config(
+    "PROFILE_IMAGE_MAX_BYTES", default=PROFILE_IMAGE_MAX_BYTES, formatter=int
+)
+PROFILE_IMAGE_MIN_BYTES = config(
+    "PROFILE_IMAGE_MIN_BYTES", default=PROFILE_IMAGE_MIN_BYTES, formatter=int
+)
+PROFILE_IMAGE_DEFAULT_FILENAME = "images/profiles/default"
+PROFILE_IMAGE_SIZES_MAP = config(
+    "PROFILE_IMAGE_SIZES_MAP", default=PROFILE_IMAGE_SIZES_MAP, formatter=json.loads
+)
+
+# EdxNotes config
+
+EDXNOTES_PUBLIC_API = config("EDXNOTES_PUBLIC_API", default=EDXNOTES_PUBLIC_API)
+EDXNOTES_INTERNAL_API = config("EDXNOTES_INTERNAL_API", default=EDXNOTES_INTERNAL_API)
+
+EDXNOTES_CONNECT_TIMEOUT = config(
+    "EDXNOTES_CONNECT_TIMEOUT", default=EDXNOTES_CONNECT_TIMEOUT, formatter=int
+)
+EDXNOTES_READ_TIMEOUT = config(
+    "EDXNOTES_READ_TIMEOUT", default=EDXNOTES_READ_TIMEOUT, formatter=int
+)
+
+##### Credit Provider Integration #####
+
+CREDIT_PROVIDER_SECRET_KEYS = config(
+    "CREDIT_PROVIDER_SECRET_KEYS", default={}, formatter=json.loads
+)
+
+##################### LTI Provider #####################
+if FEATURES.get("ENABLE_LTI_PROVIDER"):
+    INSTALLED_APPS.append("lti_provider.apps.LtiProviderConfig")
+
+LTI_USER_EMAIL_DOMAIN = config("LTI_USER_EMAIL_DOMAIN", default="lti.example.com")
+
+# For more info on this, see the notes in common.py
+LTI_AGGREGATE_SCORE_PASSBACK_DELAY = config(
+    "LTI_AGGREGATE_SCORE_PASSBACK_DELAY",
+    default=LTI_AGGREGATE_SCORE_PASSBACK_DELAY,
+    formatter=int,
+)
+
+##################### Credit Provider help link ####################
+CREDIT_HELP_LINK_URL = config("CREDIT_HELP_LINK_URL", default=CREDIT_HELP_LINK_URL)
+
+#### JWT configuration ####
+DEFAULT_JWT_ISSUER = config("DEFAULT_JWT_ISSUER", default=DEFAULT_JWT_ISSUER)
+RESTRICTED_APPLICATION_JWT_ISSUER = config(
+    "RESTRICTED_APPLICATION_JWT_ISSUER", default=RESTRICTED_APPLICATION_JWT_ISSUER
+)
+JWT_AUTH.update(config("JWT_AUTH", default={}, formatter=json.loads))
+JWT_PRIVATE_SIGNING_KEY = config(
+    "JWT_PRIVATE_SIGNING_KEY", default=JWT_PRIVATE_SIGNING_KEY
+)
+JWT_EXPIRED_PRIVATE_SIGNING_KEYS = config(
+    "JWT_EXPIRED_PRIVATE_SIGNING_KEYS",
+    default=JWT_EXPIRED_PRIVATE_SIGNING_KEYS,
+    formatter=json.loads,
+)
+
+################# PROCTORING CONFIGURATION ##################
+
+PROCTORING_BACKEND_PROVIDER = config(
+    "PROCTORING_BACKEND_PROVIDER", default=PROCTORING_BACKEND_PROVIDER
+)
+PROCTORING_SETTINGS = config(
+    "PROCTORING_SETTINGS", default=PROCTORING_SETTINGS, formatter=json.loads
+)
+
+################# MICROSITE ####################
+MICROSITE_CONFIGURATION = config(
+    "MICROSITE_CONFIGURATION", default={}, formatter=json.loads
+)
+MICROSITE_ROOT_DIR = path(config("MICROSITE_ROOT_DIR", default=""))
+# this setting specify which backend to be used when pulling microsite specific configuration
+MICROSITE_BACKEND = config("MICROSITE_BACKEND", default=MICROSITE_BACKEND)
+# this setting specify which backend to be used when loading microsite specific templates
+MICROSITE_TEMPLATE_BACKEND = config(
+    "MICROSITE_TEMPLATE_BACKEND", default=MICROSITE_TEMPLATE_BACKEND
+)
+# TTL for microsite database template cache
+MICROSITE_DATABASE_TEMPLATE_CACHE_TTL = config(
+    "MICROSITE_DATABASE_TEMPLATE_CACHE_TTL",
+    default=MICROSITE_DATABASE_TEMPLATE_CACHE_TTL,
+    formatter=int,
+)
+
+# Offset for pk of courseware.StudentModuleHistoryExtended
+STUDENTMODULEHISTORYEXTENDED_OFFSET = config(
+    "STUDENTMODULEHISTORYEXTENDED_OFFSET",
+    default=STUDENTMODULEHISTORYEXTENDED_OFFSET,
+    formatter=int,
+)
+
+# Cutoff date for granting audit certificates
+AUDIT_CERT_CUTOFF_DATE = config(
+    "AUDIT_CERT_CUTOFF_DATE", default=None, formatter=dateutil.parser.parse
+)
+
+################################ Settings for Credentials Service ################################
+
+CREDENTIALS_GENERATION_ROUTING_KEY = config(
+    "CREDENTIALS_GENERATION_ROUTING_KEY", default=HIGH_PRIORITY_QUEUE
+)
+
+# The extended StudentModule history table
+if FEATURES.get("ENABLE_CSMH_EXTENDED"):
+    INSTALLED_APPS.append("coursewarehistoryextended")
+
+API_ACCESS_MANAGER_EMAIL = config(
+    "API_ACCESS_MANAGER_EMAIL", default=API_ACCESS_MANAGER_EMAIL
+)
+API_ACCESS_FROM_EMAIL = config("API_ACCESS_FROM_EMAIL", default=API_ACCESS_FROM_EMAIL)
+
+# Mobile App Version Upgrade config
+APP_UPGRADE_CACHE_TIMEOUT = config(
+    "APP_UPGRADE_CACHE_TIMEOUT", default=APP_UPGRADE_CACHE_TIMEOUT, formatter=int
+)
+
+AFFILIATE_COOKIE_NAME = config("AFFILIATE_COOKIE_NAME", default=AFFILIATE_COOKIE_NAME)
+
+############## Settings for LMS Context Sensitive Help ##############
+
+HELP_TOKENS_BOOKS = config(
+    "HELP_TOKENS_BOOKS", default=HELP_TOKENS_BOOKS, formatter=json.loads
+)
+
+
+############## OPEN EDX ENTERPRISE SERVICE CONFIGURATION ######################
+# The Open edX Enterprise service is currently hosted via the LMS container/process.
+# However, for all intents and purposes this service is treated as a standalone IDA.
+# These configuration settings are specific to the Enterprise service and you should
+# not find references to them within the edx-platform project.
+
+# Publicly-accessible enrollment URL, for use on the client side.
+ENTERPRISE_PUBLIC_ENROLLMENT_API_URL = config(
+    "ENTERPRISE_PUBLIC_ENROLLMENT_API_URL",
+    default=(LMS_ROOT_URL or "") + LMS_ENROLLMENT_API_PATH,
+)
+
+# Enrollment URL used on the server-side.
+ENTERPRISE_ENROLLMENT_API_URL = config(
+    "ENTERPRISE_ENROLLMENT_API_URL",
+    default=(LMS_INTERNAL_ROOT_URL or "") + LMS_ENROLLMENT_API_PATH,
+)
+
+# Enterprise logo image size limit in KB's
+ENTERPRISE_CUSTOMER_LOGO_IMAGE_SIZE = config(
+    "ENTERPRISE_CUSTOMER_LOGO_IMAGE_SIZE",
+    default=ENTERPRISE_CUSTOMER_LOGO_IMAGE_SIZE,
+    formatter=int,
+)
+
+# Course enrollment modes to be hidden in the Enterprise enrollment page
+# if the "Hide audit track" flag is enabled for an EnterpriseCustomer
+ENTERPRISE_COURSE_ENROLLMENT_AUDIT_MODES = config(
+    "ENTERPRISE_COURSE_ENROLLMENT_AUDIT_MODES",
+    default=ENTERPRISE_COURSE_ENROLLMENT_AUDIT_MODES,
+    formatter=json.loads,
+)
+
+# A support URL used on Enterprise landing pages for when a warning
+# message goes off.
+ENTERPRISE_SUPPORT_URL = config(
+    "ENTERPRISE_SUPPORT_URL", default=ENTERPRISE_SUPPORT_URL
+)
+
+# A shared secret to be used for encrypting passwords passed from the enterprise api
+# to the enteprise reporting script.
+ENTERPRISE_REPORTING_SECRET = config(
+    "ENTERPRISE_REPORTING_SECRET", default=ENTERPRISE_REPORTING_SECRET
+)
+
+# A default dictionary to be used for filtering out enterprise customer catalog.
+ENTERPRISE_CUSTOMER_CATALOG_DEFAULT_CONTENT_FILTER = config(
+    "ENTERPRISE_CUSTOMER_CATALOG_DEFAULT_CONTENT_FILTER",
+    default=ENTERPRISE_CUSTOMER_CATALOG_DEFAULT_CONTENT_FILTER,
+)
+
+############## ENTERPRISE SERVICE API CLIENT CONFIGURATION ######################
+# The LMS communicates with the Enterprise service via the EdxRestApiClient class
+# The below environmental settings are utilized by the LMS when interacting with
+# the service, and override the default parameters which are defined in common.py
+
+DEFAULT_ENTERPRISE_API_URL = None
+if LMS_INTERNAL_ROOT_URL is not None:
+    DEFAULT_ENTERPRISE_API_URL = LMS_INTERNAL_ROOT_URL + "/enterprise/api/v1/"
+ENTERPRISE_API_URL = config("ENTERPRISE_API_URL", default=DEFAULT_ENTERPRISE_API_URL)
+
+DEFAULT_ENTERPRISE_CONSENT_API_URL = None
+if LMS_INTERNAL_ROOT_URL is not None:
+    DEFAULT_ENTERPRISE_CONSENT_API_URL = LMS_INTERNAL_ROOT_URL + "/consent/api/v1/"
+ENTERPRISE_CONSENT_API_URL = config(
+    "ENTERPRISE_CONSENT_API_URL", default=DEFAULT_ENTERPRISE_CONSENT_API_URL
+)
+
+ENTERPRISE_SERVICE_WORKER_USERNAME = config(
+    "ENTERPRISE_SERVICE_WORKER_USERNAME", default=ENTERPRISE_SERVICE_WORKER_USERNAME
+)
+ENTERPRISE_API_CACHE_TIMEOUT = config(
+    "ENTERPRISE_API_CACHE_TIMEOUT", default=ENTERPRISE_API_CACHE_TIMEOUT, formatter=int
+)
+
+############## ENTERPRISE SERVICE LMS CONFIGURATION ##################################
+# The LMS has some features embedded that are related to the Enterprise service, but
+# which are not provided by the Enterprise service. These settings override the
+# base values for the parameters as defined in common.py
+
+ENTERPRISE_PLATFORM_WELCOME_TEMPLATE = config(
+    "ENTERPRISE_PLATFORM_WELCOME_TEMPLATE", default=ENTERPRISE_PLATFORM_WELCOME_TEMPLATE
+)
+ENTERPRISE_SPECIFIC_BRANDED_WELCOME_TEMPLATE = config(
+    "ENTERPRISE_SPECIFIC_BRANDED_WELCOME_TEMPLATE",
+    default=ENTERPRISE_SPECIFIC_BRANDED_WELCOME_TEMPLATE,
+)
+ENTERPRISE_TAGLINE = config("ENTERPRISE_TAGLINE", default=ENTERPRISE_TAGLINE)
+ENTERPRISE_EXCLUDED_REGISTRATION_FIELDS = set(
+    config(
+        "ENTERPRISE_EXCLUDED_REGISTRATION_FIELDS",
+        default=ENTERPRISE_EXCLUDED_REGISTRATION_FIELDS,
+        formatter=json.loads,
+    )
+)
+BASE_COOKIE_DOMAIN = config("BASE_COOKIE_DOMAIN", default=BASE_COOKIE_DOMAIN)
+
+############## CATALOG/DISCOVERY SERVICE API CLIENT CONFIGURATION ######################
+# The LMS communicates with the Catalog service via the EdxRestApiClient class
+# The below environmental settings are utilized by the LMS when interacting with
+# the service, and override the default parameters which are defined in common.py
+
+COURSES_API_CACHE_TIMEOUT = config(
+    "COURSES_API_CACHE_TIMEOUT", default=COURSES_API_CACHE_TIMEOUT, formatter=int
+)
+
+# Add an ICP license for serving content in China if your organization is registered to do so
+ICP_LICENSE = config("ICP_LICENSE", default=None, formatter=bool)
+
+############## Settings for CourseGraph ############################
+COURSEGRAPH_JOB_QUEUE = config("COURSEGRAPH_JOB_QUEUE", default=LOW_PRIORITY_QUEUE)
+
+########################## Parental controls config  #######################
+
+# The age at which a learner no longer requires parental consent, or None
+# if parental consent is never required.
+PARENTAL_CONSENT_AGE_LIMIT = config(
+    "PARENTAL_CONSENT_AGE_LIMIT", default=PARENTAL_CONSENT_AGE_LIMIT, formatter=int
+)
+
+# Do NOT calculate this dynamically at startup with git because it's *slow*.
+EDX_PLATFORM_REVISION = config("EDX_PLATFORM_REVISION", default=EDX_PLATFORM_REVISION)
+
+########################## Extra middleware classes  #######################
+
+# Allow extra middleware classes to be added to the app through configuration.
+MIDDLEWARE_CLASSES.extend(
+    config("EXTRA_MIDDLEWARE_CLASSES", default=[], formatter=json.loads)
+)
+
+########################## Settings for Completion API #####################
+
+# Once a user has watched this percentage of a video, mark it as complete:
+# (0.0 = 0%, 1.0 = 100%)
+COMPLETION_VIDEO_COMPLETE_PERCENTAGE = config(
+    "COMPLETION_VIDEO_COMPLETE_PERCENTAGE",
+    default=COMPLETION_VIDEO_COMPLETE_PERCENTAGE,
+    formatter=float,
+)
+# The time a block needs to be viewed to be considered complete, in milliseconds.
+COMPLETION_BY_VIEWING_DELAY_MS = config(
+    "COMPLETION_BY_VIEWING_DELAY_MS",
+    default=COMPLETION_BY_VIEWING_DELAY_MS,
+    formatter=int,
+)
+
+############### Settings for django-fernet-fields ##################
+FERNET_KEYS = config("FERNET_KEYS", default=FERNET_KEYS, formatter=json.loads)
+
+################# Settings for the maintenance banner #################
+MAINTENANCE_BANNER_TEXT = config("MAINTENANCE_BANNER_TEXT", default=None)
+
+############### Settings for Retirement #####################
+RETIRED_USERNAME_PREFIX = config(
+    "RETIRED_USERNAME_PREFIX", default=RETIRED_USERNAME_PREFIX
+)
+RETIRED_EMAIL_PREFIX = config("RETIRED_EMAIL_PREFIX", default=RETIRED_EMAIL_PREFIX)
+RETIRED_EMAIL_DOMAIN = config("RETIRED_EMAIL_DOMAIN", default=RETIRED_EMAIL_DOMAIN)
+RETIREMENT_SERVICE_WORKER_USERNAME = config(
+    "RETIREMENT_SERVICE_WORKER_USERNAME", default=RETIREMENT_SERVICE_WORKER_USERNAME
+)
+RETIREMENT_STATES = config(
+    "RETIREMENT_STATES", default=RETIREMENT_STATES, formatter=json.loads
+)
+
+############################### Plugin Settings ###############################
+
+from openedx.core.djangoapps.plugins import (
+    plugin_settings,
+    constants as plugin_constants,
+)
+
+plugin_settings.add_plugins(
+    __name__, plugin_constants.ProjectType.LMS, plugin_constants.SettingsType.AWS
+)
+
+########################## Derive Any Derived Settings  #######################
+
+derive_settings(__name__)

--- a/releases/ironwood/2/bare/config/lms/docker_run_staging.py
+++ b/releases/ironwood/2/bare/config/lms/docker_run_staging.py
@@ -1,0 +1,14 @@
+# This file includes overrides to build the `staging` environment for the LMS starting from the
+# settings of the `production` environment
+
+from docker_run_production import *
+from .utils import Configuration
+
+# Load custom configuration parameters from yaml files
+config = Configuration(os.path.dirname(__file__))
+
+LOGGING["handlers"]["sentry"]["environment"] = "staging"
+
+EMAIL_BACKEND = config(
+    "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"
+)

--- a/releases/ironwood/2/bare/config/lms/storage.py
+++ b/releases/ironwood/2/bare/config/lms/storage.py
@@ -1,0 +1,18 @@
+"""Django static file storage backend for OpenEdX."""
+from django.conf import settings
+
+from openedx.core.storage import ProductionStorage
+
+
+class CDNProductionStorage(ProductionStorage):
+    """Open edX production static files storage backend that can be placed behing a CDN."""
+
+    def url(self, name, force=False):
+        """Prepend static files path by the CDN base url when configured in settings."""
+        url = super(CDNProductionStorage, self).url(name, force=force)
+
+        cdn_base_url = getattr(settings, "CDN_BASE_URL", None)
+        if cdn_base_url:
+            url = "{:s}{:s}".format(cdn_base_url, url)
+
+        return url

--- a/releases/ironwood/2/bare/config/lms/utils.py
+++ b/releases/ironwood/2/bare/config/lms/utils.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+
+import yaml
+import os
+
+from django.core.exceptions import ImproperlyConfigured
+
+
+class Configuration(dict):
+    """
+    Try getting a setting from the settings.yml or secrets.yml files placed in
+    the directory passed when initializing the configuration instance.
+    """
+
+    def __init__(self, dir=None, *args, **kwargs):
+        """
+        Initialize with the path to the directory in which the configuration is
+        to be found.
+        """
+        super(Configuration, self).__init__(*args, **kwargs)
+
+        if dir is None:
+            self.settings = {}
+
+        else:
+            # Load the content of a `settings.yml` file placed in the current
+            # directory if any. This file is where customizable settings are stored
+            # for a given environment.
+            try:
+                with open(os.path.join(dir, "settings.yml")) as f:
+                    settings = yaml.load(f.read()) or {}
+            except IOError:
+                settings = {}
+
+            # Load the content of a `secrets.yml` file placed in the current
+            # directory if any. This file is where sensitive credentials are stored
+            # for a given environment.
+            try:
+                with open(os.path.join(dir, "secrets.yml")) as f:
+                    credentials = yaml.load(f.read()) or {}
+            except IOError:
+                credentials = {}
+
+            settings.update(credentials)
+            self.settings = settings
+
+    def __call__(self, var_name, formatter=str, *args, **kwargs):
+        """
+        The config returns in order of priority:
+
+            - the value set in the secrets.yml file,
+            - the value set in the settings.yml file,
+            - the value set as environment variable
+            - the value passed as default.
+
+        If the value is passed as a string, a type is forced via the function passed in
+        the "formatter" kwarg.
+
+        Raise an "ImproperlyConfigured" error if the name is not found, except
+        if the `default` key is given in kwargs (using kwargs allows to pass a
+        default to None, which is different from not passing any default):
+
+            $ config = Configuration('path/to/config/directory')
+            $ config('foo')  # raise ImproperlyConfigured error if `foo` is not defined
+            $ config('foo', default='bar')  # return 'bar' if `foo` is not defined
+            $ config('foo', default=None)  # return `None` if `foo` is not defined
+        """
+        try:
+            value = self.settings[var_name]
+        except KeyError:
+            try:
+                value = formatter(os.environ[var_name])
+            except KeyError:
+                if "default" in kwargs:
+                    value = kwargs["default"]
+                else:
+                    raise ImproperlyConfigured(
+                        'Please set the "{:s}" variable in a settings.yml file, a secrets.yml '
+                        "file or an environment variable.".format(var_name)
+                    )
+        # If a formatter is specified, force the value but only if it was passed as a string
+        if isinstance(value, basestring):
+            value = formatter(value.encode("utf-8"))
+
+        return value
+
+    def get(self, name, *args, **kwargs):
+        """
+        edX is loading the content of 2 json files to settings.ENV_TOKEN and settings.AUTH_TOKEN
+        They have started calling these attributes anywhere in the code base, so we must make
+        sure that the following call works (and the same for AUTH_TOKEN):
+
+            settings.ENV_TOKEN.get('ANY_SETTING_NAME')
+
+        That's what this method will do after we add this to our settings:
+           ```
+           config = Configuration('path/to/my/settings/directory.yml')
+           ENV_TOKEN = config
+           AUTH_TOKEN = config
+           ```
+        """
+        try:
+            default = args[0]
+        except IndexError:
+            # As a first approach, all defaults that are not provided by Open edX are set to None.
+            # If this creates a problem, we can either:
+            #    - make sure we provide a value for this setting in our yaml files,
+            #    - make a PR to Open edX to provide a better default for this setting.
+            default = None
+        return self(name, default=default)

--- a/releases/ironwood/2/bare/entrypoint.sh
+++ b/releases/ironwood/2/bare/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#
+# Development entrypoint
+#
+
+# Activate user's virtualenv
+source /edx/app/edxapp/venv/bin/activate
+exec "$@"

--- a/releases/ironwood/2/oee/CHANGELOG.md
+++ b/releases/ironwood/2/oee/CHANGELOG.md
@@ -9,6 +9,6 @@ release.
 
 ## [Unreleased]
 
-## [ironwood.2-1.0.0] - 2020-09-10
+## [ironwood.2-oee-1.0.0] - 2020-09-10
 
-- First release of an `ironwood.2-bare` Docker image.
+- First release of an `ironwood.2-oee` Docker image.

--- a/releases/ironwood/2/oee/Dockerfile
+++ b/releases/ironwood/2/oee/Dockerfile
@@ -1,0 +1,279 @@
+# EDX-PLATFORM multi-stage docker build
+
+# Change release to build, by providing the EDX_RELEASE_REF build argument to
+# your build command:
+#
+# $ docker build \
+#     --build-arg EDX_RELEASE_REF="open-release/ironwood.2" \
+#     -t edxapp:ironwood.2 \
+#     .
+ARG DOCKER_UID=1000
+ARG DOCKER_GID=1000
+ARG EDX_RELEASE_REF=open-release/ironwood.2
+ARG EDXAPP_STATIC_ROOT=/edx/app/edxapp/staticfiles
+ARG NGINX_IMAGE_NAME=fundocker/openshift-nginx
+ARG NGINX_IMAGE_TAG=1.13
+
+# === BASE ===
+FROM ubuntu:16.04 as base
+
+# Configure locales & timezone
+RUN apt-get update && \
+    apt-get install -y \
+      gettext \
+      locales \
+      tzdata && \
+    rm -rf /var/lib/apt/lists/*
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    locale-gen
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+# === DOWNLOAD ===
+FROM base as downloads
+
+WORKDIR /downloads
+
+# Install curl
+RUN apt-get update && \
+    apt-get install -y curl
+
+# Download pip installer
+RUN curl -sLo get-pip.py https://bootstrap.pypa.io/get-pip.py
+
+# Download edxapp release
+# Get default EDX_RELEASE_REF value (defined on top)
+ARG EDX_RELEASE_REF
+RUN curl -sLo edxapp.tgz https://github.com/edx/edx-platform/archive/$EDX_RELEASE_REF.tar.gz && \
+    tar xzf edxapp.tgz
+
+
+# === EDXAPP ===
+FROM base as edxapp
+
+# Install apt https support (required to use node sources repository)
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y \
+      apt-transport-https
+
+# Add a recent release of nodejs to apt sources (ubuntu package for precise is
+# broken)
+RUN echo "deb https://deb.nodesource.com/node_10.x trusty main" \
+	> /etc/apt/sources.list.d/nodesource.list && \
+    curl -s 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key' | apt-key add -
+
+# Install base system dependencies
+RUN apt-get update && \
+    apt-get install -y \
+      nodejs \
+      python && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /edx/app/edxapp/edx-platform
+
+# Get default EDX_RELEASE_REF value (defined on top)
+ARG EDX_RELEASE_REF
+COPY --from=downloads /downloads/edx-platform-* .
+
+COPY ./requirements.txt /edx/app/edxapp/edx-platform/requirements/edx/extend.txt
+
+# We copy default configuration files to "/config" and we point to them via
+# symlinks. That allows to easily override default configurations by mounting a
+# docker volume.
+COPY ./config /config
+RUN ln -sf /config/lms /edx/app/edxapp/edx-platform/lms/envs/fun && \
+    ln -sf /config/cms /edx/app/edxapp/edx-platform/cms/envs/fun && \
+    ln -sf /config/lms/root_urls.py /edx/app/edxapp/edx-platform/lms/
+
+# Add node_modules/.bin to the PATH so that paver-related commands can execute
+# node scripts
+ENV PATH="/edx/app/edxapp/edx-platform/node_modules/.bin:${PATH}"
+
+# === BUILDER ===
+FROM edxapp as builder
+
+WORKDIR /builder
+
+# Install builder system dependencies
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y \
+    build-essential \
+    gettext \
+    git \
+    graphviz-dev \
+    libgeos-dev \
+    libmysqlclient-dev \
+    libxml2-dev \
+    libxmlsec1-dev \
+    python-dev \
+    rdfind && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install the latest pip release
+COPY --from=downloads /downloads/get-pip.py ./get-pip.py
+RUN python get-pip.py
+
+WORKDIR /edx/app/edxapp/edx-platform
+
+# Patch the CMS to activate our customizable LTI Xblock
+COPY ironwood.2-oee.patch /tmp/
+RUN patch -p1 < /tmp/ironwood.2-oee.patch
+
+# Install python dependencies
+RUN pip install --src /usr/local/src -r requirements/edx/base.txt && \
+    pip install -r requirements/edx/extend.txt
+
+# Install Javascript requirements
+RUN npm install
+
+# Update assets skipping collectstatic (it should be done during deployment)
+RUN NO_PREREQ_INSTALL=1 \
+    paver update_assets --settings=fun.docker_build_production --skip-collect
+
+# === STATIC LINKS COLLECTOR ===
+FROM builder as links_collector
+
+ARG EDXAPP_STATIC_ROOT
+
+RUN python manage.py lms collectstatic --link --noinput --settings=fun.docker_run && \
+    python manage.py cms collectstatic --link --noinput --settings=fun.docker_run
+
+# Replace duplicated file by a symlink to decrease the overall size of the
+# final image
+RUN rdfind -makesymlinks true -followsymlinks true ${EDXAPP_STATIC_ROOT}
+
+# === STATIC FILES COLLECTOR ===
+FROM builder as files_collector
+
+ARG EDXAPP_STATIC_ROOT
+
+RUN python manage.py lms collectstatic --noinput --settings=fun.docker_run && \
+    python manage.py cms collectstatic --noinput --settings=fun.docker_run
+
+# Replace duplicated file by a symlink to decrease the overall size of the
+# final image
+RUN rdfind -makesymlinks true ${EDXAPP_STATIC_ROOT}
+
+# === DEVELOPMENT ===
+FROM builder as development
+
+ARG DOCKER_UID
+ARG DOCKER_GID
+ARG EDX_RELEASE_REF
+
+# Install system dependencies
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y \
+      libsqlite3-dev \
+      mongodb && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN groupadd --gid ${DOCKER_GID} edx || \
+      echo "Group with ID ${DOCKER_GID} already exists." && \
+    useradd \
+      --create-home \
+      --home-dir /home/edx \
+      --uid ${DOCKER_UID} \
+      --gid ${DOCKER_GID} \
+      edx
+
+# To prevent permission issues related to the non-priviledged user running in
+# development, we will install development dependencies in a python virtual
+# environment belonging to that user
+RUN pip install virtualenv
+
+# Create the virtualenv directory where we will install python development
+# dependencies
+RUN mkdir -p /edx/app/edxapp/venv && \
+    chown -R ${DOCKER_UID}:${DOCKER_GID} /edx/app/edxapp/venv
+
+# Change edxapp directory owner to allow the development image docker user to
+# perform installations from edxapp sources (yeah, I know...)
+RUN chown -R ${DOCKER_UID}:${DOCKER_GID} /edx/app/edxapp
+
+# Copy the entrypoint that will activate the virtualenv
+COPY ./entrypoint.sh /usr/local/bin/entrypoint.sh
+
+# Switch to an un-privileged user matching the host user to prevent permission
+# issues with volumes (host folders)
+USER ${DOCKER_UID}:${DOCKER_GID}
+
+# Create the virtualenv with a non-priviledged user
+RUN virtualenv -p python2.7 --system-site-packages /edx/app/edxapp/venv
+
+# Install development dependencies in a virtualenv
+RUN bash -c "source /edx/app/edxapp/venv/bin/activate && \
+    pip install --no-cache-dir -r requirements/edx/testing.txt && \
+    pip install --no-cache-dir -r requirements/edx/development.txt"
+
+ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]
+
+
+# === PRODUCTION ===
+FROM edxapp as production
+
+ARG EDXAPP_STATIC_ROOT
+
+# Install runner system dependencies
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y \
+    libgeos-dev \
+    libmysqlclient20 \
+    libxml2 \
+    libxmlsec1-dev \
+    lynx \
+    tzdata && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy installed dependencies
+COPY --from=builder /usr/local /usr/local
+
+# Copy modified sources (sic!)
+COPY --from=builder /edx/app/edxapp/edx-platform  /edx/app/edxapp/edx-platform
+
+# Copy static files
+COPY --from=links_collector ${EDXAPP_STATIC_ROOT} ${EDXAPP_STATIC_ROOT}
+
+# Now that dependencies are installed and configuration has been set, the above
+# statements will run with a un-privileged user.
+USER 10000
+
+# To start the CMS, inject the SERVICE_VARIANT=cms environment variable
+# (defaults to "lms")
+ENV SERVICE_VARIANT=lms
+
+# Gunicorn configuration
+#
+# We want to be able to easily increase gunicorn if needed
+ENV GUNICORN_TIMEOUT 300
+
+# In docker we must increase the number of workers and threads created
+# by gunicorn.
+# This blogpost explains why and how to do that https://pythonspeed.com/articles/gunicorn-in-docker/
+ENV GUNICORN_WORKERS 3
+ENV GUNICORN_THREADS 6
+
+# Use Gunicorn in production as web server
+CMD DJANGO_SETTINGS_MODULE=${SERVICE_VARIANT}.envs.fun.docker_run \
+    gunicorn \
+      --name=${SERVICE_VARIANT} \
+      --bind=0.0.0.0:8000 \
+      --max-requests=1000 \
+      --timeout=${GUNICORN_TIMEOUT} \
+      --workers=${GUNICORN_WORKERS} \
+      --threads=${GUNICORN_THREADS} \
+      ${SERVICE_VARIANT}.wsgi:application
+
+# === NGINX ===
+FROM ${NGINX_IMAGE_NAME}:${NGINX_IMAGE_TAG} as nginx
+
+ARG EDXAPP_STATIC_ROOT
+
+RUN mkdir -p ${EDXAPP_STATIC_ROOT}
+
+COPY --from=files_collector ${EDXAPP_STATIC_ROOT} ${EDXAPP_STATIC_ROOT}

--- a/releases/ironwood/2/oee/Dockerfile
+++ b/releases/ironwood/2/oee/Dockerfile
@@ -138,8 +138,8 @@ FROM builder as links_collector
 
 ARG EDXAPP_STATIC_ROOT
 
-RUN python manage.py lms collectstatic --link --noinput --settings=fun.docker_run && \
-    python manage.py cms collectstatic --link --noinput --settings=fun.docker_run
+RUN python manage.py lms collectstatic --link --noinput --settings=fun.docker_build_production && \
+    python manage.py cms collectstatic --link --noinput --settings=fun.docker_build_production
 
 # Replace duplicated file by a symlink to decrease the overall size of the
 # final image
@@ -150,8 +150,8 @@ FROM builder as files_collector
 
 ARG EDXAPP_STATIC_ROOT
 
-RUN python manage.py lms collectstatic --noinput --settings=fun.docker_run && \
-    python manage.py cms collectstatic --noinput --settings=fun.docker_run
+RUN python manage.py lms collectstatic --noinput --settings=fun.docker_build_production && \
+    python manage.py cms collectstatic --noinput --settings=fun.docker_build_production
 
 # Replace duplicated file by a symlink to decrease the overall size of the
 # final image

--- a/releases/ironwood/2/oee/activate
+++ b/releases/ironwood/2/oee/activate
@@ -1,0 +1,4 @@
+export EDX_RELEASE="ironwood.2"
+export FLAVOR="oee"
+export EDX_RELEASE_REF="open-release/ironwood.2"
+export EDX_DEMO_RELEASE_REF="open-release/ironwood.2"

--- a/releases/ironwood/2/oee/config/cms/docker_build_development.py
+++ b/releases/ironwood/2/oee/config/cms/docker_build_development.py
@@ -1,0 +1,9 @@
+# This is a minimal settings file allowing us to run "update_assets"
+# in the Dockerfile for the development image of the edxapp CMS
+
+from .docker_build_production import *
+
+DEBUG = True
+REQUIRE_DEBUG = True
+
+WEBPACK_CONFIG_PATH = "webpack.dev.config.js"

--- a/releases/ironwood/2/oee/config/cms/docker_build_production.py
+++ b/releases/ironwood/2/oee/config/cms/docker_build_production.py
@@ -1,0 +1,29 @@
+# This is a minimal settings file allowing us to run "update_assets"
+# in the Dockerfile for the production image of the edxapp CMS
+
+from openedx.core.lib.derived import derive_settings
+
+from lms.envs.fun.utils import Configuration
+from path import Path as path
+
+from .docker_run_production import *
+
+# Load custom configuration parameters
+config = Configuration()
+
+DATABASES = {"default": {}}
+
+XQUEUE_INTERFACE = {"url": None, "django_auth": None}
+
+# We need to override STATIC_ROOT because for CMS, edX appends the value of
+# "EDX_PLATFORM_REVISION" to it by default and we don't want to use this.
+# We should use Django's ManifestStaticFilesStorage for this purpose.
+STATIC_URL = "/static/studio/"
+STATIC_ROOT = path("/edx/app/edxapp/staticfiles/studio")
+
+# Allow setting a custom theme
+DEFAULT_SITE_THEME = config("DEFAULT_SITE_THEME", default=None)
+
+########################## Derive Any Derived Settings  #######################
+
+derive_settings(__name__)

--- a/releases/ironwood/2/oee/config/cms/docker_run.py
+++ b/releases/ironwood/2/oee/config/cms/docker_run.py
@@ -1,0 +1,3 @@
+# This file is meant to import the environment related settings file
+
+from docker_run_production import *

--- a/releases/ironwood/2/oee/config/cms/docker_run_ci.py
+++ b/releases/ironwood/2/oee/config/cms/docker_run_ci.py
@@ -1,0 +1,14 @@
+# This file includes overrides to build the `CI` environment for the CMS, starting from
+# the settings of the `production` environment
+
+from docker_run_production import *
+
+
+DEBUG = True
+
+EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+
+PIPELINE_ENABLED = False
+STATICFILES_STORAGE = "openedx.core.storage.DevelopmentStorage"
+
+ALLOWED_HOSTS = ["*"]

--- a/releases/ironwood/2/oee/config/cms/docker_run_development.py
+++ b/releases/ironwood/2/oee/config/cms/docker_run_development.py
@@ -1,0 +1,23 @@
+# This file includes overrides to build the `development` environment for the CMS, starting from
+# the settings of the `production` environment
+
+from docker_run_production import *
+from lms.envs.fun.utils import Configuration
+
+# Load custom configuration parameters from yaml files
+config = Configuration(os.path.dirname(__file__))
+
+if "sentry" in LOGGING.get("handlers"):
+    LOGGING["handlers"]["sentry"]["environment"] = "development"
+
+DEBUG = True
+REQUIRE_DEBUG = True
+
+EMAIL_BACKEND = config(
+    "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"
+)
+
+PIPELINE_ENABLED = False
+STATICFILES_STORAGE = "openedx.core.storage.DevelopmentStorage"
+
+ALLOWED_HOSTS = ["*"]

--- a/releases/ironwood/2/oee/config/cms/docker_run_feature.py
+++ b/releases/ironwood/2/oee/config/cms/docker_run_feature.py
@@ -1,0 +1,14 @@
+# This file includes overrides to build the `feature` environment for the CMS starting from the
+# settings of the `production` environment
+
+from docker_run_production import *
+from lms.envs.fun.utils import Configuration
+
+# Load custom configuration parameters from yaml files
+config = Configuration(os.path.dirname(__file__))
+
+LOGGING["handlers"]["sentry"]["environment"] = "feature"
+
+EMAIL_BACKEND = config(
+    "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"
+)

--- a/releases/ironwood/2/oee/config/cms/docker_run_preprod.py
+++ b/releases/ironwood/2/oee/config/cms/docker_run_preprod.py
@@ -1,0 +1,14 @@
+# This file includes overrides to build the `preprod` environment for the CMS starting from the
+# settings of the `production` environment
+
+from docker_run_production import *
+from lms.envs.fun.utils import Configuration
+
+# Load custom configuration parameters from yaml files
+config = Configuration(os.path.dirname(__file__))
+
+LOGGING["handlers"]["sentry"]["environment"] = "preprod"
+
+EMAIL_BACKEND = config(
+    "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"
+)

--- a/releases/ironwood/2/oee/config/cms/docker_run_production.py
+++ b/releases/ironwood/2/oee/config/cms/docker_run_production.py
@@ -64,7 +64,6 @@ DEFAULT_PRIORITY_QUEUE = config(
     "DEFAULT_PRIORITY_QUEUE", default="edx.cms.core.default"
 )
 HIGH_PRIORITY_QUEUE = config("HIGH_PRIORITY_QUEUE", default="edx.cms.core.high")
-LOW_PRIORITY_QUEUE = config("LOW_PRIORITY_QUEUE", default="edx.cms.core.low")
 
 CELERY_DEFAULT_QUEUE = DEFAULT_PRIORITY_QUEUE
 CELERY_DEFAULT_ROUTING_KEY = DEFAULT_PRIORITY_QUEUE
@@ -74,7 +73,6 @@ CELERY_QUEUES = config(
     default={
         DEFAULT_PRIORITY_QUEUE: {},
         HIGH_PRIORITY_QUEUE: {},
-        LOW_PRIORITY_QUEUE: {},
     },
     formatter=json.loads,
 )
@@ -139,6 +137,12 @@ ENTERPRISE_API_URL = config(
 )
 ENTERPRISE_CONSENT_API_URL = config(
     "ENTERPRISE_CONSENT_API_URL", default=LMS_INTERNAL_ROOT_URL + "/consent/api/v1/"
+)
+
+# List of logout URIs for each IDA that the learner should be logged out of when they logout of the LMS. Only applies to
+# IDA for which the social auth flow uses DOT (Django OAuth Toolkit).
+IDA_LOGOUT_URI_LIST = config(
+    "IDA_LOGOUT_URI_LIST", default=[], formatter=json.loads
 )
 
 SITE_NAME = config("SITE_NAME", default=CMS_BASE)
@@ -606,7 +610,7 @@ CELERY_EVENT_QUEUE_TTL = config("CELERY_EVENT_QUEUE_TTL", default=None, formatte
 
 # Queue to use for updating grades due to grading policy change
 POLICY_CHANGE_GRADES_ROUTING_KEY = config(
-    "POLICY_CHANGE_GRADES_ROUTING_KEY", default=LOW_PRIORITY_QUEUE
+    "POLICY_CHANGE_GRADES_ROUTING_KEY", default=DEFAULT_PRIORITY_QUEUE
 )
 
 # Event tracking
@@ -629,16 +633,9 @@ MAX_FAILED_LOGIN_ATTEMPTS_LOCKOUT_PERIOD_SECS = config(
 )
 
 #### PASSWORD POLICY SETTINGS #####
-PASSWORD_MIN_LENGTH = config("PASSWORD_MIN_LENGTH", default=12, formatter=int)
-PASSWORD_MAX_LENGTH = config("PASSWORD_MAX_LENGTH", default=None, formatter=int)
-
-PASSWORD_COMPLEXITY = config(
-    "PASSWORD_COMPLEXITY",
-    default={"UPPER": 1, "LOWER": 1, "DIGITS": 1},
-    formatter=json.loads,
+AUTH_PASSWORD_VALIDATORS = config(
+    "AUTH_PASSWORD_VALIDATORS", default=AUTH_PASSWORD_VALIDATORS
 )
-
-PASSWORD_DICTIONARY = config("PASSWORD_DICTIONARY", default=[], formatter=json.loads)
 
 ### INACTIVITY SETTINGS ####
 SESSION_INACTIVITY_TIMEOUT_IN_SECONDS = config(
@@ -647,11 +644,6 @@ SESSION_INACTIVITY_TIMEOUT_IN_SECONDS = config(
 
 ##### X-Frame-Options response header settings #####
 X_FRAME_OPTIONS = config("X_FRAME_OPTIONS", default=X_FRAME_OPTIONS)
-
-##### ADVANCED_SECURITY_CONFIG #####
-ADVANCED_SECURITY_CONFIG = config(
-    "ADVANCED_SECURITY_CONFIG", default={}, formatter=json.loads
-)
 
 ################ ADVANCED COMPONENT/PROBLEM TYPES ###############
 
@@ -774,11 +766,16 @@ HELP_TOKENS_BOOKS = config(
 )
 
 ############## Settings for CourseGraph ############################
-COURSEGRAPH_JOB_QUEUE = config("COURSEGRAPH_JOB_QUEUE", default=LOW_PRIORITY_QUEUE)
+COURSEGRAPH_JOB_QUEUE = config("COURSEGRAPH_JOB_QUEUE", default=DEFAULT_PRIORITY_QUEUE)
 
 ########## Settings for video transcript migration tasks ############
 VIDEO_TRANSCRIPT_MIGRATIONS_JOB_QUEUE = config(
-    "VIDEO_TRANSCRIPT_MIGRATIONS_JOB_QUEUE", default=LOW_PRIORITY_QUEUE
+    "VIDEO_TRANSCRIPT_MIGRATIONS_JOB_QUEUE", default=DEFAULT_PRIORITY_QUEUE
+)
+
+########## Settings youtube thumbnails scraper tasks ############
+SCRAPE_YOUTUBE_THUMBNAILS_JOB_QUEUE = config(
+    "SCRAPE_YOUTUBE_THUMBNAILS_JOB_QUEUE", default=DEFAULT_PRIORITY_QUEUE
 )
 
 ########################## Parental controls config  #######################
@@ -828,8 +825,14 @@ RETIRED_EMAIL_DOMAIN = config("RETIRED_EMAIL_DOMAIN", default=RETIRED_EMAIL_DOMA
 RETIREMENT_SERVICE_WORKER_USERNAME = config(
     "RETIREMENT_SERVICE_WORKER_USERNAME", default=RETIREMENT_SERVICE_WORKER_USERNAME
 )
+RETIRED_USER_SALTS = config("RETIRED_USER_SALTS", default=RETIRED_USER_SALTS)
 RETIREMENT_STATES = config(
     "RETIREMENT_STATES", default=RETIREMENT_STATES, formatter=json.loads
+)
+
+############## Settings for Course Enrollment Modes ######################
+COURSE_ENROLLMENT_MODES = config(
+    "COURSE_ENROLLMENT_MODES", default=COURSE_ENROLLMENT_MODES
 )
 
 ####################### Plugin Settings ##########################

--- a/releases/ironwood/2/oee/config/cms/docker_run_production.py
+++ b/releases/ironwood/2/oee/config/cms/docker_run_production.py
@@ -152,53 +152,41 @@ LOG_DIR = config("LOG_DIR", default=path("/edx/var/logs/edx"), formatter=path)
 CACHE_REDIS_HOST = config("CACHE_REDIS_HOST", default="redis")
 CACHE_REDIS_PORT = config("CACHE_REDIS_PORT", default=6379, formatter=int)
 CACHE_REDIS_DB = config("CACHE_REDIS_DB", default=1, formatter=int)
-CACHE_REDIS_URI = "redis://{}:{}/{}".format(CACHE_REDIS_HOST, CACHE_REDIS_PORT, CACHE_REDIS_DB)
-CACHE_REDIS_BACKEND = config("CACHE_REDIS_BACKEND", default="django_redis.cache.RedisCache")
-CACHE_REDIS_CLIENT = config("CACHE_REDIS_CLIENT", default="django_redis.client.DefaultClient")
+CACHE_REDIS_BACKEND = config(
+    "CACHE_REDIS_BACKEND", default="django_redis.cache.RedisCache"
+)
+CACHE_REDIS_URI = "redis://{}:{}/{}".format(
+    CACHE_REDIS_HOST, CACHE_REDIS_PORT, CACHE_REDIS_DB
+)
+CACHE_REDIS_CLIENT = config(
+    "CACHE_REDIS_CLIENT", default="django_redis.client.DefaultClient"
+)
+
+CACHES_DEFAULT_CONFIG = {
+    "BACKEND": CACHE_REDIS_BACKEND,
+    "LOCATION": CACHE_REDIS_URI,
+    "OPTIONS": {"CLIENT_CLASS": CACHE_REDIS_CLIENT},
+}
+
+if "Sentinel" in CACHE_REDIS_BACKEND:
+    CACHES_DEFAULT_CONFIG["LOCATION"] = [(CACHE_REDIS_HOST, CACHE_REDIS_PORT)]
+    CACHES_DEFAULT_CONFIG["OPTIONS"]["SENTINEL_SERVICE_NAME"] = config(
+        "CACHE_REDIS_SENTINEL_SERVICE_NAME", default="mymaster"
+    )
+    CACHES_DEFAULT_CONFIG["OPTIONS"]["REDIS_CLIENT_KWARGS"] = {"db": CACHE_REDIS_DB}
 
 CACHES = config(
     "CACHES",
     default={
-        "default": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "default",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
-        "general": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "general",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
-        "celery": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "celery",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
-        "mongo_metadata_inheritance": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "mongo_metadata_inheritance",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
-        "openassessment_submissions": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "openassessment_submissions",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
+        "default": dict(CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "default"}),
+        "general": dict(CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "general"}),
+        "celery": dict(CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "celery"}),
+        "mongo_metadata_inheritance": dict(
+            CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "mongo_metadata_inheritance"}
+        ),
+        "openassessment_submissions": dict(
+            CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "openassessment_submissions"}
+        ),
         "loc_cache": {
             "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
             "LOCATION": "edx_location_mem_cache",
@@ -229,8 +217,12 @@ SESSION_REDIS_PORT = config("SESSION_REDIS_PORT", default=6379, formatter=int)
 SESSION_REDIS_DB = config("SESSION_REDIS_DB", default=1, formatter=int)
 SESSION_REDIS_PASSWORD = config("SESSION_REDIS_PASSWORD", default=None)
 SESSION_REDIS_PREFIX = config("SESSION_REDIS_PREFIX", default="session")
-SESSION_REDIS_SOCKET_TIMEOUT = config("SESSION_REDIS_SOCKET_TIMEOUT", default=1, formatter=int)
-SESSION_REDIS_RETRY_ON_TIMEOUT = config("SESSION_REDIS_RETRY_ON_TIMEOUT", default=False, formatter=bool)
+SESSION_REDIS_SOCKET_TIMEOUT = config(
+    "SESSION_REDIS_SOCKET_TIMEOUT", default=1, formatter=int
+)
+SESSION_REDIS_RETRY_ON_TIMEOUT = config(
+    "SESSION_REDIS_RETRY_ON_TIMEOUT", default=False, formatter=bool
+)
 
 SESSION_REDIS = config(
     "SESSION_REDIS",
@@ -245,8 +237,12 @@ SESSION_REDIS = config(
     },
     formatter=json.loads,
 )
-SESSION_REDIS_SENTINEL_LIST = config("SESSION_REDIS_SENTINEL_LIST", default=None, formatter=json.loads)
-SESSION_REDIS_SENTINEL_MASTER_ALIAS = config("SESSION_REDIS_SENTINEL_MASTER_ALIAS", default=None)
+SESSION_REDIS_SENTINEL_LIST = config(
+    "SESSION_REDIS_SENTINEL_LIST", default=None, formatter=json.loads
+)
+SESSION_REDIS_SENTINEL_MASTER_ALIAS = config(
+    "SESSION_REDIS_SENTINEL_MASTER_ALIAS", default=None
+)
 
 # social sharing settings
 SOCIAL_SHARING_SETTINGS = config(
@@ -305,8 +301,6 @@ COURSES_WITH_UNSAFE_CODE = config(
 
 ASSET_IGNORE_REGEX = config("ASSET_IGNORE_REGEX", default=ASSET_IGNORE_REGEX)
 
-LOCALE_PATHS = config("LOCALE_PATHS", default=LOCALE_PATHS, formatter=json.loads)
-
 COMPREHENSIVE_THEME_DIRS = (
     config(
         "COMPREHENSIVE_THEME_DIRS",
@@ -315,6 +309,8 @@ COMPREHENSIVE_THEME_DIRS = (
     )
     or []
 )
+
+LOCALE_PATHS = config("LOCALE_PATHS", default=LOCALE_PATHS, formatter=json.loads)
 
 # COMPREHENSIVE_THEME_LOCALE_PATHS contain the paths to themes locale directories e.g.
 # "COMPREHENSIVE_THEME_LOCALE_PATHS" : [
@@ -413,13 +409,17 @@ if SENTRY_DSN:
 # strings but edX tries to serialize them with a default json serializer which breaks. We should
 # submit a PR to fix it in edx-platform
 PLATFORM_NAME = config("PLATFORM_NAME", default="Your Platform Name Here")
-PLATFORM_DESCRIPTION = config("PLATFORM_DESCRIPTION", default="Your Platform Description Here")
+PLATFORM_DESCRIPTION = config(
+    "PLATFORM_DESCRIPTION", default="Your Platform Description Here"
+)
 STUDIO_NAME = config("STUDIO_NAME", default=STUDIO_NAME)
 STUDIO_SHORT_NAME = config("STUDIO_SHORT_NAME", default=STUDIO_SHORT_NAME)
 
 # Event Tracking
 TRACKING_IGNORE_URL_PATTERNS = config(
-    "TRACKING_IGNORE_URL_PATTERNS", default=TRACKING_IGNORE_URL_PATTERNS, formatter=json.loads
+    "TRACKING_IGNORE_URL_PATTERNS",
+    default=TRACKING_IGNORE_URL_PATTERNS,
+    formatter=json.loads,
 )
 
 # Heartbeat
@@ -597,7 +597,9 @@ BROKER_URL = "{transport}://{user}:{password}@{host}:{port}/{vhost}".format(
 BROKER_USE_SSL = config("CELERY_BROKER_USE_SSL", default=False, formatter=bool)
 # To use redis-sentinel, refer to the documentation here
 # https://celery-redis-sentinel.readthedocs.io/en/latest/
-BROKER_TRANSPORT_OPTIONS = config("BROKER_TRANSPORT_OPTIONS", default={}, formatter=json.loads)
+BROKER_TRANSPORT_OPTIONS = config(
+    "BROKER_TRANSPORT_OPTIONS", default={}, formatter=json.loads
+)
 
 # Message expiry time in seconds
 CELERY_EVENT_QUEUE_TTL = config("CELERY_EVENT_QUEUE_TTL", default=None, formatter=int)

--- a/releases/ironwood/2/oee/config/cms/docker_run_production.py
+++ b/releases/ironwood/2/oee/config/cms/docker_run_production.py
@@ -1,0 +1,846 @@
+"""
+This is the settings to run the Open edX CMS with Docker the FUN way.
+"""
+
+import json
+import os
+import platform
+
+from celery_redis_sentinel import register
+from lms.envs.fun.utils import Configuration
+from openedx.core.lib.derived import derive_settings
+from path import Path as path
+from xmodule.modulestore.modulestore_settings import (
+    convert_module_store_setting_if_needed,
+)
+
+from ..common import *
+
+
+# Load custom configuration parameters from yaml files
+config = Configuration(os.path.dirname(__file__))
+
+# edX has now started using "settings.ENV_TOKENS" and "settings.AUTH_TOKENS" everywhere in the
+# project, not just in the settings. Let's make sure our settings still work in this case
+ENV_TOKENS = config
+AUTH_TOKENS = config
+
+############### ALWAYS THE SAME ################################
+
+RELEASE = config("RELEASE", default=None)
+DEBUG = False
+
+# IMPORTANT: With this enabled, the server must always be behind a proxy that
+# strips the header HTTP_X_FORWARDED_PROTO from client requests. Otherwise,
+# a user can fool our server into thinking it was an https connection.
+# See
+# https://docs.djangoproject.com/en/dev/ref/settings/#secure-proxy-ssl-header
+# for other warnings.
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
+###################################### CELERY  ################################
+
+CELERY_ALWAYS_EAGER = config("CELERY_ALWAYS_EAGER", default=False, formatter=bool)
+
+# Don't use a connection pool, since connections are dropped by ELB.
+BROKER_POOL_LIMIT = 0
+BROKER_CONNECTION_TIMEOUT = 1
+
+# For the Result Store, use the django cache named 'celery'
+CELERY_RESULT_BACKEND = config(
+    "CELERY_RESULT_BACKEND", default="djcelery.backends.cache:CacheBackend"
+)
+
+# When the broker is behind an ELB, use a heartbeat to refresh the
+# connection and to detect if it has been dropped.
+BROKER_HEARTBEAT = 60.0
+BROKER_HEARTBEAT_CHECKRATE = 2
+
+# Each worker should only fetch one message at a time
+CELERYD_PREFETCH_MULTIPLIER = 1
+
+# Celery queues
+DEFAULT_PRIORITY_QUEUE = config(
+    "DEFAULT_PRIORITY_QUEUE", default="edx.cms.core.default"
+)
+HIGH_PRIORITY_QUEUE = config("HIGH_PRIORITY_QUEUE", default="edx.cms.core.high")
+LOW_PRIORITY_QUEUE = config("LOW_PRIORITY_QUEUE", default="edx.cms.core.low")
+
+CELERY_DEFAULT_QUEUE = DEFAULT_PRIORITY_QUEUE
+CELERY_DEFAULT_ROUTING_KEY = DEFAULT_PRIORITY_QUEUE
+
+CELERY_QUEUES = config(
+    "CELERY_QUEUES",
+    default={
+        DEFAULT_PRIORITY_QUEUE: {},
+        HIGH_PRIORITY_QUEUE: {},
+        LOW_PRIORITY_QUEUE: {},
+    },
+    formatter=json.loads,
+)
+
+CELERY_ROUTES = "cms.celery.Router"
+
+# Force accepted content to "json" only. If we also accept pickle-serialized
+# messages, the worker will crash when it's running with a privileged user (even
+# if it's not the root user but a user belonging to the root group, which is the
+# case with OpenShift for example).
+CELERY_ACCEPT_CONTENT = ["json"]
+
+############# NON-SECURE ENV CONFIG ##############################
+# Things like server locations, ports, etc.
+
+# DEFAULT_COURSE_ABOUT_IMAGE_URL specifies the default image to show for courses that don't
+# provide one
+DEFAULT_COURSE_ABOUT_IMAGE_URL = config(
+    "DEFAULT_COURSE_ABOUT_IMAGE_URL", default=DEFAULT_COURSE_ABOUT_IMAGE_URL
+)
+
+DEFAULT_COURSE_VISIBILITY_IN_CATALOG = config(
+    "DEFAULT_COURSE_VISIBILITY_IN_CATALOG", default=DEFAULT_COURSE_VISIBILITY_IN_CATALOG
+)
+
+# DEFAULT_MOBILE_AVAILABLE specifies if the course is available for mobile by default
+DEFAULT_MOBILE_AVAILABLE = config(
+    "DEFAULT_MOBILE_AVAILABLE", default=DEFAULT_MOBILE_AVAILABLE, formatter=bool
+)
+
+# GITHUB_REPO_ROOT is the base directory
+# for course data
+GITHUB_REPO_ROOT = config("GITHUB_REPO_ROOT", default=GITHUB_REPO_ROOT)
+
+STATIC_URL = "/static/studio/"
+STATIC_ROOT_BASE = path("/edx/app/edxapp/staticfiles")
+STATIC_ROOT = path("/edx/app/edxapp/staticfiles/studio")
+STATICFILES_STORAGE = config(
+    "STATICFILES_STORAGE", default="lms.envs.fun.storage.CDNProductionStorage"
+)
+CDN_BASE_URL = config("CDN_BASE_URL", default=None)
+
+WEBPACK_LOADER["DEFAULT"]["STATS_FILE"] = STATIC_ROOT / "webpack-stats.json"
+
+EMAIL_BACKEND = config(
+    "EMAIL_BACKEND", default="django.core.mail.backends.smtp.EmailBackend"
+)
+EMAIL_FILE_PATH = config("EMAIL_FILE_PATH", default=None)
+
+EMAIL_HOST = config("EMAIL_HOST", default="localhost")
+EMAIL_PORT = config("EMAIL_PORT", default=25, formatter=int)
+EMAIL_USE_TLS = config("EMAIL_USE_TLS", default=False, formatter=bool)
+
+LMS_BASE = config("LMS_BASE", default="localhost:8072")
+CMS_BASE = config("CMS_BASE", default="localhost:8082")
+
+LMS_ROOT_URL = config("LMS_ROOT_URL", default="http://{:s}".format(LMS_BASE))
+LMS_INTERNAL_ROOT_URL = config("LMS_INTERNAL_ROOT_URL", default=LMS_ROOT_URL)
+
+ENTERPRISE_API_URL = config(
+    "ENTERPRISE_API_URL", default=LMS_INTERNAL_ROOT_URL + "/enterprise/api/v1/"
+)
+ENTERPRISE_CONSENT_API_URL = config(
+    "ENTERPRISE_CONSENT_API_URL", default=LMS_INTERNAL_ROOT_URL + "/consent/api/v1/"
+)
+
+SITE_NAME = config("SITE_NAME", default=CMS_BASE)
+
+ALLOWED_HOSTS = config(
+    "ALLOWED_HOSTS", default=[CMS_BASE.split(":")[0]], formatter=json.loads
+)
+
+LOG_DIR = config("LOG_DIR", default=path("/edx/var/logs/edx"), formatter=path)
+
+CACHE_REDIS_HOST = config("CACHE_REDIS_HOST", default="redis")
+CACHE_REDIS_PORT = config("CACHE_REDIS_PORT", default=6379, formatter=int)
+CACHE_REDIS_DB = config("CACHE_REDIS_DB", default=1, formatter=int)
+CACHE_REDIS_URI = "redis://{}:{}/{}".format(CACHE_REDIS_HOST, CACHE_REDIS_PORT, CACHE_REDIS_DB)
+CACHE_REDIS_BACKEND = config("CACHE_REDIS_BACKEND", default="django_redis.cache.RedisCache")
+CACHE_REDIS_CLIENT = config("CACHE_REDIS_CLIENT", default="django_redis.client.DefaultClient")
+
+CACHES = config(
+    "CACHES",
+    default={
+        "default": {
+            "BACKEND": CACHE_REDIS_BACKEND,
+            "LOCATION": CACHE_REDIS_URI,
+            "KEY_PREFIX": "default",
+            "OPTIONS": {
+              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
+            },
+        },
+        "general": {
+            "BACKEND": CACHE_REDIS_BACKEND,
+            "LOCATION": CACHE_REDIS_URI,
+            "KEY_PREFIX": "general",
+            "OPTIONS": {
+              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
+            },
+        },
+        "celery": {
+            "BACKEND": CACHE_REDIS_BACKEND,
+            "LOCATION": CACHE_REDIS_URI,
+            "KEY_PREFIX": "celery",
+            "OPTIONS": {
+              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
+            },
+        },
+        "mongo_metadata_inheritance": {
+            "BACKEND": CACHE_REDIS_BACKEND,
+            "LOCATION": CACHE_REDIS_URI,
+            "KEY_PREFIX": "mongo_metadata_inheritance",
+            "OPTIONS": {
+              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
+            },
+        },
+        "openassessment_submissions": {
+            "BACKEND": CACHE_REDIS_BACKEND,
+            "LOCATION": CACHE_REDIS_URI,
+            "KEY_PREFIX": "openassessment_submissions",
+            "OPTIONS": {
+              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
+            },
+        },
+        "loc_cache": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "edx_location_mem_cache",
+        },
+        "staticfiles": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "edx_location_mem_cache",
+        },
+    },
+    formatter=json.loads,
+)
+
+SESSION_COOKIE_DOMAIN = config("SESSION_COOKIE_DOMAIN", default=None)
+SESSION_COOKIE_HTTPONLY = config(
+    "SESSION_COOKIE_HTTPONLY", default=True, formatter=bool
+)
+SESSION_ENGINE = config("SESSION_ENGINE", default="redis_sessions.session")
+
+SESSION_COOKIE_SECURE = config(
+    "SESSION_COOKIE_SECURE", default=SESSION_COOKIE_SECURE, formatter=bool
+)
+SESSION_SAVE_EVERY_REQUEST = config(
+    "SESSION_SAVE_EVERY_REQUEST", default=SESSION_SAVE_EVERY_REQUEST, formatter=bool
+)
+
+SESSION_REDIS_HOST = config("SESSION_REDIS_HOST", default="redis")
+SESSION_REDIS_PORT = config("SESSION_REDIS_PORT", default=6379, formatter=int)
+SESSION_REDIS_DB = config("SESSION_REDIS_DB", default=1, formatter=int)
+SESSION_REDIS_PASSWORD = config("SESSION_REDIS_PASSWORD", default=None)
+SESSION_REDIS_PREFIX = config("SESSION_REDIS_PREFIX", default="session")
+SESSION_REDIS_SOCKET_TIMEOUT = config("SESSION_REDIS_SOCKET_TIMEOUT", default=1, formatter=int)
+SESSION_REDIS_RETRY_ON_TIMEOUT = config("SESSION_REDIS_RETRY_ON_TIMEOUT", default=False, formatter=bool)
+
+SESSION_REDIS = config(
+    "SESSION_REDIS",
+    default={
+        "host": SESSION_REDIS_HOST,
+        "port": SESSION_REDIS_PORT,
+        "db": SESSION_REDIS_DB,  # db 0 is used for Celery Broker
+        "password": SESSION_REDIS_PASSWORD,
+        "prefix": SESSION_REDIS_PREFIX,
+        "socket_timeout": SESSION_REDIS_SOCKET_TIMEOUT,
+        "retry_on_timeout": SESSION_REDIS_RETRY_ON_TIMEOUT,
+    },
+    formatter=json.loads,
+)
+SESSION_REDIS_SENTINEL_LIST = config("SESSION_REDIS_SENTINEL_LIST", default=None, formatter=json.loads)
+SESSION_REDIS_SENTINEL_MASTER_ALIAS = config("SESSION_REDIS_SENTINEL_MASTER_ALIAS", default=None)
+
+# social sharing settings
+SOCIAL_SHARING_SETTINGS = config(
+    "SOCIAL_SHARING_SETTINGS", default=SOCIAL_SHARING_SETTINGS, formatter=json.loads
+)
+
+REGISTRATION_EMAIL_PATTERNS_ALLOWED = config(
+    "REGISTRATION_EMAIL_PATTERNS_ALLOWED", default=None, formatter=json.loads
+)
+
+# allow for environments to specify what cookie name our login subsystem should use
+# this is to fix a bug regarding simultaneous logins between edx.org and edge.edx.org which can
+# happen with some browsers (e.g. Firefox)
+if config("SESSION_COOKIE_NAME", default=None):
+    # NOTE, there's a bug in Django (http://bugs.python.org/issue18012) which necessitates this
+    # being a str()
+    SESSION_COOKIE_NAME = str(config("SESSION_COOKIE_NAME"))
+
+# Set the names of cookies shared with the marketing site
+# These have the same cookie domain as the session, which in production
+# usually includes subdomains.
+EDXMKTG_LOGGED_IN_COOKIE_NAME = config(
+    "EDXMKTG_LOGGED_IN_COOKIE_NAME", default=EDXMKTG_LOGGED_IN_COOKIE_NAME
+)
+EDXMKTG_USER_INFO_COOKIE_NAME = config(
+    "EDXMKTG_USER_INFO_COOKIE_NAME", default=EDXMKTG_USER_INFO_COOKIE_NAME
+)
+
+# Determines whether the CSRF token can be transported on
+# unencrypted channels. It is set to False here for backward compatibility,
+# but it is highly recommended that this is True for environments accessed
+# by end users.
+CSRF_COOKIE_SECURE = config("CSRF_COOKIE_SECURE", default=False, formatter=bool)
+
+# Email overrides
+DEFAULT_FROM_EMAIL = config("DEFAULT_FROM_EMAIL", default=DEFAULT_FROM_EMAIL)
+DEFAULT_FEEDBACK_EMAIL = config(
+    "DEFAULT_FEEDBACK_EMAIL", default=DEFAULT_FEEDBACK_EMAIL
+)
+ADMINS = config("ADMINS", default=ADMINS, formatter=json.loads)
+SERVER_EMAIL = config("SERVER_EMAIL", default=SERVER_EMAIL)
+MKTG_URLS = config("MKTG_URLS", default=MKTG_URLS, formatter=json.loads)
+TECH_SUPPORT_EMAIL = config("TECH_SUPPORT_EMAIL", default=TECH_SUPPORT_EMAIL)
+
+for name, value in config("CODE_JAIL", default={}, formatter=json.loads).items():
+    oldvalue = CODE_JAIL.get(name)
+    if isinstance(oldvalue, dict):
+        for subname, subvalue in value.items():
+            oldvalue[subname] = subvalue
+    else:
+        CODE_JAIL[name] = value
+
+COURSES_WITH_UNSAFE_CODE = config(
+    "COURSES_WITH_UNSAFE_CODE", default=[], formatter=json.loads
+)
+
+ASSET_IGNORE_REGEX = config("ASSET_IGNORE_REGEX", default=ASSET_IGNORE_REGEX)
+
+LOCALE_PATHS = config("LOCALE_PATHS", default=LOCALE_PATHS, formatter=json.loads)
+
+COMPREHENSIVE_THEME_DIRS = (
+    config(
+        "COMPREHENSIVE_THEME_DIRS",
+        default=COMPREHENSIVE_THEME_DIRS,
+        formatter=json.loads,
+    )
+    or []
+)
+
+# COMPREHENSIVE_THEME_LOCALE_PATHS contain the paths to themes locale directories e.g.
+# "COMPREHENSIVE_THEME_LOCALE_PATHS" : [
+#        "/edx/src/edx-themes/conf/locale"
+#    ],
+COMPREHENSIVE_THEME_LOCALE_PATHS = config(
+    "COMPREHENSIVE_THEME_LOCALE_PATHS", default=[], formatter=json.loads
+)
+
+DEFAULT_SITE_THEME = config("DEFAULT_SITE_THEME", default=DEFAULT_SITE_THEME)
+ENABLE_COMPREHENSIVE_THEMING = config(
+    "ENABLE_COMPREHENSIVE_THEMING", default=ENABLE_COMPREHENSIVE_THEMING, formatter=bool
+)
+
+# Timezone overrides
+TIME_ZONE = config("TIME_ZONE", default=TIME_ZONE)
+
+# Push to LMS overrides
+GIT_REPO_EXPORT_DIR = config(
+    "GIT_REPO_EXPORT_DIR",
+    default=path("/edx/var/edxapp/export_course_repos"),
+    formatter=path,
+)
+
+# Translation overrides
+LANGUAGES = config("LANGUAGES", default=LANGUAGES, formatter=json.loads)
+LANGUAGE_CODE = config("LANGUAGE_CODE", default=LANGUAGE_CODE)
+LANGUAGE_COOKIE = config("LANGUAGE_COOKIE", default=LANGUAGE_COOKIE)
+
+USE_I18N = config("USE_I18N", default=USE_I18N, formatter=bool)
+ALL_LANGUAGES = config("ALL_LANGUAGES", default=ALL_LANGUAGES, formatter=json.loads)
+
+# Override feature by feature by whatever is being redefined in the settings.yaml file
+CONFIG_FEATURES = config("FEATURES", default={}, formatter=json.loads)
+FEATURES.update(CONFIG_FEATURES)
+
+# Additional installed apps
+for app in config("ADDL_INSTALLED_APPS", default=[], formatter=json.loads):
+    INSTALLED_APPS.append(app)
+
+WIKI_ENABLED = config("WIKI_ENABLED", default=WIKI_ENABLED, formatter=bool)
+
+# Configure Logging
+
+# Default format for syslog logging
+standard_format = "%(asctime)s %(levelname)s %(process)d [%(name)s] %(filename)s:%(lineno)d - %(message)s"
+syslog_format = (
+    "[variant:cms][%(name)s][env:sandbox] %(levelname)s "
+    "[{hostname}  %(process)d] [%(filename)s:%(lineno)d] - %(message)s"
+).format(hostname=platform.node().split(".")[0])
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "local": {
+            "formatter": "syslog_format",
+            "class": "logging.StreamHandler",
+            "level": "INFO",
+        },
+        "tracking": {
+            "formatter": "raw",
+            "class": "logging.StreamHandler",
+            "level": "DEBUG",
+        },
+        "console": {
+            "formatter": "standard",
+            "class": "logging.StreamHandler",
+            "level": "INFO",
+        },
+    },
+    "formatters": {
+        "raw": {"format": "%(message)s"},
+        "syslog_format": {"format": syslog_format},
+        "standard": {"format": standard_format},
+    },
+    "filters": {"require_debug_false": {"()": "django.utils.log.RequireDebugFalse"}},
+    "loggers": {
+        "": {"level": "INFO", "propagate": False, "handlers": ["console", "local"]},
+        "tracking": {"level": "DEBUG", "propagate": False, "handlers": ["tracking"]},
+    },
+}
+
+SENTRY_DSN = config("SENTRY_DSN", default=None)
+if SENTRY_DSN:
+    LOGGING["loggers"][""]["handlers"].append("sentry")
+    LOGGING["handlers"]["sentry"] = {
+        "class": "raven.handlers.logging.SentryHandler",
+        "dsn": SENTRY_DSN,
+        "level": "ERROR",
+        "environment": "production",
+        "release": RELEASE,
+    }
+
+# FIXME: the PLATFORM_NAME and PLATFORM_DESCRIPTION settings should be set to lazy translatable
+# strings but edX tries to serialize them with a default json serializer which breaks. We should
+# submit a PR to fix it in edx-platform
+PLATFORM_NAME = config("PLATFORM_NAME", default="Your Platform Name Here")
+PLATFORM_DESCRIPTION = config("PLATFORM_DESCRIPTION", default="Your Platform Description Here")
+STUDIO_NAME = config("STUDIO_NAME", default=STUDIO_NAME)
+STUDIO_SHORT_NAME = config("STUDIO_SHORT_NAME", default=STUDIO_SHORT_NAME)
+
+# Event Tracking
+TRACKING_IGNORE_URL_PATTERNS = config(
+    "TRACKING_IGNORE_URL_PATTERNS", default=TRACKING_IGNORE_URL_PATTERNS, formatter=json.loads
+)
+
+# Heartbeat
+HEARTBEAT_CHECKS = config(
+    "HEARTBEAT_CHECKS", default=HEARTBEAT_CHECKS, formatter=json.loads
+)
+HEARTBEAT_EXTENDED_CHECKS = config(
+    "HEARTBEAT_EXTENDED_CHECKS", default=HEARTBEAT_EXTENDED_CHECKS, formatter=json.loads
+)
+HEARTBEAT_CELERY_TIMEOUT = config(
+    "HEARTBEAT_CELERY_TIMEOUT", default=HEARTBEAT_CELERY_TIMEOUT, formatter=int
+)
+
+# Django CAS external authentication settings
+CAS_EXTRA_LOGIN_PARAMS = config(
+    "CAS_EXTRA_LOGIN_PARAMS", default=None, formatter=json.loads
+)
+if FEATURES.get("AUTH_USE_CAS"):
+    CAS_SERVER_URL = config("CAS_SERVER_URL", default=None)
+    AUTHENTICATION_BACKENDS = [
+        "django.contrib.auth.backends.ModelBackend",
+        "django_cas.backends.CASBackend",
+    ]
+    INSTALLED_APPS.append("django_cas")
+    MIDDLEWARE_CLASSES.append("django_cas.middleware.CASMiddleware")
+    CAS_ATTRIBUTE_CALLBACK = config(
+        "CAS_ATTRIBUTE_CALLBACK", default=None, formatter=json.loads
+    )
+    if CAS_ATTRIBUTE_CALLBACK:
+        import importlib
+
+        CAS_USER_DETAILS_RESOLVER = getattr(
+            importlib.import_module(CAS_ATTRIBUTE_CALLBACK["module"]),
+            CAS_ATTRIBUTE_CALLBACK["function"],
+        )
+
+# Specific setting for the File Upload Service to store media in a bucket.
+FILE_UPLOAD_STORAGE_BUCKET_NAME = config(
+    "FILE_UPLOAD_STORAGE_BUCKET_NAME", default="uploads"
+)
+FILE_UPLOAD_STORAGE_PREFIX = config(
+    "FILE_UPLOAD_STORAGE_PREFIX", default=FILE_UPLOAD_STORAGE_PREFIX
+)
+
+# Zendesk
+ZENDESK_URL = config("ZENDESK_URL", default=ZENDESK_URL)
+ZENDESK_CUSTOM_FIELDS = config(
+    "ZENDESK_CUSTOM_FIELDS", default=ZENDESK_CUSTOM_FIELDS, formatter=json.loads
+)
+
+################ SECURE AUTH ITEMS ###############################
+
+############### XBlock filesystem field config ##########
+DJFS = config("DJFS", default=None, formatter=json.loads)
+
+EMAIL_HOST_USER = config("EMAIL_HOST_USER", default=EMAIL_HOST_USER)
+EMAIL_HOST_PASSWORD = config("EMAIL_HOST_PASSWORD", default=EMAIL_HOST_PASSWORD)
+
+# Note that this is the Studio key for Segment. There is a separate key for the LMS.
+CMS_SEGMENT_KEY = config("SEGMENT_KEY", default=None)
+
+SECRET_KEY = config("SECRET_KEY", default="ThisIsAnExampleKeyForDevPurposeOnly")
+
+DEFAULT_FILE_STORAGE = config(
+    "DEFAULT_FILE_STORAGE", default="django.core.files.storage.FileSystemStorage"
+)
+
+USER_TASKS_ARTIFACT_STORAGE = COURSE_IMPORT_EXPORT_STORAGE
+
+# Databases
+
+DATABASE_ENGINE = config("DATABASE_ENGINE", default="django.db.backends.mysql")
+DATABASE_HOST = config("DATABASE_HOST", default="mysql")
+DATABASE_PORT = config("DATABASE_PORT", default=3306, formatter=int)
+DATABASE_NAME = config("DATABASE_NAME", default="edxapp")
+DATABASE_USER = config("DATABASE_USER", default="edxapp_user")
+DATABASE_PASSWORD = config("DATABASE_PASSWORD", default="password")
+
+DATABASES = config(
+    "DATABASES",
+    default={
+        "default": {
+            "ENGINE": DATABASE_ENGINE,
+            "HOST": DATABASE_HOST,
+            "PORT": DATABASE_PORT,
+            "NAME": DATABASE_NAME,
+            "USER": DATABASE_USER,
+            "PASSWORD": DATABASE_PASSWORD,
+        }
+    },
+    formatter=json.loads,
+)
+
+# Configure the MODULESTORE
+MODULESTORE = convert_module_store_setting_if_needed(
+    config("MODULESTORE", default=MODULESTORE, formatter=json.loads)
+)
+
+MONGODB_PASSWORD = config("MONGODB_PASSWORD", default="")
+MONGODB_HOST = config("MONGODB_HOST", default="mongodb")
+MONGODB_PORT = config("MONGODB_PORT", default=27017, formatter=int)
+MONGODB_NAME = config("MONGODB_NAME", default="edxapp")
+MONGODB_USER = config("MONGODB_USER", default=None)
+MONGODB_SSL = config("MONGODB_SSL", default=False, formatter=bool)
+MONGODB_REPLICASET = config("MONGODB_REPLICASET", default=None)
+# Accepted read_preference value can be found here https://github.com/mongodb/mongo-python-driver/blob/2.9.1/pymongo/read_preferences.py#L54
+MONGODB_READ_PREFERENCE = config("MONGODB_READ_PREFERENCE", default="PRIMARY")
+
+DOC_STORE_CONFIG = config(
+    "DOC_STORE_CONFIG",
+    default={
+        "collection": "modulestore",
+        "host": MONGODB_HOST,
+        "port": MONGODB_PORT,
+        "db": MONGODB_NAME,
+        "user": MONGODB_USER,
+        "password": MONGODB_PASSWORD,
+        "ssl": MONGODB_SSL,
+        "replicaSet": MONGODB_REPLICASET,
+        "read_preference": MONGODB_READ_PREFERENCE,
+    },
+    formatter=json.loads,
+)
+
+MODULESTORE_FIELD_OVERRIDE_PROVIDERS = config(
+    "MODULESTORE_FIELD_OVERRIDE_PROVIDERS",
+    default=MODULESTORE_FIELD_OVERRIDE_PROVIDERS,
+    formatter=json.loads,
+)
+
+XBLOCK_FIELD_DATA_WRAPPERS = config(
+    "XBLOCK_FIELD_DATA_WRAPPERS",
+    default=XBLOCK_FIELD_DATA_WRAPPERS,
+    formatter=json.loads,
+)
+
+CONTENTSTORE = config(
+    "CONTENTSTORE",
+    default={
+        "DOC_STORE_CONFIG": DOC_STORE_CONFIG,
+        "ENGINE": "xmodule.contentstore.mongo.MongoContentStore",
+    },
+    formatter=json.loads,
+)
+
+update_module_store_settings(MODULESTORE, doc_store_settings=DOC_STORE_CONFIG)
+
+# Datadog for events!
+DATADOG = config("DATADOG", default={}, formatter=json.loads)
+
+# TODO: deprecated (compatibility with previous settings)
+DATADOG["api_key"] = config("DATADOG_API", default=None)
+
+# Celery Broker
+# For redis sentinel use the `redis-sentinel` transport
+CELERY_BROKER_TRANSPORT = config("CELERY_BROKER_TRANSPORT", default="redis")
+CELERY_BROKER_USER = config("CELERY_BROKER_USER", default="")
+CELERY_BROKER_PASSWORD = config("CELERY_BROKER_PASSWORD", default="")
+CELERY_BROKER_HOST = config("CELERY_BROKER_HOST", default="redis")
+CELERY_BROKER_PORT = config("CELERY_BROKER_PORT", default=6379, formatter=int)
+CELERY_BROKER_VHOST = config("CELERY_BROKER_VHOST", default=0, formatter=int)
+
+if CELERY_BROKER_TRANSPORT == "redis-sentinel":
+    # register redis sentinel schema in celery
+    register()
+
+BROKER_URL = "{transport}://{user}:{password}@{host}:{port}/{vhost}".format(
+    transport=CELERY_BROKER_TRANSPORT,
+    user=CELERY_BROKER_USER,
+    password=CELERY_BROKER_PASSWORD,
+    host=CELERY_BROKER_HOST,
+    port=CELERY_BROKER_PORT,
+    vhost=CELERY_BROKER_VHOST,
+)
+BROKER_USE_SSL = config("CELERY_BROKER_USE_SSL", default=False, formatter=bool)
+# To use redis-sentinel, refer to the documentation here
+# https://celery-redis-sentinel.readthedocs.io/en/latest/
+BROKER_TRANSPORT_OPTIONS = config("BROKER_TRANSPORT_OPTIONS", default={}, formatter=json.loads)
+
+# Message expiry time in seconds
+CELERY_EVENT_QUEUE_TTL = config("CELERY_EVENT_QUEUE_TTL", default=None, formatter=int)
+
+# Queue to use for updating grades due to grading policy change
+POLICY_CHANGE_GRADES_ROUTING_KEY = config(
+    "POLICY_CHANGE_GRADES_ROUTING_KEY", default=LOW_PRIORITY_QUEUE
+)
+
+# Event tracking
+TRACKING_BACKENDS.update(config("TRACKING_BACKENDS", default={}, formatter=json.loads))
+EVENT_TRACKING_BACKENDS["tracking_logs"]["OPTIONS"]["backends"].update(
+    config("EVENT_TRACKING_BACKENDS", default={}, formatter=json.loads)
+)
+EVENT_TRACKING_BACKENDS["segmentio"]["OPTIONS"]["processors"][0]["OPTIONS"][
+    "whitelist"
+].extend(
+    config("EVENT_TRACKING_SEGMENTIO_EMIT_WHITELIST", default=[], formatter=json.loads)
+)
+
+##### ACCOUNT LOCKOUT DEFAULT PARAMETERS #####
+MAX_FAILED_LOGIN_ATTEMPTS_ALLOWED = config(
+    "MAX_FAILED_LOGIN_ATTEMPTS_ALLOWED", default=5, formatter=int
+)
+MAX_FAILED_LOGIN_ATTEMPTS_LOCKOUT_PERIOD_SECS = config(
+    "MAX_FAILED_LOGIN_ATTEMPTS_LOCKOUT_PERIOD_SECS", default=15 * 60, formatter=int
+)
+
+#### PASSWORD POLICY SETTINGS #####
+PASSWORD_MIN_LENGTH = config("PASSWORD_MIN_LENGTH", default=12, formatter=int)
+PASSWORD_MAX_LENGTH = config("PASSWORD_MAX_LENGTH", default=None, formatter=int)
+
+PASSWORD_COMPLEXITY = config(
+    "PASSWORD_COMPLEXITY",
+    default={"UPPER": 1, "LOWER": 1, "DIGITS": 1},
+    formatter=json.loads,
+)
+
+PASSWORD_DICTIONARY = config("PASSWORD_DICTIONARY", default=[], formatter=json.loads)
+
+### INACTIVITY SETTINGS ####
+SESSION_INACTIVITY_TIMEOUT_IN_SECONDS = config(
+    "SESSION_INACTIVITY_TIMEOUT_IN_SECONDS", default=None, formatter=int
+)
+
+##### X-Frame-Options response header settings #####
+X_FRAME_OPTIONS = config("X_FRAME_OPTIONS", default=X_FRAME_OPTIONS)
+
+##### ADVANCED_SECURITY_CONFIG #####
+ADVANCED_SECURITY_CONFIG = config(
+    "ADVANCED_SECURITY_CONFIG", default={}, formatter=json.loads
+)
+
+################ ADVANCED COMPONENT/PROBLEM TYPES ###############
+
+ADVANCED_PROBLEM_TYPES = config(
+    "ADVANCED_PROBLEM_TYPES", default=ADVANCED_PROBLEM_TYPES, formatter=json.loads
+)
+
+################ VIDEO UPLOAD PIPELINE ###############
+
+VIDEO_UPLOAD_PIPELINE = config(
+    "VIDEO_UPLOAD_PIPELINE", default=VIDEO_UPLOAD_PIPELINE, formatter=json.loads
+)
+
+################ VIDEO IMAGE STORAGE ###############
+
+VIDEO_IMAGE_SETTINGS = config(
+    "VIDEO_IMAGE_SETTINGS", default=VIDEO_IMAGE_SETTINGS, formatter=json.loads
+)
+
+################ VIDEO TRANSCRIPTS STORAGE ###############
+
+VIDEO_TRANSCRIPTS_SETTINGS = config(
+    "VIDEO_TRANSCRIPTS_SETTINGS",
+    default=VIDEO_TRANSCRIPTS_SETTINGS,
+    formatter=json.loads,
+)
+
+################ PUSH NOTIFICATIONS ###############
+
+PARSE_KEYS = config("PARSE_KEYS", default={}, formatter=json.loads)
+
+
+# Video Caching. Pairing country codes with CDN URLs.
+# Example: {'CN': 'http://api.xuetangx.com/edx/video?s3_url='}
+VIDEO_CDN_URL = config("VIDEO_CDN_URL", default={}, formatter=json.loads)
+
+if FEATURES["ENABLE_COURSEWARE_INDEX"] or FEATURES["ENABLE_LIBRARY_INDEX"]:
+    # Use ElasticSearch for the search engine
+    SEARCH_ENGINE = "search.elastic.ElasticSearchEngine"
+
+ELASTIC_SEARCH_CONFIG = config(
+    "ELASTIC_SEARCH_CONFIG", default=[{}], formatter=json.loads
+)
+
+################ CONFIGURABLE LTI CONSUMER ###############
+
+# Add just the standard LTI consumer by default, forcing it to open in a new window and ask
+# the user before sending email and username:
+LTI_XBLOCK_CONFIGURATIONS = config(
+    "LTI_XBLOCK_CONFIGURATIONS",
+    default=[
+        {
+            "display_name": "LTI consumer",
+            "pattern": ".*",
+            "hidden_fields": [
+                "ask_to_send_email",
+                "ask_to_send_username",
+                "new_window",
+            ],
+            "defaults": {
+                "ask_to_send_email": True,
+                "ask_to_send_username": True,
+                "launch_target": "new_window",
+            },
+        }
+    ],
+    formatter=json.loads,
+)
+LTI_XBLOCK_SECRETS = config("LTI_XBLOCK_SECRETS", default={}, formatter=json.loads)
+
+XBLOCK_SETTINGS = config("XBLOCK_SETTINGS", default={}, formatter=json.loads)
+XBLOCK_SETTINGS.setdefault("VideoDescriptor", {})["licensing_enabled"] = FEATURES.get(
+    "LICENSING", False
+)
+XBLOCK_SETTINGS.setdefault("VideoModule", {})["YOUTUBE_API_KEY"] = config(
+    "YOUTUBE_API_KEY", default=YOUTUBE_API_KEY
+)
+
+################# MICROSITE ####################
+# microsite specific configurations.
+MICROSITE_CONFIGURATION = config(
+    "MICROSITE_CONFIGURATION", default={}, formatter=json.loads
+)
+MICROSITE_ROOT_DIR = path(config("MICROSITE_ROOT_DIR", default=""))
+# this setting specify which backend to be used when pulling microsite specific configuration
+MICROSITE_BACKEND = config("MICROSITE_BACKEND", default=MICROSITE_BACKEND)
+# this setting specify which backend to be used when loading microsite specific templates
+MICROSITE_TEMPLATE_BACKEND = config(
+    "MICROSITE_TEMPLATE_BACKEND", default=MICROSITE_TEMPLATE_BACKEND
+)
+# TTL for microsite database template cache
+MICROSITE_DATABASE_TEMPLATE_CACHE_TTL = config(
+    "MICROSITE_DATABASE_TEMPLATE_CACHE_TTL",
+    default=MICROSITE_DATABASE_TEMPLATE_CACHE_TTL,
+    formatter=int,
+)
+
+############################ OAUTH2 Provider ###################################
+
+# OpenID Connect issuer ID. Normally the URL of the authentication endpoint.
+OAUTH_OIDC_ISSUER = config("OAUTH_OIDC_ISSUER", default=None)
+
+#### JWT configuration ####
+JWT_AUTH.update(config("JWT_AUTH", default={}, formatter=json.loads))
+
+######################## CUSTOM COURSES for EDX CONNECTOR ######################
+if FEATURES.get("CUSTOM_COURSES_EDX"):
+    INSTALLED_APPS.append("openedx.core.djangoapps.ccxcon.apps.CCXConnectorConfig")
+
+# Partner support link for CMS footer
+PARTNER_SUPPORT_EMAIL = config("PARTNER_SUPPORT_EMAIL", default=PARTNER_SUPPORT_EMAIL)
+
+# Affiliate cookie tracking
+AFFILIATE_COOKIE_NAME = config("AFFILIATE_COOKIE_NAME", default=AFFILIATE_COOKIE_NAME)
+
+############## Settings for Studio Context Sensitive Help ##############
+
+HELP_TOKENS_BOOKS = config(
+    "HELP_TOKENS_BOOKS", default=HELP_TOKENS_BOOKS, formatter=json.loads
+)
+
+############## Settings for CourseGraph ############################
+COURSEGRAPH_JOB_QUEUE = config("COURSEGRAPH_JOB_QUEUE", default=LOW_PRIORITY_QUEUE)
+
+########## Settings for video transcript migration tasks ############
+VIDEO_TRANSCRIPT_MIGRATIONS_JOB_QUEUE = config(
+    "VIDEO_TRANSCRIPT_MIGRATIONS_JOB_QUEUE", default=LOW_PRIORITY_QUEUE
+)
+
+########################## Parental controls config  #######################
+
+# The age at which a learner no longer requires parental consent, or None
+# if parental consent is never required.
+PARENTAL_CONSENT_AGE_LIMIT = config(
+    "PARENTAL_CONSENT_AGE_LIMIT", default=PARENTAL_CONSENT_AGE_LIMIT, formatter=int
+)
+
+########################## Extra middleware classes  #######################
+
+# Allow extra middleware classes to be added to the app through configuration.
+MIDDLEWARE_CLASSES.extend(
+    config("EXTRA_MIDDLEWARE_CLASSES", default=[], formatter=json.loads)
+)
+
+########################## Settings for Completion API #####################
+
+# Once a user has watched this percentage of a video, mark it as complete:
+# (0.0 = 0%, 1.0 = 100%)
+COMPLETION_VIDEO_COMPLETE_PERCENTAGE = config(
+    "COMPLETION_VIDEO_COMPLETE_PERCENTAGE",
+    default=COMPLETION_VIDEO_COMPLETE_PERCENTAGE,
+    formatter=float,
+)
+
+####################### Enterprise Settings ######################
+# A shared secret to be used for encrypting passwords passed from the enterprise api
+# to the enteprise reporting script.
+ENTERPRISE_REPORTING_SECRET = config(
+    "ENTERPRISE_REPORTING_SECRET", default=ENTERPRISE_REPORTING_SECRET
+)
+
+# A default dictionary to be used for filtering out enterprise customer catalog.
+ENTERPRISE_CUSTOMER_CATALOG_DEFAULT_CONTENT_FILTER = config(
+    "ENTERPRISE_CUSTOMER_CATALOG_DEFAULT_CONTENT_FILTER",
+    default=ENTERPRISE_CUSTOMER_CATALOG_DEFAULT_CONTENT_FILTER,
+)
+
+############### Settings for Retirement #####################
+RETIRED_USERNAME_PREFIX = config(
+    "RETIRED_USERNAME_PREFIX", default=RETIRED_USERNAME_PREFIX
+)
+RETIRED_EMAIL_PREFIX = config("RETIRED_EMAIL_PREFIX", default=RETIRED_EMAIL_PREFIX)
+RETIRED_EMAIL_DOMAIN = config("RETIRED_EMAIL_DOMAIN", default=RETIRED_EMAIL_DOMAIN)
+RETIREMENT_SERVICE_WORKER_USERNAME = config(
+    "RETIREMENT_SERVICE_WORKER_USERNAME", default=RETIREMENT_SERVICE_WORKER_USERNAME
+)
+RETIREMENT_STATES = config(
+    "RETIREMENT_STATES", default=RETIREMENT_STATES, formatter=json.loads
+)
+
+####################### Plugin Settings ##########################
+
+from openedx.core.djangoapps.plugins import (
+    plugin_settings,
+    constants as plugin_constants,
+)
+
+plugin_settings.add_plugins(
+    __name__, plugin_constants.ProjectType.CMS, plugin_constants.SettingsType.AWS
+)
+
+########################## Derive Any Derived Settings  #######################
+
+derive_settings(__name__)

--- a/releases/ironwood/2/oee/config/cms/docker_run_staging.py
+++ b/releases/ironwood/2/oee/config/cms/docker_run_staging.py
@@ -1,0 +1,14 @@
+# This file includes overrides to build the `staging` environment for the CMS starting from the
+# settings of the `production` environment
+
+from docker_run_production import *
+from lms.envs.fun.utils import Configuration
+
+# Load custom configuration parameters from yaml files
+config = Configuration(os.path.dirname(__file__))
+
+LOGGING["handlers"]["sentry"]["environment"] = "staging"
+
+EMAIL_BACKEND = config(
+    "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"
+)

--- a/releases/ironwood/2/oee/config/lms/backends.py
+++ b/releases/ironwood/2/oee/config/lms/backends.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+from ratelimitbackend.backends import RateLimitModelBackend
+
+
+class ProxyRateLimitModelBackend(RateLimitModelBackend):
+    """A rate limiting Backend that works behind a proxy."""
+
+    def get_ip(self, request):
+        """Return the end user address string as set by proxies."""
+        return request.META['HTTP_X_FORWARDED_FOR']

--- a/releases/ironwood/2/oee/config/lms/docker_build_development.py
+++ b/releases/ironwood/2/oee/config/lms/docker_build_development.py
@@ -1,0 +1,9 @@
+# This is a minimal settings file allowing us to run "update_assets"
+# in the Dockerfile for the development image of the edxapp LMS
+
+from .docker_build_production import *
+
+DEBUG = True
+REQUIRE_DEBUG = True
+
+WEBPACK_CONFIG_PATH = "webpack.dev.config.js"

--- a/releases/ironwood/2/oee/config/lms/docker_build_development.py
+++ b/releases/ironwood/2/oee/config/lms/docker_build_development.py
@@ -7,3 +7,35 @@ DEBUG = True
 REQUIRE_DEBUG = True
 
 WEBPACK_CONFIG_PATH = "webpack.dev.config.js"
+
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "default",
+    },
+    "general": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "general",
+    },
+    "celery": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "celery",
+    },
+    "mongo_metadata_inheritance": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "mongo_metadata_inheritance",
+    },
+    "openassessment_submissions": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "openassessment_submissions",
+    },
+    "loc_cache": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "loc_cache",
+    },
+    # Cache backend used by Django 1.8 storage backend while processing static files
+    "staticfiles": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "staticfiles",
+    },
+}

--- a/releases/ironwood/2/oee/config/lms/docker_build_production.py
+++ b/releases/ironwood/2/oee/config/lms/docker_build_production.py
@@ -1,0 +1,24 @@
+# This is a minimal settings file allowing us to run "update_assets"
+# in the Dockerfile for the production image of the edxapp LMS
+
+from openedx.core.lib.derived import derive_settings
+from path import Path as path
+
+from .docker_run_production import *
+from .utils import Configuration
+
+# Load custom configuration parameters
+config = Configuration()
+
+DATABASES = {"default": {}}
+
+XQUEUE_INTERFACE = {"url": None, "django_auth": None}
+
+STATIC_ROOT = path("/edx/app/edxapp/staticfiles")
+
+# Allow setting a custom theme
+DEFAULT_SITE_THEME = config("DEFAULT_SITE_THEME", default=None)
+
+########################## Derive Any Derived Settings  #######################
+
+derive_settings(__name__)

--- a/releases/ironwood/2/oee/config/lms/docker_build_production.py
+++ b/releases/ironwood/2/oee/config/lms/docker_build_production.py
@@ -19,6 +19,39 @@ STATIC_ROOT = path("/edx/app/edxapp/staticfiles")
 # Allow setting a custom theme
 DEFAULT_SITE_THEME = config("DEFAULT_SITE_THEME", default=None)
 
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "default",
+    },
+    "general": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "general",
+    },
+    "celery": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "celery",
+    },
+    "mongo_metadata_inheritance": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "mongo_metadata_inheritance",
+    },
+    "openassessment_submissions": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "openassessment_submissions",
+    },
+    "loc_cache": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "loc_cache",
+    },
+    # Cache backend used by Django 1.8 storage backend while processing static files
+    "staticfiles": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "staticfiles",
+    },
+}
+
+
 ########################## Derive Any Derived Settings  #######################
 
 derive_settings(__name__)

--- a/releases/ironwood/2/oee/config/lms/docker_run.py
+++ b/releases/ironwood/2/oee/config/lms/docker_run.py
@@ -1,0 +1,3 @@
+# This file is meant to import the environment related settings file
+
+from docker_run_production import *

--- a/releases/ironwood/2/oee/config/lms/docker_run_ci.py
+++ b/releases/ironwood/2/oee/config/lms/docker_run_ci.py
@@ -1,0 +1,14 @@
+# This file includes overrides to build the `CI` environment for the LMS starting from the
+# settings of the `production` environment
+
+from docker_run_production import *
+
+
+DEBUG = True
+
+EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+
+PIPELINE_ENABLED = False
+STATICFILES_STORAGE = "openedx.core.storage.DevelopmentStorage"
+
+ALLOWED_HOSTS = ["*"]

--- a/releases/ironwood/2/oee/config/lms/docker_run_development.py
+++ b/releases/ironwood/2/oee/config/lms/docker_run_development.py
@@ -1,0 +1,33 @@
+# This file includes overrides to build the `development` environment for the LMS starting from the
+# settings of the `production` environment
+
+import json
+
+from docker_run_production import *
+from .utils import Configuration
+
+# Load custom configuration parameters from yaml files
+config = Configuration(os.path.dirname(__file__))
+
+if "sentry" in LOGGING.get("handlers"):
+    LOGGING["handlers"]["sentry"]["environment"] = "development"
+
+DEBUG = True
+REQUIRE_DEBUG = True
+
+EMAIL_BACKEND = config(
+    "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"
+)
+
+PIPELINE_ENABLED = False
+STATICFILES_STORAGE = "openedx.core.storage.DevelopmentStorage"
+
+ALLOWED_HOSTS = ["*"]
+
+WEBPACK_CONFIG_PATH = "webpack.dev.config.js"
+
+AUTHENTICATION_BACKENDS = config(
+    "AUTHENTICATION_BACKENDS",
+    default=["django.contrib.auth.backends.ModelBackend"],
+    formatter=json.loads
+)

--- a/releases/ironwood/2/oee/config/lms/docker_run_feature.py
+++ b/releases/ironwood/2/oee/config/lms/docker_run_feature.py
@@ -1,0 +1,14 @@
+# This file includes overrides to build the `feature` environment for the LMS starting from the
+# settings of the `production` environment
+
+from docker_run_production import *
+from .utils import Configuration
+
+# Load custom configuration parameters from yaml files
+config = Configuration(os.path.dirname(__file__))
+
+LOGGING["handlers"]["sentry"]["environment"] = "feature"
+
+EMAIL_BACKEND = config(
+    "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"
+)

--- a/releases/ironwood/2/oee/config/lms/docker_run_preprod.py
+++ b/releases/ironwood/2/oee/config/lms/docker_run_preprod.py
@@ -1,0 +1,14 @@
+# This file includes overrides to build the `preprod` environment for the LMS starting from the
+# settings of the `production` environment
+
+from docker_run_production import *
+from .utils import Configuration
+
+# Load custom configuration parameters from yaml files
+config = Configuration(os.path.dirname(__file__))
+
+LOGGING["handlers"]["sentry"]["environment"] = "preprod"
+
+EMAIL_BACKEND = config(
+    "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"
+)

--- a/releases/ironwood/2/oee/config/lms/docker_run_production.py
+++ b/releases/ironwood/2/oee/config/lms/docker_run_production.py
@@ -256,45 +256,41 @@ if config("SESSION_COOKIE_NAME", default=None):
 CACHE_REDIS_HOST = config("CACHE_REDIS_HOST", default="redis")
 CACHE_REDIS_PORT = config("CACHE_REDIS_PORT", default=6379, formatter=int)
 CACHE_REDIS_DB = config("CACHE_REDIS_DB", default=1, formatter=int)
-CACHE_REDIS_URI = "redis://{}:{}/{}".format(CACHE_REDIS_HOST, CACHE_REDIS_PORT, CACHE_REDIS_DB)
-CACHE_REDIS_BACKEND = config("CACHE_REDIS_BACKEND", default="django_redis.cache.RedisCache")
-CACHE_REDIS_CLIENT = config("CACHE_REDIS_CLIENT", default="django_redis.client.DefaultClient")
+CACHE_REDIS_BACKEND = config(
+    "CACHE_REDIS_BACKEND", default="django_redis.cache.RedisCache"
+)
+CACHE_REDIS_URI = "redis://{}:{}/{}".format(
+    CACHE_REDIS_HOST, CACHE_REDIS_PORT, CACHE_REDIS_DB
+)
+CACHE_REDIS_CLIENT = config(
+    "CACHE_REDIS_CLIENT", default="django_redis.client.DefaultClient"
+)
+
+CACHES_DEFAULT_CONFIG = {
+    "BACKEND": CACHE_REDIS_BACKEND,
+    "LOCATION": CACHE_REDIS_URI,
+    "OPTIONS": {"CLIENT_CLASS": CACHE_REDIS_CLIENT},
+}
+
+if "Sentinel" in CACHE_REDIS_BACKEND:
+    CACHES_DEFAULT_CONFIG["LOCATION"] = [(CACHE_REDIS_HOST, CACHE_REDIS_PORT)]
+    CACHES_DEFAULT_CONFIG["OPTIONS"]["SENTINEL_SERVICE_NAME"] = config(
+        "CACHE_REDIS_SENTINEL_SERVICE_NAME", default="mymaster"
+    )
+    CACHES_DEFAULT_CONFIG["OPTIONS"]["REDIS_CLIENT_KWARGS"] = {"db": CACHE_REDIS_DB}
 
 CACHES = config(
     "CACHES",
     default={
-        "default": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "default",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
-        "general": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "general",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
-        "celery": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "celery",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
-        "mongo_metadata_inheritance": {
-            "BACKEND": CACHE_REDIS_BACKEND,
-            "LOCATION": CACHE_REDIS_URI,
-            "KEY_PREFIX": "mongo_metadata_inheritance",
-            "OPTIONS": {
-              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
-            },
-        },
+        "default": dict(CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "default"}),
+        "general": dict(CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "general"}),
+        "celery": dict(CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "celery"}),
+        "mongo_metadata_inheritance": dict(
+            CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "mongo_metadata_inheritance"}
+        ),
+        "openassessment_submissions": dict(
+            CACHES_DEFAULT_CONFIG, **{"KEY_PREFIX": "openassessment_submissions"}
+        ),
         "openassessment_submissions": {
             "BACKEND": CACHE_REDIS_BACKEND,
             "LOCATION": CACHE_REDIS_URI,

--- a/releases/ironwood/2/oee/config/lms/docker_run_production.py
+++ b/releases/ironwood/2/oee/config/lms/docker_run_production.py
@@ -11,6 +11,7 @@ import os
 import platform
 
 from celery_redis_sentinel import register
+from corsheaders.defaults import default_headers as corsheaders_default_headers
 from openedx.core.lib.derived import derive_settings
 from path import Path as path
 from xmodule.modulestore.modulestore_settings import (
@@ -106,7 +107,6 @@ DEFAULT_PRIORITY_QUEUE = config(
     "DEFAULT_PRIORITY_QUEUE", default="edx.lms.core.default"
 )
 HIGH_PRIORITY_QUEUE = config("HIGH_PRIORITY_QUEUE", default="edx.lms.core.high")
-LOW_PRIORITY_QUEUE = config("LOW_PRIORITY_QUEUE", default="edx.lms.core.low")
 HIGH_MEM_QUEUE = config("HIGH_MEM_QUEUE", default="edx.lms.core.high_mem")
 
 CELERY_DEFAULT_QUEUE = DEFAULT_PRIORITY_QUEUE
@@ -117,7 +117,6 @@ CELERY_QUEUES = config(
     default={
         DEFAULT_PRIORITY_QUEUE: {},
         HIGH_PRIORITY_QUEUE: {},
-        LOW_PRIORITY_QUEUE: {},
         HIGH_MEM_QUEUE: {},
     },
     formatter=json.loads,
@@ -236,6 +235,12 @@ CMS_BASE = config("CMS_BASE", default="localhost:8082")
 
 LMS_ROOT_URL = config("LMS_ROOT_URL", default="http://{:s}".format(LMS_BASE))
 LMS_INTERNAL_ROOT_URL = config("LMS_INTERNAL_ROOT_URL", default=LMS_ROOT_URL)
+
+# List of logout URIs for each IDA that the learner should be logged out of when they logout of the LMS. Only applies to
+# IDA for which the social auth flow uses DOT (Django OAuth Toolkit).
+IDA_LOGOUT_URI_LIST = config(
+    "IDA_LOGOUT_URI_LIST", default=[], formatter=json.loads
+)
 
 SITE_NAME = config("SITE_NAME", default=LMS_BASE)
 
@@ -381,12 +386,12 @@ BULK_EMAIL_ROUTING_KEY = config("BULK_EMAIL_ROUTING_KEY", default=HIGH_PRIORITY_
 # We can run smaller jobs on the low priority queue. See note above for why
 # we have to reset the value here.
 BULK_EMAIL_ROUTING_KEY_SMALL_JOBS = config(
-    "BULK_EMAIL_ROUTING_KEY_SMALL_JOBS", default=LOW_PRIORITY_QUEUE
+    "BULK_EMAIL_ROUTING_KEY_SMALL_JOBS", default=DEFAULT_PRIORITY_QUEUE
 )
 
 # Queue to use for expiring old entitlements
 ENTITLEMENTS_EXPIRATION_ROUTING_KEY = config(
-    "ENTITLEMENTS_EXPIRATION_ROUTING_KEY", default=LOW_PRIORITY_QUEUE
+    "ENTITLEMENTS_EXPIRATION_ROUTING_KEY", default=DEFAULT_PRIORITY_QUEUE
 )
 
 # Message expiry time in seconds
@@ -628,6 +633,11 @@ AUTHENTICATION_BACKENDS = config(
 # by end users.
 CSRF_COOKIE_SECURE = config("CSRF_COOKIE_SECURE", default=False, formatter=bool)
 
+# Whitelist of domains to which the login/logout pages will redirect.
+LOGIN_REDIRECT_WHITELIST = config(
+    "LOGIN_REDIRECT_WHITELIST", default=LOGIN_REDIRECT_WHITELIST
+)
+
 ############# CORS headers for cross-domain requests #################
 
 if FEATURES.get("ENABLE_CORS_HEADERS") or FEATURES.get(
@@ -641,6 +651,9 @@ if FEATURES.get("ENABLE_CORS_HEADERS") or FEATURES.get(
         "CORS_ORIGIN_ALLOW_ALL", default=False, formatter=bool
     )
     CORS_ALLOW_INSECURE = config("CORS_ALLOW_INSECURE", default=False, formatter=bool)
+    CORS_ALLOW_HEADERS = corsheaders_default_headers + (
+        'use-jwt-cookie',
+    )
 
     # If setting a cross-domain cookie, it's really important to choose
     # a name for the cookie that is DIFFERENT than the cookies used
@@ -676,7 +689,7 @@ if FEATURES.get("ENABLE_CORS_HEADERS") or FEATURES.get(
 
 
 # Field overrides. To use the IDDE feature, add
-# 'courseware.student_field_overrides.IndividualStudentOverrideProvider'.
+# 'lms.djangoapps.courseware.student_field_overrides.IndividualStudentOverrideProvider'.
 FIELD_OVERRIDE_PROVIDERS = tuple(
     config("FIELD_OVERRIDE_PROVIDERS", default=[], formatter=json.loads)
 )
@@ -983,16 +996,9 @@ MAX_FAILED_LOGIN_ATTEMPTS_LOCKOUT_PERIOD_SECS = config(
 )
 
 #### PASSWORD POLICY SETTINGS #####
-PASSWORD_MIN_LENGTH = config("PASSWORD_MIN_LENGTH", default=12, formatter=int)
-PASSWORD_MAX_LENGTH = config("PASSWORD_MAX_LENGTH", default=None, formatter=int)
-
-PASSWORD_COMPLEXITY = config(
-    "PASSWORD_COMPLEXITY",
-    default={"UPPER": 1, "LOWER": 1, "DIGITS": 1},
-    formatter=json.loads,
+AUTH_PASSWORD_VALIDATORS = config(
+    "AUTH_PASSWORD_VALIDATORS", default=AUTH_PASSWORD_VALIDATORS
 )
-
-PASSWORD_DICTIONARY = config("PASSWORD_DICTIONARY", default=[], formatter=json.loads)
 
 ### INACTIVITY SETTINGS ####
 SESSION_INACTIVITY_TIMEOUT_IN_SECONDS = config(
@@ -1053,6 +1059,11 @@ if FEATURES.get("ENABLE_THIRD_PARTY_AUTH"):
         "THIRD_PARTY_AUTH_CUSTOM_AUTH_FORMS", default={}, formatter=json.loads
     )
 
+    # Whether to allow unprivileged users to discover SSO providers for arbitrary usernames.
+    ALLOW_UNPRIVILEGED_SSO_PROVIDER_QUERY = config(
+        "ALLOW_UNPRIVILEGED_SSO_PROVIDER_QUERY", default=False, formatter=bool
+    )
+
 ##### OAUTH2 Provider ##############
 if FEATURES.get("ENABLE_OAUTH2_PROVIDER"):
     OAUTH_OIDC_ISSUER = config("OAUTH_OIDC_ISSUER")
@@ -1082,9 +1093,13 @@ if FEATURES.get("ENABLE_OAUTH2_PROVIDER"):
         "OAUTH_DELETE_EXPIRED", default=OAUTH_DELETE_EXPIRED, formatter=bool
     )
 
-##### ADVANCED_SECURITY_CONFIG #####
-ADVANCED_SECURITY_CONFIG = config(
-    "ADVANCED_SECURITY_CONFIG", default={}, formatter=json.loads
+##### THIRD_PARTY_AUTH #############
+
+TPA_PROVIDER_BURST_THROTTLE = config(
+    "TPA_PROVIDER_BURST_THROTTLE", default=TPA_PROVIDER_BURST_THROTTLE
+)
+TPA_PROVIDER_SUSTAINED_THROTTLE = config(
+    "TPA_PROVIDER_SUSTAINED_THROTTLE", default=TPA_PROVIDER_SUSTAINED_THROTTLE
 )
 
 ##### GOOGLE ANALYTICS IDS #####
@@ -1233,7 +1248,7 @@ CCX_MAX_STUDENTS_ALLOWED = config(
 ##### Individual Due Date Extensions #####
 if FEATURES.get("INDIVIDUAL_DUE_DATES"):
     FIELD_OVERRIDE_PROVIDERS += (
-        "courseware.student_field_overrides.IndividualStudentOverrideProvider",
+        "lms.djangoapps.courseware.student_field_overrides.IndividualStudentOverrideProvider",
     )
 
 ##### Self-Paced Course Due Dates #####
@@ -1357,7 +1372,7 @@ AUDIT_CERT_CUTOFF_DATE = config(
 ################################ Settings for Credentials Service ################################
 
 CREDENTIALS_GENERATION_ROUTING_KEY = config(
-    "CREDENTIALS_GENERATION_ROUTING_KEY", default=HIGH_PRIORITY_QUEUE
+    "CREDENTIALS_GENERATION_ROUTING_KEY", default=DEFAULT_PRIORITY_QUEUE
 )
 
 # The extended StudentModule history table
@@ -1493,7 +1508,7 @@ COURSES_API_CACHE_TIMEOUT = config(
 ICP_LICENSE = config("ICP_LICENSE", default=None, formatter=bool)
 
 ############## Settings for CourseGraph ############################
-COURSEGRAPH_JOB_QUEUE = config("COURSEGRAPH_JOB_QUEUE", default=LOW_PRIORITY_QUEUE)
+COURSEGRAPH_JOB_QUEUE = config("COURSEGRAPH_JOB_QUEUE", default=DEFAULT_PRIORITY_QUEUE)
 
 ########################## Parental controls config  #######################
 
@@ -1541,11 +1556,22 @@ RETIRED_USERNAME_PREFIX = config(
 )
 RETIRED_EMAIL_PREFIX = config("RETIRED_EMAIL_PREFIX", default=RETIRED_EMAIL_PREFIX)
 RETIRED_EMAIL_DOMAIN = config("RETIRED_EMAIL_DOMAIN", default=RETIRED_EMAIL_DOMAIN)
+RETIRED_USER_SALTS = config("RETIRED_USER_SALTS", default=RETIRED_USER_SALTS)
 RETIREMENT_SERVICE_WORKER_USERNAME = config(
     "RETIREMENT_SERVICE_WORKER_USERNAME", default=RETIREMENT_SERVICE_WORKER_USERNAME
 )
 RETIREMENT_STATES = config(
     "RETIREMENT_STATES", default=RETIREMENT_STATES, formatter=json.loads
+)
+
+############## Settings for Course Enrollment Modes ######################
+COURSE_ENROLLMENT_MODES = config(
+    "COURSE_ENROLLMENT_MODES", default=COURSE_ENROLLMENT_MODES
+)
+
+############## Settings for Writable Gradebook  #########################
+WRITABLE_GRADEBOOK_URL = config(
+    "WRITABLE_GRADEBOOK_URL", default=WRITABLE_GRADEBOOK_URL
 )
 
 ############################### Plugin Settings ###############################

--- a/releases/ironwood/2/oee/config/lms/docker_run_production.py
+++ b/releases/ironwood/2/oee/config/lms/docker_run_production.py
@@ -1,0 +1,1568 @@
+# -*- coding: utf-8 -*-
+
+"""
+This is the settings to run Open edX with Docker the FUN way.
+"""
+
+import datetime
+import dateutil
+import json
+import os
+import platform
+
+from celery_redis_sentinel import register
+from openedx.core.lib.derived import derive_settings
+from path import Path as path
+from xmodule.modulestore.modulestore_settings import (
+    convert_module_store_setting_if_needed,
+)
+
+from ..common import *
+from .utils import Configuration
+
+# Load custom configuration parameters from yaml files
+config = Configuration(os.path.dirname(__file__))
+
+# edX has now started using "settings.ENV_TOKENS" and "settings.AUTH_TOKENS" everywhere in the
+# project, not just in the settings. Let's make sure our settings still work in this case
+ENV_TOKENS = config
+AUTH_TOKENS = config
+
+################################ ALWAYS THE SAME ##############################
+
+RELEASE = config("RELEASE", default=None)
+DEBUG = False
+DEFAULT_TEMPLATE_ENGINE["OPTIONS"]["debug"] = False
+
+SESSION_ENGINE = config("SESSION_ENGINE", default="redis_sessions.session")
+
+SESSION_REDIS_HOST = config("SESSION_REDIS_HOST", default="redis")
+SESSION_REDIS_PORT = config("SESSION_REDIS_PORT", default=6379, formatter=int)
+SESSION_REDIS_DB = config("SESSION_REDIS_DB", default=1, formatter=int)
+SESSION_REDIS_PASSWORD = config("SESSION_REDIS_PASSWORD", default=None)
+SESSION_REDIS_PREFIX = config("SESSION_REDIS_PREFIX", default="session")
+SESSION_REDIS_SOCKET_TIMEOUT = config(
+    "SESSION_REDIS_SOCKET_TIMEOUT", default=1, formatter=int
+)
+SESSION_REDIS_RETRY_ON_TIMEOUT = config(
+    "SESSION_REDIS_RETRY_ON_TIMEOUT", default=False, formatter=bool
+)
+
+SESSION_REDIS = config(
+    "SESSION_REDIS",
+    default={
+        "host": SESSION_REDIS_HOST,
+        "port": SESSION_REDIS_PORT,
+        "db": SESSION_REDIS_DB,  # db 0 is used for Celery Broker
+        "password": SESSION_REDIS_PASSWORD,
+        "prefix": SESSION_REDIS_PREFIX,
+        "socket_timeout": SESSION_REDIS_SOCKET_TIMEOUT,
+        "retry_on_timeout": SESSION_REDIS_RETRY_ON_TIMEOUT,
+    },
+    formatter=json.loads,
+)
+SESSION_REDIS_SENTINEL_LIST = config(
+    "SESSION_REDIS_SENTINEL_LIST", default=None, formatter=json.loads
+)
+SESSION_REDIS_SENTINEL_MASTER_ALIAS = config(
+    "SESSION_REDIS_SENTINEL_MASTER_ALIAS", default=None
+)
+
+# Override edX LMS urls with Fonzie's
+ROOT_URLCONF = "lms.root_urls"
+
+# IMPORTANT: With this enabled, the server must always be behind a proxy that
+# strips the header HTTP_X_FORWARDED_PROTO from client requests. Otherwise,
+# a user can fool our server into thinking it was an https connection.
+# See
+# https://docs.djangoproject.com/en/dev/ref/settings/#secure-proxy-ssl-header
+# for other warnings.
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
+###################################### CELERY  ################################
+
+CELERY_ALWAYS_EAGER = config("CELERY_ALWAYS_EAGER", default=False, formatter=bool)
+
+# Don't use a connection pool, since connections are dropped by ELB.
+BROKER_POOL_LIMIT = 0
+BROKER_CONNECTION_TIMEOUT = 1
+
+# For the Result Store, use the django cache named 'celery'
+CELERY_RESULT_BACKEND = config(
+    "CELERY_RESULT_BACKEND", default="djcelery.backends.cache:CacheBackend"
+)
+
+# When the broker is behind an ELB, use a heartbeat to refresh the
+# connection and to detect if it has been dropped.
+BROKER_HEARTBEAT = 60.0
+BROKER_HEARTBEAT_CHECKRATE = 2
+
+# Each worker should only fetch one message at a time
+CELERYD_PREFETCH_MULTIPLIER = 1
+
+# Celery queues
+
+DEFAULT_PRIORITY_QUEUE = config(
+    "DEFAULT_PRIORITY_QUEUE", default="edx.lms.core.default"
+)
+HIGH_PRIORITY_QUEUE = config("HIGH_PRIORITY_QUEUE", default="edx.lms.core.high")
+LOW_PRIORITY_QUEUE = config("LOW_PRIORITY_QUEUE", default="edx.lms.core.low")
+HIGH_MEM_QUEUE = config("HIGH_MEM_QUEUE", default="edx.lms.core.high_mem")
+
+CELERY_DEFAULT_QUEUE = DEFAULT_PRIORITY_QUEUE
+CELERY_DEFAULT_ROUTING_KEY = DEFAULT_PRIORITY_QUEUE
+
+CELERY_QUEUES = config(
+    "CELERY_QUEUES",
+    default={
+        DEFAULT_PRIORITY_QUEUE: {},
+        HIGH_PRIORITY_QUEUE: {},
+        LOW_PRIORITY_QUEUE: {},
+        HIGH_MEM_QUEUE: {},
+    },
+    formatter=json.loads,
+)
+
+CELERY_ROUTES = "lms.celery.Router"
+
+# Force accepted content to "json" only. If we also accept pickle-serialized
+# messages, the worker will crash when it's running with a privileged user (even
+# if it's not the root user but a user belonging to the root group, which is our
+# case with OpenShift).
+CELERY_ACCEPT_CONTENT = ["json"]
+
+CELERYBEAT_SCHEDULE = {}  # For scheduling tasks, entries can be added to this dict
+
+########################## NON-SECURE ENV CONFIG ##############################
+# Things like server locations, ports, etc.
+
+STATIC_ROOT_BASE = path("/edx/app/edxapp/staticfiles")
+STATIC_ROOT = STATIC_ROOT_BASE
+STATIC_URL = "/static/"
+STATICFILES_STORAGE = config(
+    "STATICFILES_STORAGE", default="lms.envs.fun.storage.CDNProductionStorage"
+)
+CDN_BASE_URL = config("CDN_BASE_URL", default=None)
+
+WEBPACK_LOADER["DEFAULT"]["STATS_FILE"] = STATIC_ROOT / "webpack-stats.json"
+
+MEDIA_ROOT = path("/edx/var/edxapp/media/")
+MEDIA_URL = "/media/"
+
+LOG_DIR = config("LOG_DIR", default=path("/edx/var/logs/edx"), formatter=path)
+DATA_DIR = config("DATA_DIR", default=path("/edx/app/edxapp/data"), formatter=path)
+
+# DEFAULT_COURSE_ABOUT_IMAGE_URL specifies the default image to show for courses that don't provide one
+DEFAULT_COURSE_ABOUT_IMAGE_URL = config(
+    "DEFAULT_COURSE_ABOUT_IMAGE_URL", default=DEFAULT_COURSE_ABOUT_IMAGE_URL
+)
+
+# COURSE_MODE_DEFAULTS specifies the course mode to use for courses that do not set one
+COURSE_MODE_DEFAULTS = config(
+    "COURSE_MODE_DEFAULTS", default=COURSE_MODE_DEFAULTS, formatter=json.loads
+)
+
+# FIXME: the PLATFORM_NAME and PLATFORM_DESCRIPTION settings should be set to lazy translatable
+# strings but edX tries to serialize them with a default json serializer which breaks. We should
+# submit a PR to fix it in edx-platform
+PLATFORM_NAME = config("PLATFORM_NAME", default="Your Platform Name Here")
+PLATFORM_DESCRIPTION = config(
+    "PLATFORM_DESCRIPTION", default="Your Platform Description Here"
+)
+PLATFORM_TWITTER_ACCOUNT = config(
+    "PLATFORM_TWITTER_ACCOUNT", default=PLATFORM_TWITTER_ACCOUNT
+)
+PLATFORM_FACEBOOK_ACCOUNT = config(
+    "PLATFORM_FACEBOOK_ACCOUNT", default=PLATFORM_FACEBOOK_ACCOUNT
+)
+SOCIAL_SHARING_SETTINGS = config(
+    "SOCIAL_SHARING_SETTINGS", default=SOCIAL_SHARING_SETTINGS, formatter=json.loads
+)
+
+# Social media links for the page footer
+SOCIAL_MEDIA_FOOTER_URLS = config(
+    "SOCIAL_MEDIA_FOOTER_URLS", default=SOCIAL_MEDIA_FOOTER_URLS, formatter=json.loads
+)
+
+CC_MERCHANT_NAME = config("CC_MERCHANT_NAME", default=PLATFORM_NAME)
+EMAIL_BACKEND = config(
+    "EMAIL_BACKEND", default="django.core.mail.backends.smtp.EmailBackend"
+)
+EMAIL_FILE_PATH = config("EMAIL_FILE_PATH", default=None)
+EMAIL_HOST = config("EMAIL_HOST", default="localhost")
+EMAIL_PORT = config("EMAIL_PORT", default=25, formatter=int)
+EMAIL_USE_TLS = config("EMAIL_USE_TLS", default=False, formatter=bool)
+HTTPS = config("HTTPS", default=HTTPS)
+SESSION_COOKIE_DOMAIN = config("SESSION_COOKIE_DOMAIN", default=None)
+SESSION_COOKIE_HTTPONLY = config(
+    "SESSION_COOKIE_HTTPONLY", default=True, formatter=bool
+)
+SESSION_COOKIE_SECURE = config(
+    "SESSION_COOKIE_SECURE", default=SESSION_COOKIE_SECURE, formatter=bool
+)
+SESSION_SAVE_EVERY_REQUEST = config(
+    "SESSION_SAVE_EVERY_REQUEST", default=SESSION_SAVE_EVERY_REQUEST, formatter=bool
+)
+
+REGISTRATION_EXTRA_FIELDS = config(
+    "REGISTRATION_EXTRA_FIELDS", default=REGISTRATION_EXTRA_FIELDS, formatter=json.loads
+)
+REGISTRATION_EXTENSION_FORM = config(
+    "REGISTRATION_EXTENSION_FORM", default=REGISTRATION_EXTENSION_FORM
+)
+REGISTRATION_EMAIL_PATTERNS_ALLOWED = config(
+    "REGISTRATION_EMAIL_PATTERNS_ALLOWED", default=None, formatter=json.loads
+)
+REGISTRATION_FIELD_ORDER = config(
+    "REGISTRATION_FIELD_ORDER", default=REGISTRATION_FIELD_ORDER, formatter=json.loads
+)
+
+# Set the names of cookies shared with the marketing site
+# These have the same cookie domain as the session, which in production
+# usually includes subdomains.
+EDXMKTG_LOGGED_IN_COOKIE_NAME = config(
+    "EDXMKTG_LOGGED_IN_COOKIE_NAME", default=EDXMKTG_LOGGED_IN_COOKIE_NAME
+)
+EDXMKTG_USER_INFO_COOKIE_NAME = config(
+    "EDXMKTG_USER_INFO_COOKIE_NAME", default=EDXMKTG_USER_INFO_COOKIE_NAME
+)
+
+# Override feature by feature by whatever is being redefined in the settings.yaml file
+CONFIG_FEATURES = config("FEATURES", default={}, formatter=json.loads)
+FEATURES.update(CONFIG_FEATURES)
+
+LMS_BASE = config("LMS_BASE", default="localhost:8072")
+CMS_BASE = config("CMS_BASE", default="localhost:8082")
+
+LMS_ROOT_URL = config("LMS_ROOT_URL", default="http://{:s}".format(LMS_BASE))
+LMS_INTERNAL_ROOT_URL = config("LMS_INTERNAL_ROOT_URL", default=LMS_ROOT_URL)
+
+SITE_NAME = config("SITE_NAME", default=LMS_BASE)
+
+ALLOWED_HOSTS = config(
+    "ALLOWED_HOSTS", default=[LMS_BASE.split(":")[0]], formatter=json.loads
+)
+if FEATURES.get("PREVIEW_LMS_BASE"):
+    ALLOWED_HOSTS.append(FEATURES["PREVIEW_LMS_BASE"])
+
+# allow for environments to specify what cookie name our login subsystem should use
+# this is to fix a bug regarding simultaneous logins between edx.org and edge.edx.org which can
+# happen with some browsers (e.g. Firefox)
+if config("SESSION_COOKIE_NAME", default=None):
+    # NOTE, there's a bug in Django (http://bugs.python.org/issue18012) which necessitates this
+    # being a str()
+    SESSION_COOKIE_NAME = str(config("SESSION_COOKIE_NAME"))
+
+CACHE_REDIS_HOST = config("CACHE_REDIS_HOST", default="redis")
+CACHE_REDIS_PORT = config("CACHE_REDIS_PORT", default=6379, formatter=int)
+CACHE_REDIS_DB = config("CACHE_REDIS_DB", default=1, formatter=int)
+CACHE_REDIS_URI = "redis://{}:{}/{}".format(CACHE_REDIS_HOST, CACHE_REDIS_PORT, CACHE_REDIS_DB)
+CACHE_REDIS_BACKEND = config("CACHE_REDIS_BACKEND", default="django_redis.cache.RedisCache")
+CACHE_REDIS_CLIENT = config("CACHE_REDIS_CLIENT", default="django_redis.client.DefaultClient")
+
+CACHES = config(
+    "CACHES",
+    default={
+        "default": {
+            "BACKEND": CACHE_REDIS_BACKEND,
+            "LOCATION": CACHE_REDIS_URI,
+            "KEY_PREFIX": "default",
+            "OPTIONS": {
+              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
+            },
+        },
+        "general": {
+            "BACKEND": CACHE_REDIS_BACKEND,
+            "LOCATION": CACHE_REDIS_URI,
+            "KEY_PREFIX": "general",
+            "OPTIONS": {
+              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
+            },
+        },
+        "celery": {
+            "BACKEND": CACHE_REDIS_BACKEND,
+            "LOCATION": CACHE_REDIS_URI,
+            "KEY_PREFIX": "celery",
+            "OPTIONS": {
+              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
+            },
+        },
+        "mongo_metadata_inheritance": {
+            "BACKEND": CACHE_REDIS_BACKEND,
+            "LOCATION": CACHE_REDIS_URI,
+            "KEY_PREFIX": "mongo_metadata_inheritance",
+            "OPTIONS": {
+              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
+            },
+        },
+        "openassessment_submissions": {
+            "BACKEND": CACHE_REDIS_BACKEND,
+            "LOCATION": CACHE_REDIS_URI,
+            "KEY_PREFIX": "openassessment_submissions",
+            "OPTIONS": {
+              "CLIENT_CLASS": CACHE_REDIS_CLIENT,
+            },
+        },
+        "loc_cache": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "edx_location_mem_cache",
+        },
+        "staticfiles": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "edx_location_mem_cache",
+        },
+    },
+    formatter=json.loads,
+)
+
+# Email overrides
+DEFAULT_FROM_EMAIL = config("DEFAULT_FROM_EMAIL", default=DEFAULT_FROM_EMAIL)
+DEFAULT_FEEDBACK_EMAIL = config(
+    "DEFAULT_FEEDBACK_EMAIL", default=DEFAULT_FEEDBACK_EMAIL
+)
+ADMINS = config("ADMINS", default=ADMINS, formatter=json.loads)
+SERVER_EMAIL = config("SERVER_EMAIL", default=SERVER_EMAIL)
+TECH_SUPPORT_EMAIL = config("TECH_SUPPORT_EMAIL", default=TECH_SUPPORT_EMAIL)
+CONTACT_EMAIL = config("CONTACT_EMAIL", default=CONTACT_EMAIL)
+BUGS_EMAIL = config("BUGS_EMAIL", default=BUGS_EMAIL)
+PAYMENT_SUPPORT_EMAIL = config("PAYMENT_SUPPORT_EMAIL", default=PAYMENT_SUPPORT_EMAIL)
+FINANCE_EMAIL = config("FINANCE_EMAIL", default=FINANCE_EMAIL)
+UNIVERSITY_EMAIL = config("UNIVERSITY_EMAIL", default=UNIVERSITY_EMAIL)
+PRESS_EMAIL = config("PRESS_EMAIL", default=PRESS_EMAIL)
+
+CONTACT_MAILING_ADDRESS = config(
+    "CONTACT_MAILING_ADDRESS", default=CONTACT_MAILING_ADDRESS
+)
+
+# Account activation email sender address
+ACTIVATION_EMAIL_FROM_ADDRESS = config(
+    "ACTIVATION_EMAIL_FROM_ADDRESS", default=DEFAULT_FROM_EMAIL
+)
+
+# Currency
+PAID_COURSE_REGISTRATION_CURRENCY = config(
+    "PAID_COURSE_REGISTRATION_CURRENCY", default=PAID_COURSE_REGISTRATION_CURRENCY
+)
+
+# Payment Report Settings
+PAYMENT_REPORT_GENERATOR_GROUP = config(
+    "PAYMENT_REPORT_GENERATOR_GROUP", default=PAYMENT_REPORT_GENERATOR_GROUP
+)
+
+# Bulk Email overrides
+BULK_EMAIL_DEFAULT_FROM_EMAIL = config(
+    "BULK_EMAIL_DEFAULT_FROM_EMAIL", default=BULK_EMAIL_DEFAULT_FROM_EMAIL
+)
+BULK_EMAIL_EMAILS_PER_TASK = config(
+    "BULK_EMAIL_EMAILS_PER_TASK", default=BULK_EMAIL_EMAILS_PER_TASK, formatter=int
+)
+BULK_EMAIL_DEFAULT_RETRY_DELAY = config(
+    "BULK_EMAIL_DEFAULT_RETRY_DELAY",
+    default=BULK_EMAIL_DEFAULT_RETRY_DELAY,
+    formatter=int,
+)
+BULK_EMAIL_MAX_RETRIES = config(
+    "BULK_EMAIL_MAX_RETRIES", default=BULK_EMAIL_MAX_RETRIES, formatter=int
+)
+BULK_EMAIL_INFINITE_RETRY_CAP = config(
+    "BULK_EMAIL_INFINITE_RETRY_CAP",
+    default=BULK_EMAIL_INFINITE_RETRY_CAP,
+    formatter=int,
+)
+BULK_EMAIL_LOG_SENT_EMAILS = config(
+    "BULK_EMAIL_LOG_SENT_EMAILS", default=BULK_EMAIL_LOG_SENT_EMAILS, formatter=bool
+)
+BULK_EMAIL_RETRY_DELAY_BETWEEN_SENDS = config(
+    "BULK_EMAIL_RETRY_DELAY_BETWEEN_SENDS",
+    default=BULK_EMAIL_RETRY_DELAY_BETWEEN_SENDS,
+    formatter=int,
+)
+# We want Bulk Email running on the high-priority queue, so we define the
+# routing key that points to it. At the moment, the name is the same.
+# We have to reset the value here, since we have changed the value of the queue name.
+BULK_EMAIL_ROUTING_KEY = config("BULK_EMAIL_ROUTING_KEY", default=HIGH_PRIORITY_QUEUE)
+
+# We can run smaller jobs on the low priority queue. See note above for why
+# we have to reset the value here.
+BULK_EMAIL_ROUTING_KEY_SMALL_JOBS = config(
+    "BULK_EMAIL_ROUTING_KEY_SMALL_JOBS", default=LOW_PRIORITY_QUEUE
+)
+
+# Queue to use for expiring old entitlements
+ENTITLEMENTS_EXPIRATION_ROUTING_KEY = config(
+    "ENTITLEMENTS_EXPIRATION_ROUTING_KEY", default=LOW_PRIORITY_QUEUE
+)
+
+# Message expiry time in seconds
+CELERY_EVENT_QUEUE_TTL = config("CELERY_EVENT_QUEUE_TTL", default=None, formatter=int)
+
+# following setting is for backward compatibility
+if config("COMPREHENSIVE_THEME_DIR", default=None):
+    COMPREHENSIVE_THEME_DIR = config("COMPREHENSIVE_THEME_DIR")
+
+COMPREHENSIVE_THEME_DIRS = (
+    config(
+        "COMPREHENSIVE_THEME_DIRS",
+        default=COMPREHENSIVE_THEME_DIRS,
+        formatter=json.loads,
+    )
+    or []
+)
+
+LOCALE_PATHS = config(
+    "LOCALE_PATHS", default=(REPO_ROOT + "/conf/locale",), formatter=json.loads
+)
+
+# COMPREHENSIVE_THEME_LOCALE_PATHS contain the paths to themes locale directories e.g.
+# "COMPREHENSIVE_THEME_LOCALE_PATHS" : [
+#        "/edx/src/edx-themes/conf/locale"
+#    ],
+COMPREHENSIVE_THEME_LOCALE_PATHS = config(
+    "COMPREHENSIVE_THEME_LOCALE_PATHS", default=[], formatter=json.loads
+)
+
+DEFAULT_SITE_THEME = config("DEFAULT_SITE_THEME", default=DEFAULT_SITE_THEME)
+ENABLE_COMPREHENSIVE_THEMING = config(
+    "ENABLE_COMPREHENSIVE_THEMING", default=ENABLE_COMPREHENSIVE_THEMING, formatter=bool
+)
+
+# Marketing link overrides
+MKTG_URL_LINK_MAP = config("MKTG_URL_LINK_MAP", default={}, formatter=json.loads)
+
+# Intentional defaults.
+SUPPORT_SITE_LINK = config("SUPPORT_SITE_LINK", default=SUPPORT_SITE_LINK)
+ID_VERIFICATION_SUPPORT_LINK = config(
+    "ID_VERIFICATION_SUPPORT_LINK", default=SUPPORT_SITE_LINK
+)
+PASSWORD_RESET_SUPPORT_LINK = config(
+    "PASSWORD_RESET_SUPPORT_LINK", default=SUPPORT_SITE_LINK
+)
+ACTIVATION_EMAIL_SUPPORT_LINK = config(
+    "ACTIVATION_EMAIL_SUPPORT_LINK", default=SUPPORT_SITE_LINK
+)
+
+# Mobile store URL overrides
+MOBILE_STORE_URLS = config(
+    "MOBILE_STORE_URLS", default=MOBILE_STORE_URLS, formatter=json.loads
+)
+
+# Timezone overrides
+TIME_ZONE = config("TIME_ZONE", default=TIME_ZONE)
+
+# Translation overrides
+LANGUAGES = config("LANGUAGES", default=LANGUAGES, formatter=json.loads)
+CERTIFICATE_TEMPLATE_LANGUAGES = config(
+    "CERTIFICATE_TEMPLATE_LANGUAGES",
+    default=CERTIFICATE_TEMPLATE_LANGUAGES,
+    formatter=json.loads,
+)
+LANGUAGE_DICT = dict(LANGUAGES)
+LANGUAGE_CODE = config("LANGUAGE_CODE", default=LANGUAGE_CODE)
+LANGUAGE_COOKIE = config("LANGUAGE_COOKIE", default=LANGUAGE_COOKIE)
+ALL_LANGUAGES = config("ALL_LANGUAGES", default=ALL_LANGUAGES, formatter=json.loads)
+
+USE_I18N = config("USE_I18N", default=USE_I18N, formatter=bool)
+
+# Additional installed apps
+for app in config("ADDL_INSTALLED_APPS", default=[], formatter=json.loads):
+    INSTALLED_APPS.append(app)
+
+WIKI_ENABLED = config("WIKI_ENABLED", default=WIKI_ENABLED, formatter=bool)
+local_loglevel = config("LOCAL_LOGLEVEL", default="INFO")
+
+# Default format for syslog logging
+standard_format = "%(asctime)s %(levelname)s %(process)d [%(name)s] %(filename)s:%(lineno)d - %(message)s"
+syslog_format = (
+    "[variant:lms][%(name)s][env:sandbox] %(levelname)s "
+    "[{hostname}  %(process)d] [%(filename)s:%(lineno)d] - %(message)s"
+).format(hostname=platform.node().split(".")[0])
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "local": {
+            "formatter": "syslog_format",
+            "class": "logging.StreamHandler",
+            "level": "INFO",
+        },
+        "tracking": {
+            "formatter": "raw",
+            "class": "logging.StreamHandler",
+            "level": "DEBUG",
+        },
+        "console": {
+            "formatter": "standard",
+            "class": "logging.StreamHandler",
+            "level": "INFO",
+        },
+    },
+    "formatters": {
+        "raw": {"format": "%(message)s"},
+        "syslog_format": {"format": syslog_format},
+        "standard": {"format": standard_format},
+    },
+    "filters": {"require_debug_false": {"()": "django.utils.log.RequireDebugFalse"}},
+    "loggers": {
+        "": {"level": "INFO", "propagate": False, "handlers": ["console", "local"]},
+        "tracking": {"level": "DEBUG", "propagate": False, "handlers": ["tracking"]},
+    },
+}
+
+SENTRY_DSN = config("SENTRY_DSN", default=None)
+if SENTRY_DSN:
+    LOGGING["loggers"][""]["handlers"].append("sentry")
+    LOGGING["handlers"]["sentry"] = {
+        "class": "raven.handlers.logging.SentryHandler",
+        "dsn": SENTRY_DSN,
+        "level": "ERROR",
+        "environment": "production",
+        "release": RELEASE,
+    }
+
+
+COURSE_LISTINGS = config("COURSE_LISTINGS", default={}, formatter=json.loads)
+COMMENTS_SERVICE_URL = config("COMMENTS_SERVICE_URL", default="")
+COMMENTS_SERVICE_KEY = config("COMMENTS_SERVICE_KEY", default="")
+CERT_NAME_SHORT = config("CERT_NAME_SHORT", default=CERT_NAME_SHORT)
+CERT_NAME_LONG = config("CERT_NAME_LONG", default=CERT_NAME_LONG)
+CERT_QUEUE = config("CERT_QUEUE", default="test-pull")
+
+FEEDBACK_SUBMISSION_EMAIL = config("FEEDBACK_SUBMISSION_EMAIL", default=None)
+MKTG_URLS = config("MKTG_URLS", default=MKTG_URLS, formatter=json.loads)
+
+# Badgr API
+BADGR_API_TOKEN = config("BADGR_API_TOKEN", default=BADGR_API_TOKEN)
+BADGR_BASE_URL = config("BADGR_BASE_URL", default=BADGR_BASE_URL)
+BADGR_ISSUER_SLUG = config("BADGR_ISSUER_SLUG", default=BADGR_ISSUER_SLUG)
+BADGR_TIMEOUT = config("BADGR_TIMEOUT", default=BADGR_TIMEOUT, formatter=int)
+
+# git repo loading  environment
+GIT_REPO_DIR = config(
+    "GIT_REPO_DIR", default=path("/edx/var/edxapp/course_repos"), formatter=path
+)
+GIT_IMPORT_STATIC = config("GIT_IMPORT_STATIC", default=True, formatter=bool)
+GIT_IMPORT_PYTHON_LIB = config("GIT_IMPORT_PYTHON_LIB", default=True, formatter=bool)
+PYTHON_LIB_FILENAME = config("PYTHON_LIB_FILENAME", default="python_lib.zip")
+
+for name, value in config("CODE_JAIL", default={}, formatter=json.loads).items():
+    oldvalue = CODE_JAIL.get(name)
+    if isinstance(oldvalue, dict):
+        for subname, subvalue in value.items():
+            oldvalue[subname] = subvalue
+    else:
+        CODE_JAIL[name] = value
+
+COURSES_WITH_UNSAFE_CODE = config(
+    "COURSES_WITH_UNSAFE_CODE", default=[], formatter=json.loads
+)
+
+ASSET_IGNORE_REGEX = config("ASSET_IGNORE_REGEX", default=ASSET_IGNORE_REGEX)
+
+# Event Tracking
+TRACKING_IGNORE_URL_PATTERNS = config(
+    "TRACKING_IGNORE_URL_PATTERNS",
+    default=TRACKING_IGNORE_URL_PATTERNS,
+    formatter=json.loads,
+)
+
+# SSL external authentication settings
+SSL_AUTH_EMAIL_DOMAIN = config("SSL_AUTH_EMAIL_DOMAIN", default="MIT.EDU")
+SSL_AUTH_DN_FORMAT_STRING = config("SSL_AUTH_DN_FORMAT_STRING", default=None)
+
+# Django CAS external authentication settings
+CAS_EXTRA_LOGIN_PARAMS = config(
+    "CAS_EXTRA_LOGIN_PARAMS", default=None, formatter=json.loads
+)
+if FEATURES.get("AUTH_USE_CAS"):
+    CAS_SERVER_URL = config("CAS_SERVER_URL", default=None)
+    INSTALLED_APPS.append("django_cas")
+    MIDDLEWARE_CLASSES.append("django_cas.middleware.CASMiddleware")
+    CAS_ATTRIBUTE_CALLBACK = config(
+        "CAS_ATTRIBUTE_CALLBACK", default=None, formatter=json.loads
+    )
+    if CAS_ATTRIBUTE_CALLBACK:
+        import importlib
+
+        CAS_USER_DETAILS_RESOLVER = getattr(
+            importlib.import_module(CAS_ATTRIBUTE_CALLBACK["module"]),
+            CAS_ATTRIBUTE_CALLBACK["function"],
+        )
+
+# Video Caching. Pairing country codes with CDN URLs.
+# Example: {'CN': 'http://api.xuetangx.com/edx/video?s3_url='}
+VIDEO_CDN_URL = config("VIDEO_CDN_URL", default={})
+
+# Branded footer
+FOOTER_OPENEDX_URL = config("FOOTER_OPENEDX_URL", default=FOOTER_OPENEDX_URL)
+FOOTER_OPENEDX_LOGO_IMAGE = config(
+    "FOOTER_OPENEDX_LOGO_IMAGE", default=FOOTER_OPENEDX_LOGO_IMAGE
+)
+FOOTER_ORGANIZATION_IMAGE = config(
+    "FOOTER_ORGANIZATION_IMAGE", default=FOOTER_ORGANIZATION_IMAGE
+)
+FOOTER_CACHE_TIMEOUT = config(
+    "FOOTER_CACHE_TIMEOUT", default=FOOTER_CACHE_TIMEOUT, formatter=int
+)
+FOOTER_BROWSER_CACHE_MAX_AGE = config(
+    "FOOTER_BROWSER_CACHE_MAX_AGE", default=FOOTER_BROWSER_CACHE_MAX_AGE, formatter=int
+)
+
+# Credit notifications settings
+NOTIFICATION_EMAIL_CSS = config(
+    "NOTIFICATION_EMAIL_CSS", default=NOTIFICATION_EMAIL_CSS
+)
+NOTIFICATION_EMAIL_EDX_LOGO = config(
+    "NOTIFICATION_EMAIL_EDX_LOGO", default=NOTIFICATION_EMAIL_EDX_LOGO
+)
+SECRET_KEY = config("SECRET_KEY", default="ThisIsAnExampleKeyForDevPurposeOnly")
+
+# Authentication backends
+# - behind a proxy, use: "lms.envs.fun.backends.ProxyRateLimitModelBackend"
+# - for LTI provider, add: "lti_provider.users.LtiBackend"
+# - for CAS, add: "django_cas.backends.CASBackend"
+AUTHENTICATION_BACKENDS = config(
+    "AUTHENTICATION_BACKENDS",
+    default=("lms.envs.fun.backends.ProxyRateLimitModelBackend",),
+)
+
+# Determines whether the CSRF token can be transported on
+# unencrypted channels. It is set to False here for backward compatibility,
+# but it is highly recommended that this is True for enviroments accessed
+# by end users.
+CSRF_COOKIE_SECURE = config("CSRF_COOKIE_SECURE", default=False, formatter=bool)
+
+############# CORS headers for cross-domain requests #################
+
+if FEATURES.get("ENABLE_CORS_HEADERS") or FEATURES.get(
+    "ENABLE_CROSS_DOMAIN_CSRF_COOKIE"
+):
+    CORS_ALLOW_CREDENTIALS = True
+    CORS_ORIGIN_WHITELIST = config(
+        "CORS_ORIGIN_WHITELIST", default=(), formatter=json.loads
+    )
+    CORS_ORIGIN_ALLOW_ALL = config(
+        "CORS_ORIGIN_ALLOW_ALL", default=False, formatter=bool
+    )
+    CORS_ALLOW_INSECURE = config("CORS_ALLOW_INSECURE", default=False, formatter=bool)
+
+    # If setting a cross-domain cookie, it's really important to choose
+    # a name for the cookie that is DIFFERENT than the cookies used
+    # by each subdomain.  For example, suppose the applications
+    # at these subdomains are configured to use the following cookie names:
+    #
+    # 1) foo.example.com --> "csrftoken"
+    # 2) baz.example.com --> "csrftoken"
+    # 3) bar.example.com --> "csrftoken"
+    #
+    # For the cross-domain version of the CSRF cookie, you need to choose
+    # a name DIFFERENT than "csrftoken"; otherwise, the new token configured
+    # for ".example.com" could conflict with the other cookies,
+    # non-deterministically causing 403 responses.
+    #
+    # Because of the way Django stores cookies, the cookie name MUST
+    # be a `str`, not unicode.  Otherwise there will `TypeError`s will be raised
+    # when Django tries to call the unicode `translate()` method with the wrong
+    # number of parameters.
+    CROSS_DOMAIN_CSRF_COOKIE_NAME = str(config("CROSS_DOMAIN_CSRF_COOKIE_NAME"))
+
+    # When setting the domain for the "cross-domain" version of the CSRF
+    # cookie, you should choose something like: ".example.com"
+    # (note the leading dot), where both the referer and the host
+    # are subdomains of "example.com".
+    #
+    # Browser security rules require that
+    # the cookie domain matches the domain of the server; otherwise
+    # the cookie won't get set.  And once the cookie gets set, the client
+    # needs to be on a domain that matches the cookie domain, otherwise
+    # the client won't be able to read the cookie.
+    CROSS_DOMAIN_CSRF_COOKIE_DOMAIN = config("CROSS_DOMAIN_CSRF_COOKIE_DOMAIN")
+
+
+# Field overrides. To use the IDDE feature, add
+# 'courseware.student_field_overrides.IndividualStudentOverrideProvider'.
+FIELD_OVERRIDE_PROVIDERS = tuple(
+    config("FIELD_OVERRIDE_PROVIDERS", default=[], formatter=json.loads)
+)
+
+############################## SECURE AUTH ITEMS ###############
+
+############### XBlock filesystem field config ##########
+DJFS = config("DJFS", default=None, formatter=json.loads)
+
+############### Module Store Items ##########
+HOSTNAME_MODULESTORE_DEFAULT_MAPPINGS = config(
+    "HOSTNAME_MODULESTORE_DEFAULT_MAPPINGS", default={}, formatter=json.loads
+)
+# PREVIEW DOMAIN must be present in HOSTNAME_MODULESTORE_DEFAULT_MAPPINGS for the preview to show
+# draft changes
+if "PREVIEW_LMS_BASE" in FEATURES and FEATURES["PREVIEW_LMS_BASE"] != "":
+    PREVIEW_DOMAIN = FEATURES["PREVIEW_LMS_BASE"].split(":")[0]
+    # update dictionary with preview domain regex
+    HOSTNAME_MODULESTORE_DEFAULT_MAPPINGS.update({PREVIEW_DOMAIN: "draft-preferred"})
+
+MODULESTORE_FIELD_OVERRIDE_PROVIDERS = config(
+    "MODULESTORE_FIELD_OVERRIDE_PROVIDERS",
+    default=MODULESTORE_FIELD_OVERRIDE_PROVIDERS,
+    formatter=json.loads,
+)
+
+XBLOCK_FIELD_DATA_WRAPPERS = config(
+    "XBLOCK_FIELD_DATA_WRAPPERS",
+    default=XBLOCK_FIELD_DATA_WRAPPERS,
+    formatter=json.loads,
+)
+
+############### Mixed Related(Secure/Not-Secure) Items ##########
+LMS_SEGMENT_KEY = config("LMS_SEGMENT_KEY", default=None)
+
+CC_PROCESSOR_NAME = config("CC_PROCESSOR_NAME", default=CC_PROCESSOR_NAME)
+CC_PROCESSOR = config("CC_PROCESSOR", default=CC_PROCESSOR, formatter=json.loads)
+
+
+DEFAULT_FILE_STORAGE = config(
+    "DEFAULT_FILE_STORAGE", default="django.core.files.storage.FileSystemStorage"
+)
+
+# Specific setting for the File Upload Service to store media in a bucket.
+FILE_UPLOAD_STORAGE_BUCKET_NAME = config(
+    "FILE_UPLOAD_STORAGE_BUCKET_NAME", default="uploads"
+)
+FILE_UPLOAD_STORAGE_PREFIX = config(
+    "FILE_UPLOAD_STORAGE_PREFIX", default=FILE_UPLOAD_STORAGE_PREFIX
+)
+
+# Databases
+
+# If there is a database called 'read_replica', you can use the use_read_replica_if_available
+# function in util/query.py, which is useful for very large database reads
+
+DATABASE_ENGINE = config("DATABASE_ENGINE", default="django.db.backends.mysql")
+DATABASE_HOST = config("DATABASE_HOST", default="mysql")
+DATABASE_PORT = config("DATABASE_PORT", default=3306, formatter=int)
+DATABASE_NAME = config("DATABASE_NAME", default="edxapp")
+DATABASE_USER = config("DATABASE_USER", default="edxapp_user")
+DATABASE_PASSWORD = config("DATABASE_PASSWORD", default="password")
+
+DATABASES = config(
+    "DATABASES",
+    default={
+        "default": {
+            "ENGINE": DATABASE_ENGINE,
+            "HOST": DATABASE_HOST,
+            "PORT": DATABASE_PORT,
+            "NAME": DATABASE_NAME,
+            "USER": DATABASE_USER,
+            "PASSWORD": DATABASE_PASSWORD,
+        }
+    },
+    formatter=json.loads,
+)
+
+XQUEUE_INTERFACE = config(
+    "XQUEUE_INTERFACE",
+    default={"url": None, "basic_auth": None, "django_auth": None},
+    formatter=json.loads,
+)
+
+# Configure the MODULESTORE
+MODULESTORE = convert_module_store_setting_if_needed(
+    config("MODULESTORE", default=MODULESTORE, formatter=json.loads)
+)
+
+MONGODB_PASSWORD = config("MONGODB_PASSWORD", default="")
+MONGODB_HOST = config("MONGODB_HOST", default="mongodb")
+MONGODB_PORT = config("MONGODB_PORT", default=27017, formatter=int)
+MONGODB_NAME = config("MONGODB_NAME", default="edxapp")
+MONGODB_USER = config("MONGODB_USER", default=None)
+MONGODB_SSL = config("MONGODB_SSL", default=False, formatter=bool)
+MONGODB_REPLICASET = config("MONGODB_REPLICASET", default=None)
+# Accepted read_preference value can be found here https://github.com/mongodb/mongo-python-driver/blob/2.9.1/pymongo/read_preferences.py#L54
+MONGODB_READ_PREFERENCE = config("MONGODB_READ_PREFERENCE", default="PRIMARY")
+
+DOC_STORE_CONFIG = config(
+    "DOC_STORE_CONFIG",
+    default={
+        "collection": "modulestore",
+        "host": MONGODB_HOST,
+        "port": MONGODB_PORT,
+        "db": MONGODB_NAME,
+        "user": MONGODB_USER,
+        "password": MONGODB_PASSWORD,
+        "ssl": MONGODB_SSL,
+        "replicaSet": MONGODB_REPLICASET,
+        "read_preference": MONGODB_READ_PREFERENCE,
+    },
+    formatter=json.loads,
+)
+
+MONGODB_LOG = config("MONGODB_LOG", default={}, formatter=json.loads)
+
+CONTENTSTORE = config(
+    "CONTENTSTORE",
+    default={
+        "DOC_STORE_CONFIG": DOC_STORE_CONFIG,
+        "ENGINE": "xmodule.contentstore.mongo.MongoContentStore",
+    },
+    formatter=json.loads,
+)
+
+update_module_store_settings(MODULESTORE, doc_store_settings=DOC_STORE_CONFIG)
+
+EMAIL_HOST_USER = config("EMAIL_HOST_USER", default="")  # django default is ''
+EMAIL_HOST_PASSWORD = config("EMAIL_HOST_PASSWORD", default="")  # django default is ''
+
+# Datadog for events!
+DATADOG = config("DATADOG", default={}, formatter=json.loads)
+
+# TODO: deprecated (compatibility with previous settings)
+DATADOG_API = config("DATADOG_API", default=None)
+
+# Analytics API
+ANALYTICS_API_KEY = config("ANALYTICS_API_KEY", default=ANALYTICS_API_KEY)
+ANALYTICS_API_URL = config("ANALYTICS_API_URL", default=ANALYTICS_API_URL)
+
+# Mailchimp New User List
+MAILCHIMP_NEW_USER_LIST_ID = config("MAILCHIMP_NEW_USER_LIST_ID", default=None)
+
+# Zendesk
+ZENDESK_URL = config("ZENDESK_URL", default=None)
+ZENDESK_USER = config("ZENDESK_USER", default=None)
+ZENDESK_API_KEY = config("ZENDESK_API_KEY", default=None)
+ZENDESK_CUSTOM_FIELDS = config(
+    "ZENDESK_CUSTOM_FIELDS", default={}, formatter=json.loads
+)
+
+# API Key for inbound requests from Notifier service
+EDX_API_KEY = config("EDX_API_KEY", default=None)
+
+# Celery Broker
+# For redis sentinel use the `redis-sentinel` transport
+CELERY_BROKER_TRANSPORT = config("CELERY_BROKER_TRANSPORT", default="redis")
+CELERY_BROKER_USER = config("CELERY_BROKER_USER", default="")
+CELERY_BROKER_PASSWORD = config("CELERY_BROKER_PASSWORD", default="")
+CELERY_BROKER_HOST = config("CELERY_BROKER_HOST", default="redis")
+CELERY_BROKER_PORT = config("CELERY_BROKER_PORT", default=6379, formatter=int)
+CELERY_BROKER_VHOST = config("CELERY_BROKER_VHOST", default=0, formatter=int)
+
+if CELERY_BROKER_TRANSPORT == "redis-sentinel":
+    # register redis sentinel schema in celery
+    register()
+
+BROKER_URL = "{transport}://{user}:{password}@{host}:{port}/{vhost}".format(
+    transport=CELERY_BROKER_TRANSPORT,
+    user=CELERY_BROKER_USER,
+    password=CELERY_BROKER_PASSWORD,
+    host=CELERY_BROKER_HOST,
+    port=CELERY_BROKER_PORT,
+    vhost=CELERY_BROKER_VHOST,
+)
+BROKER_USE_SSL = config("CELERY_BROKER_USE_SSL", default=False, formatter=bool)
+# To use redis-sentinel, refer to the documentation here
+# https://celery-redis-sentinel.readthedocs.io/en/latest/
+BROKER_TRANSPORT_OPTIONS = config(
+    "BROKER_TRANSPORT_OPTIONS", default={}, formatter=json.loads
+)
+
+# Block Structures
+BLOCK_STRUCTURES_SETTINGS = config(
+    "BLOCK_STRUCTURES_SETTINGS", default=BLOCK_STRUCTURES_SETTINGS, formatter=json.loads
+)
+
+# upload limits
+STUDENT_FILEUPLOAD_MAX_SIZE = config(
+    "STUDENT_FILEUPLOAD_MAX_SIZE", default=STUDENT_FILEUPLOAD_MAX_SIZE, formatter=int
+)
+
+# Event tracking
+TRACKING_BACKENDS.update(config("TRACKING_BACKENDS", default={}, formatter=json.loads))
+EVENT_TRACKING_BACKENDS["tracking_logs"]["OPTIONS"]["backends"].update(
+    config("EVENT_TRACKING_BACKENDS", default={}, formatter=json.loads)
+)
+EVENT_TRACKING_BACKENDS["segmentio"]["OPTIONS"]["processors"][0]["OPTIONS"][
+    "whitelist"
+].extend(
+    config("EVENT_TRACKING_SEGMENTIO_EMIT_WHITELIST", default=[], formatter=json.loads)
+)
+TRACKING_SEGMENTIO_WEBHOOK_SECRET = config(
+    "TRACKING_SEGMENTIO_WEBHOOK_SECRET", default=TRACKING_SEGMENTIO_WEBHOOK_SECRET
+)
+TRACKING_SEGMENTIO_ALLOWED_TYPES = config(
+    "TRACKING_SEGMENTIO_ALLOWED_TYPES",
+    default=TRACKING_SEGMENTIO_ALLOWED_TYPES,
+    formatter=json.loads,
+)
+TRACKING_SEGMENTIO_DISALLOWED_SUBSTRING_NAMES = config(
+    "TRACKING_SEGMENTIO_DISALLOWED_SUBSTRING_NAMES",
+    default=TRACKING_SEGMENTIO_DISALLOWED_SUBSTRING_NAMES,
+    formatter=json.loads,
+)
+TRACKING_SEGMENTIO_SOURCE_MAP = config(
+    "TRACKING_SEGMENTIO_SOURCE_MAP",
+    default=TRACKING_SEGMENTIO_SOURCE_MAP,
+    formatter=json.loads,
+)
+
+# Heartbeat
+HEARTBEAT_CHECKS = config(
+    "HEARTBEAT_CHECKS", default=HEARTBEAT_CHECKS, formatter=json.loads
+)
+HEARTBEAT_EXTENDED_CHECKS = config(
+    "HEARTBEAT_EXTENDED_CHECKS", default=HEARTBEAT_EXTENDED_CHECKS, formatter=json.loads
+)
+HEARTBEAT_CELERY_TIMEOUT = config(
+    "HEARTBEAT_CELERY_TIMEOUT", default=HEARTBEAT_CELERY_TIMEOUT, formatter=int
+)
+
+# Student identity verification settings
+VERIFY_STUDENT = config("VERIFY_STUDENT", default=VERIFY_STUDENT, formatter=json.loads)
+DISABLE_ACCOUNT_ACTIVATION_REQUIREMENT_SWITCH = config(
+    "DISABLE_ACCOUNT_ACTIVATION_REQUIREMENT_SWITCH",
+    default=DISABLE_ACCOUNT_ACTIVATION_REQUIREMENT_SWITCH,
+)
+
+# Grades download
+GRADES_DOWNLOAD_ROUTING_KEY = config(
+    "GRADES_DOWNLOAD_ROUTING_KEY", default=HIGH_MEM_QUEUE
+)
+
+# Fonzie API endpoint to add access control on instructor dashboard
+# CSV export files (activated by features ENABLE_GRADE_DOWNLOADS and
+# ALLOW_COURSE_STAFF_GRADE_DOWNLOADS)
+GRADES_DOWNLOAD = config(
+    "GRADES_DOWNLOAD",
+    default={
+        "STORAGE_CLASS": "django.core.files.storage.FileSystemStorage",
+        "STORAGE_KWARGS": {
+            "location": "/edx/var/edxapp/export",
+            "base_url": "/api/v1.0/acl/report",
+        },
+    },
+    formatter=json.loads,
+)
+
+# Add Django Rest Framework URL versioning required by Fonzie to edX
+# existing DRF configuration
+REST_FRAMEWORK.update(
+    {
+        "ALLOWED_VERSIONS": ("1.0",),
+        "DEFAULT_VERSION": "1.0",
+        "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.URLPathVersioning",
+    }
+)
+
+# Rate limit for regrading tasks that a grading policy change can kick off
+POLICY_CHANGE_TASK_RATE_LIMIT = config(
+    "POLICY_CHANGE_TASK_RATE_LIMIT", default=POLICY_CHANGE_TASK_RATE_LIMIT
+)
+
+# financial reports
+FINANCIAL_REPORTS = config(
+    "FINANCIAL_REPORTS", default=FINANCIAL_REPORTS, formatter=json.loads
+)
+
+##### ORA2 ######
+ORA2_FILEUPLOAD_BACKEND = config("ORA2_FILEUPLOAD_BACKEND", default="filesystem")
+
+# Prefix for uploads of example-based assessment AI classifiers
+# This can be used to separate uploads for different environments
+ORA2_FILE_PREFIX = config("ORA2_FILE_PREFIX", default=ORA2_FILE_PREFIX)
+
+# If backend is "filesystem"
+ORA2_FILEUPLOAD_ROOT = DATA_DIR / "openassessment_submissions"
+ORA2_FILEUPLOAD_CACHE_NAME = config(
+    "ORA2_FILEUPLOAD_CACHE_NAME", default="openassessment_submissions"
+)
+
+# If backend is "swift"
+ORA2_SWIFT_KEY = config("ORA2_SWIFT_KEY", default="")
+ORA2_SWIFT_URL = config("ORA2_SWIFT_URL", default="")
+
+##### ACCOUNT LOCKOUT DEFAULT PARAMETERS #####
+MAX_FAILED_LOGIN_ATTEMPTS_ALLOWED = config(
+    "MAX_FAILED_LOGIN_ATTEMPTS_ALLOWED", default=5, formatter=int
+)
+MAX_FAILED_LOGIN_ATTEMPTS_LOCKOUT_PERIOD_SECS = config(
+    "MAX_FAILED_LOGIN_ATTEMPTS_LOCKOUT_PERIOD_SECS", default=15 * 60, formatter=int
+)
+
+#### PASSWORD POLICY SETTINGS #####
+PASSWORD_MIN_LENGTH = config("PASSWORD_MIN_LENGTH", default=12, formatter=int)
+PASSWORD_MAX_LENGTH = config("PASSWORD_MAX_LENGTH", default=None, formatter=int)
+
+PASSWORD_COMPLEXITY = config(
+    "PASSWORD_COMPLEXITY",
+    default={"UPPER": 1, "LOWER": 1, "DIGITS": 1},
+    formatter=json.loads,
+)
+
+PASSWORD_DICTIONARY = config("PASSWORD_DICTIONARY", default=[], formatter=json.loads)
+
+### INACTIVITY SETTINGS ####
+SESSION_INACTIVITY_TIMEOUT_IN_SECONDS = config(
+    "SESSION_INACTIVITY_TIMEOUT_IN_SECONDS", default=None, formatter=int
+)
+
+##### LMS DEADLINE DISPLAY TIME_ZONE #######
+TIME_ZONE_DISPLAYED_FOR_DEADLINES = config(
+    "TIME_ZONE_DISPLAYED_FOR_DEADLINES", default=TIME_ZONE_DISPLAYED_FOR_DEADLINES
+)
+
+##### X-Frame-Options response header settings #####
+X_FRAME_OPTIONS = config("X_FRAME_OPTIONS", default=X_FRAME_OPTIONS)
+
+##### Third-party auth options ################################################
+if FEATURES.get("ENABLE_THIRD_PARTY_AUTH"):
+    # The reduced session expiry time during the third party login pipeline. (Value in seconds)
+    SOCIAL_AUTH_PIPELINE_TIMEOUT = config(
+        "SOCIAL_AUTH_PIPELINE_TIMEOUT", default=600, formatter=int
+    )
+
+    # The SAML private/public key values do not need the delimiter lines (such as
+    # "-----BEGIN PRIVATE KEY-----", "-----END PRIVATE KEY-----" etc.) but they may be included
+    # if you want (though it's easier to format the key values as JSON without the delimiters).
+    SOCIAL_AUTH_SAML_SP_PRIVATE_KEY = config(
+        "SOCIAL_AUTH_SAML_SP_PRIVATE_KEY", default={}, formatter=json.loads
+    )
+    SOCIAL_AUTH_SAML_SP_PUBLIC_CERT = config(
+        "SOCIAL_AUTH_SAML_SP_PUBLIC_CERT", default={}, formatter=json.loads
+    )
+    SOCIAL_AUTH_OAUTH_SECRETS = config("SOCIAL_AUTH_OAUTH_SECRETS", default={})
+    SOCIAL_AUTH_LTI_CONSUMER_SECRETS = config(
+        "SOCIAL_AUTH_LTI_CONSUMER_SECRETS", default={}, formatter=json.loads
+    )
+
+    # third_party_auth config moved to ConfigurationModels. This is for data migration only:
+    THIRD_PARTY_AUTH_OLD_CONFIG = config("THIRD_PARTY_AUTH", default=None)
+
+    if (
+        config("THIRD_PARTY_AUTH_SAML_FETCH_PERIOD_HOURS", default=24, formatter=int)
+        is not None
+    ):
+        CELERYBEAT_SCHEDULE["refresh-saml-metadata"] = {
+            "task": "third_party_auth.fetch_saml_metadata",
+            "schedule": datetime.timedelta(
+                hours=config(
+                    "THIRD_PARTY_AUTH_SAML_FETCH_PERIOD_HOURS",
+                    default=24,
+                    formatter=int,
+                )
+            ),
+        }
+
+    # The following can be used to integrate a custom login form with third_party_auth.
+    # It should be a dict where the key is a word passed via ?auth_entry=, and the value is a
+    # dict with an arbitrary 'secret_key' and a 'url'.
+    THIRD_PARTY_AUTH_CUSTOM_AUTH_FORMS = config(
+        "THIRD_PARTY_AUTH_CUSTOM_AUTH_FORMS", default={}, formatter=json.loads
+    )
+
+##### OAUTH2 Provider ##############
+if FEATURES.get("ENABLE_OAUTH2_PROVIDER"):
+    OAUTH_OIDC_ISSUER = config("OAUTH_OIDC_ISSUER")
+    OAUTH_ENFORCE_SECURE = config("OAUTH_ENFORCE_SECURE", default=True, formatter=bool)
+    OAUTH_ENFORCE_CLIENT_SECURE = config(
+        "OAUTH_ENFORCE_CLIENT_SECURE", default=True, formatter=bool
+    )
+    # Defaults for the following are defined in lms.envs.common
+    OAUTH_EXPIRE_DELTA = datetime.timedelta(
+        days=config(
+            "OAUTH_EXPIRE_CONFIDENTIAL_CLIENT_DAYS",
+            default=OAUTH_EXPIRE_CONFIDENTIAL_CLIENT_DAYS,
+            formatter=int,
+        )
+    )
+    OAUTH_EXPIRE_DELTA_PUBLIC = datetime.timedelta(
+        days=config(
+            "OAUTH_EXPIRE_PUBLIC_CLIENT_DAYS",
+            default=OAUTH_EXPIRE_PUBLIC_CLIENT_DAYS,
+            formatter=int,
+        )
+    )
+    OAUTH_ID_TOKEN_EXPIRATION = config(
+        "OAUTH_ID_TOKEN_EXPIRATION", default=OAUTH_ID_TOKEN_EXPIRATION, formatter=int
+    )
+    OAUTH_DELETE_EXPIRED = config(
+        "OAUTH_DELETE_EXPIRED", default=OAUTH_DELETE_EXPIRED, formatter=bool
+    )
+
+##### ADVANCED_SECURITY_CONFIG #####
+ADVANCED_SECURITY_CONFIG = config(
+    "ADVANCED_SECURITY_CONFIG", default={}, formatter=json.loads
+)
+
+##### GOOGLE ANALYTICS IDS #####
+GOOGLE_ANALYTICS_ACCOUNT = config("GOOGLE_ANALYTICS_ACCOUNT", default=None)
+GOOGLE_ANALYTICS_TRACKING_ID = config("GOOGLE_ANALYTICS_TRACKING_ID", default=None)
+GOOGLE_ANALYTICS_LINKEDIN = config("GOOGLE_ANALYTICS_LINKEDIN", default=None)
+GOOGLE_SITE_VERIFICATION_ID = config("GOOGLE_SITE_VERIFICATION_ID", default=None)
+
+##### BRANCH.IO KEY #####
+BRANCH_IO_KEY = config("BRANCH_IO_KEY", default=None)
+
+##### OPTIMIZELY PROJECT ID #####
+OPTIMIZELY_PROJECT_ID = config("OPTIMIZELY_PROJECT_ID", default=OPTIMIZELY_PROJECT_ID)
+
+#### Course Registration Code length ####
+REGISTRATION_CODE_LENGTH = config("REGISTRATION_CODE_LENGTH", default=8, formatter=int)
+
+# REGISTRATION CODES DISPLAY INFORMATION
+INVOICE_CORP_ADDRESS = config("INVOICE_CORP_ADDRESS", default=INVOICE_CORP_ADDRESS)
+INVOICE_PAYMENT_INSTRUCTIONS = config(
+    "INVOICE_PAYMENT_INSTRUCTIONS", default=INVOICE_PAYMENT_INSTRUCTIONS
+)
+
+# Which access.py permission names to check;
+# We default this to the legacy permission 'see_exists'.
+COURSE_CATALOG_VISIBILITY_PERMISSION = config(
+    "COURSE_CATALOG_VISIBILITY_PERMISSION", default=COURSE_CATALOG_VISIBILITY_PERMISSION
+)
+COURSE_ABOUT_VISIBILITY_PERMISSION = config(
+    "COURSE_ABOUT_VISIBILITY_PERMISSION", default=COURSE_ABOUT_VISIBILITY_PERMISSION
+)
+
+DEFAULT_COURSE_VISIBILITY_IN_CATALOG = config(
+    "DEFAULT_COURSE_VISIBILITY_IN_CATALOG", default=DEFAULT_COURSE_VISIBILITY_IN_CATALOG
+)
+
+DEFAULT_MOBILE_AVAILABLE = config(
+    "DEFAULT_MOBILE_AVAILABLE", default=DEFAULT_MOBILE_AVAILABLE, formatter=bool
+)
+
+# Enrollment API Cache Timeout
+ENROLLMENT_COURSE_DETAILS_CACHE_TIMEOUT = config(
+    "ENROLLMENT_COURSE_DETAILS_CACHE_TIMEOUT", default=60, formatter=int
+)
+
+# PDF RECEIPT/INVOICE OVERRIDES
+PDF_RECEIPT_TAX_ID = config("PDF_RECEIPT_TAX_ID", default=PDF_RECEIPT_TAX_ID)
+PDF_RECEIPT_FOOTER_TEXT = config(
+    "PDF_RECEIPT_FOOTER_TEXT", default=PDF_RECEIPT_FOOTER_TEXT
+)
+PDF_RECEIPT_DISCLAIMER_TEXT = config(
+    "PDF_RECEIPT_DISCLAIMER_TEXT", default=PDF_RECEIPT_DISCLAIMER_TEXT
+)
+PDF_RECEIPT_BILLING_ADDRESS = config(
+    "PDF_RECEIPT_BILLING_ADDRESS", default=PDF_RECEIPT_BILLING_ADDRESS
+)
+PDF_RECEIPT_TERMS_AND_CONDITIONS = config(
+    "PDF_RECEIPT_TERMS_AND_CONDITIONS", default=PDF_RECEIPT_TERMS_AND_CONDITIONS
+)
+PDF_RECEIPT_TAX_ID_LABEL = config(
+    "PDF_RECEIPT_TAX_ID_LABEL", default=PDF_RECEIPT_TAX_ID_LABEL
+)
+PDF_RECEIPT_LOGO_PATH = config("PDF_RECEIPT_LOGO_PATH", default=PDF_RECEIPT_LOGO_PATH)
+PDF_RECEIPT_COBRAND_LOGO_PATH = config(
+    "PDF_RECEIPT_COBRAND_LOGO_PATH", default=PDF_RECEIPT_COBRAND_LOGO_PATH
+)
+PDF_RECEIPT_LOGO_HEIGHT_MM = config(
+    "PDF_RECEIPT_LOGO_HEIGHT_MM", default=PDF_RECEIPT_LOGO_HEIGHT_MM, formatter=int
+)
+PDF_RECEIPT_COBRAND_LOGO_HEIGHT_MM = config(
+    "PDF_RECEIPT_COBRAND_LOGO_HEIGHT_MM",
+    default=PDF_RECEIPT_COBRAND_LOGO_HEIGHT_MM,
+    formatter=int,
+)
+
+if (
+    FEATURES.get("ENABLE_COURSEWARE_SEARCH")
+    or FEATURES.get("ENABLE_DASHBOARD_SEARCH")
+    or FEATURES.get("ENABLE_COURSE_DISCOVERY")
+    or FEATURES.get("ENABLE_TEAMS")
+):
+    # Use ElasticSearch as the search engine herein
+    SEARCH_ENGINE = "search.elastic.ElasticSearchEngine"
+
+ELASTIC_SEARCH_CONFIG = config(
+    "ELASTIC_SEARCH_CONFIG", default=[{}], formatter=json.loads
+)
+
+# Facebook app
+FACEBOOK_API_VERSION = config("FACEBOOK_API_VERSION", default=None)
+FACEBOOK_APP_SECRET = config(
+    "FACEBOOK_APP_SECRET", default="ThisIsAnExampleKeyForDevPurposeOnly"
+)
+FACEBOOK_APP_ID = config("FACEBOOK_APP_ID", default=None)
+
+XBLOCK_SETTINGS = config("XBLOCK_SETTINGS", default={}, formatter=json.loads)
+XBLOCK_SETTINGS.setdefault("VideoDescriptor", {})["licensing_enabled"] = FEATURES.get(
+    "LICENSING", False
+)
+XBLOCK_SETTINGS.setdefault("VideoModule", {})["YOUTUBE_API_KEY"] = config(
+    "YOUTUBE_API_KEY", default=YOUTUBE_API_KEY
+)
+
+##### VIDEO IMAGE STORAGE #####
+VIDEO_IMAGE_SETTINGS = config(
+    "VIDEO_IMAGE_SETTINGS", default=VIDEO_IMAGE_SETTINGS, formatter=json.loads
+)
+
+##### VIDEO TRANSCRIPTS STORAGE #####
+VIDEO_TRANSCRIPTS_SETTINGS = config(
+    "VIDEO_TRANSCRIPTS_SETTINGS",
+    default=VIDEO_TRANSCRIPTS_SETTINGS,
+    formatter=json.loads,
+)
+
+##### ECOMMERCE API CONFIGURATION SETTINGS #####
+ECOMMERCE_PUBLIC_URL_ROOT = config(
+    "ECOMMERCE_PUBLIC_URL_ROOT", default=ECOMMERCE_PUBLIC_URL_ROOT
+)
+ECOMMERCE_API_URL = config("ECOMMERCE_API_URL", default=ECOMMERCE_API_URL)
+ECOMMERCE_API_TIMEOUT = config(
+    "ECOMMERCE_API_TIMEOUT", default=ECOMMERCE_API_TIMEOUT, formatter=int
+)
+
+COURSE_CATALOG_API_URL = config(
+    "COURSE_CATALOG_API_URL", default=COURSE_CATALOG_API_URL
+)
+
+ECOMMERCE_SERVICE_WORKER_USERNAME = config(
+    "ECOMMERCE_SERVICE_WORKER_USERNAME", default=ECOMMERCE_SERVICE_WORKER_USERNAME
+)
+
+##### Custom Courses for EdX #####
+if FEATURES.get("CUSTOM_COURSES_EDX"):
+    INSTALLED_APPS += [
+        "lms.djangoapps.ccx",
+        "openedx.core.djangoapps.ccxcon.apps.CCXConnectorConfig",
+    ]
+    MODULESTORE_FIELD_OVERRIDE_PROVIDERS += (
+        "lms.djangoapps.ccx.overrides.CustomCoursesForEdxOverrideProvider",
+    )
+CCX_MAX_STUDENTS_ALLOWED = config(
+    "CCX_MAX_STUDENTS_ALLOWED", default=CCX_MAX_STUDENTS_ALLOWED, formatter=int
+)
+
+##### Individual Due Date Extensions #####
+if FEATURES.get("INDIVIDUAL_DUE_DATES"):
+    FIELD_OVERRIDE_PROVIDERS += (
+        "courseware.student_field_overrides.IndividualStudentOverrideProvider",
+    )
+
+##### Self-Paced Course Due Dates #####
+XBLOCK_FIELD_DATA_WRAPPERS += (
+    "lms.djangoapps.courseware.field_overrides:OverrideModulestoreFieldData.wrap",
+)
+
+MODULESTORE_FIELD_OVERRIDE_PROVIDERS += (
+    "courseware.self_paced_overrides.SelfPacedDateOverrideProvider",
+)
+
+# PROFILE IMAGE CONFIG
+PROFILE_IMAGE_BACKEND = config("PROFILE_IMAGE_BACKEND", default=PROFILE_IMAGE_BACKEND)
+PROFILE_IMAGE_SECRET_KEY = config(
+    "PROFILE_IMAGE_SECRET_KEY", default=PROFILE_IMAGE_SECRET_KEY
+)
+PROFILE_IMAGE_MAX_BYTES = config(
+    "PROFILE_IMAGE_MAX_BYTES", default=PROFILE_IMAGE_MAX_BYTES, formatter=int
+)
+PROFILE_IMAGE_MIN_BYTES = config(
+    "PROFILE_IMAGE_MIN_BYTES", default=PROFILE_IMAGE_MIN_BYTES, formatter=int
+)
+PROFILE_IMAGE_DEFAULT_FILENAME = "images/profiles/default"
+PROFILE_IMAGE_SIZES_MAP = config(
+    "PROFILE_IMAGE_SIZES_MAP", default=PROFILE_IMAGE_SIZES_MAP, formatter=json.loads
+)
+
+# EdxNotes config
+
+EDXNOTES_PUBLIC_API = config("EDXNOTES_PUBLIC_API", default=EDXNOTES_PUBLIC_API)
+EDXNOTES_INTERNAL_API = config("EDXNOTES_INTERNAL_API", default=EDXNOTES_INTERNAL_API)
+
+EDXNOTES_CONNECT_TIMEOUT = config(
+    "EDXNOTES_CONNECT_TIMEOUT", default=EDXNOTES_CONNECT_TIMEOUT, formatter=int
+)
+EDXNOTES_READ_TIMEOUT = config(
+    "EDXNOTES_READ_TIMEOUT", default=EDXNOTES_READ_TIMEOUT, formatter=int
+)
+
+##### Credit Provider Integration #####
+
+CREDIT_PROVIDER_SECRET_KEYS = config(
+    "CREDIT_PROVIDER_SECRET_KEYS", default={}, formatter=json.loads
+)
+
+##################### LTI Provider #####################
+if FEATURES.get("ENABLE_LTI_PROVIDER"):
+    INSTALLED_APPS.append("lti_provider.apps.LtiProviderConfig")
+
+LTI_USER_EMAIL_DOMAIN = config("LTI_USER_EMAIL_DOMAIN", default="lti.example.com")
+
+# For more info on this, see the notes in common.py
+LTI_AGGREGATE_SCORE_PASSBACK_DELAY = config(
+    "LTI_AGGREGATE_SCORE_PASSBACK_DELAY",
+    default=LTI_AGGREGATE_SCORE_PASSBACK_DELAY,
+    formatter=int,
+)
+
+################ CONFIGURABLE LTI CONSUMER ###############
+
+# Add just the standard LTI consumer by default, forcing it to open in a new window and ask
+# the user before sending email and username:
+LTI_XBLOCK_CONFIGURATIONS = config(
+    "LTI_XBLOCK_CONFIGURATIONS",
+    default=[
+        {
+            "display_name": "LTI consumer",
+            "pattern": ".*",
+            "hidden_fields": [
+                "ask_to_send_email",
+                "ask_to_send_username",
+                "new_window",
+            ],
+            "defaults": {
+                "ask_to_send_email": True,
+                "ask_to_send_username": True,
+                "launch_target": "new_window",
+            },
+        }
+    ],
+    formatter=json.loads,
+)
+LTI_XBLOCK_SECRETS = config("LTI_XBLOCK_SECRETS", default={}, formatter=json.loads)
+
+##################### Credit Provider help link ####################
+CREDIT_HELP_LINK_URL = config("CREDIT_HELP_LINK_URL", default=CREDIT_HELP_LINK_URL)
+
+#### JWT configuration ####
+JWT_AUTH.update(config("JWT_AUTH", default={}, formatter=json.loads))
+
+################# MICROSITE ####################
+MICROSITE_CONFIGURATION = config(
+    "MICROSITE_CONFIGURATION", default={}, formatter=json.loads
+)
+MICROSITE_ROOT_DIR = path(config("MICROSITE_ROOT_DIR", default=""))
+# this setting specify which backend to be used when pulling microsite specific configuration
+MICROSITE_BACKEND = config("MICROSITE_BACKEND", default=MICROSITE_BACKEND)
+# this setting specify which backend to be used when loading microsite specific templates
+MICROSITE_TEMPLATE_BACKEND = config(
+    "MICROSITE_TEMPLATE_BACKEND", default=MICROSITE_TEMPLATE_BACKEND
+)
+# TTL for microsite database template cache
+MICROSITE_DATABASE_TEMPLATE_CACHE_TTL = config(
+    "MICROSITE_DATABASE_TEMPLATE_CACHE_TTL",
+    default=MICROSITE_DATABASE_TEMPLATE_CACHE_TTL,
+    formatter=int,
+)
+
+# Offset for pk of courseware.StudentModuleHistoryExtended
+STUDENTMODULEHISTORYEXTENDED_OFFSET = config(
+    "STUDENTMODULEHISTORYEXTENDED_OFFSET",
+    default=STUDENTMODULEHISTORYEXTENDED_OFFSET,
+    formatter=int,
+)
+
+# Cutoff date for granting audit certificates
+AUDIT_CERT_CUTOFF_DATE = config(
+    "AUDIT_CERT_CUTOFF_DATE", default=None, formatter=dateutil.parser.parse
+)
+
+################################ Settings for Credentials Service ################################
+
+CREDENTIALS_GENERATION_ROUTING_KEY = config(
+    "CREDENTIALS_GENERATION_ROUTING_KEY", default=HIGH_PRIORITY_QUEUE
+)
+
+# The extended StudentModule history table
+if FEATURES.get("ENABLE_CSMH_EXTENDED"):
+    INSTALLED_APPS.append("coursewarehistoryextended")
+
+API_ACCESS_MANAGER_EMAIL = config(
+    "API_ACCESS_MANAGER_EMAIL", default=API_ACCESS_MANAGER_EMAIL
+)
+API_ACCESS_FROM_EMAIL = config("API_ACCESS_FROM_EMAIL", default=API_ACCESS_FROM_EMAIL)
+
+# Mobile App Version Upgrade config
+APP_UPGRADE_CACHE_TIMEOUT = config(
+    "APP_UPGRADE_CACHE_TIMEOUT", default=APP_UPGRADE_CACHE_TIMEOUT, formatter=int
+)
+
+AFFILIATE_COOKIE_NAME = config("AFFILIATE_COOKIE_NAME", default=AFFILIATE_COOKIE_NAME)
+
+############## Settings for LMS Context Sensitive Help ##############
+
+HELP_TOKENS_BOOKS = config(
+    "HELP_TOKENS_BOOKS", default=HELP_TOKENS_BOOKS, formatter=json.loads
+)
+
+
+############## OPEN EDX ENTERPRISE SERVICE CONFIGURATION ######################
+# The Open edX Enterprise service is currently hosted via the LMS container/process.
+# However, for all intents and purposes this service is treated as a standalone IDA.
+# These configuration settings are specific to the Enterprise service and you should
+# not find references to them within the edx-platform project.
+
+# Publicly-accessible enrollment URL, for use on the client side.
+ENTERPRISE_PUBLIC_ENROLLMENT_API_URL = config(
+    "ENTERPRISE_PUBLIC_ENROLLMENT_API_URL",
+    default=(LMS_ROOT_URL or "") + LMS_ENROLLMENT_API_PATH,
+)
+
+# Enrollment URL used on the server-side.
+ENTERPRISE_ENROLLMENT_API_URL = config(
+    "ENTERPRISE_ENROLLMENT_API_URL",
+    default=(LMS_INTERNAL_ROOT_URL or "") + LMS_ENROLLMENT_API_PATH,
+)
+
+# Enterprise logo image size limit in KB's
+ENTERPRISE_CUSTOMER_LOGO_IMAGE_SIZE = config(
+    "ENTERPRISE_CUSTOMER_LOGO_IMAGE_SIZE",
+    default=ENTERPRISE_CUSTOMER_LOGO_IMAGE_SIZE,
+    formatter=int,
+)
+
+# Course enrollment modes to be hidden in the Enterprise enrollment page
+# if the "Hide audit track" flag is enabled for an EnterpriseCustomer
+ENTERPRISE_COURSE_ENROLLMENT_AUDIT_MODES = config(
+    "ENTERPRISE_COURSE_ENROLLMENT_AUDIT_MODES",
+    default=ENTERPRISE_COURSE_ENROLLMENT_AUDIT_MODES,
+    formatter=json.loads,
+)
+
+# A support URL used on Enterprise landing pages for when a warning
+# message goes off.
+ENTERPRISE_SUPPORT_URL = config(
+    "ENTERPRISE_SUPPORT_URL", default=ENTERPRISE_SUPPORT_URL
+)
+
+# A shared secret to be used for encrypting passwords passed from the enterprise api
+# to the enteprise reporting script.
+ENTERPRISE_REPORTING_SECRET = config(
+    "ENTERPRISE_REPORTING_SECRET", default=ENTERPRISE_REPORTING_SECRET
+)
+
+# A default dictionary to be used for filtering out enterprise customer catalog.
+ENTERPRISE_CUSTOMER_CATALOG_DEFAULT_CONTENT_FILTER = config(
+    "ENTERPRISE_CUSTOMER_CATALOG_DEFAULT_CONTENT_FILTER",
+    default=ENTERPRISE_CUSTOMER_CATALOG_DEFAULT_CONTENT_FILTER,
+)
+
+############## ENTERPRISE SERVICE API CLIENT CONFIGURATION ######################
+# The LMS communicates with the Enterprise service via the EdxRestApiClient class
+# The below environmental settings are utilized by the LMS when interacting with
+# the service, and override the default parameters which are defined in common.py
+
+DEFAULT_ENTERPRISE_API_URL = None
+if LMS_INTERNAL_ROOT_URL is not None:
+    DEFAULT_ENTERPRISE_API_URL = LMS_INTERNAL_ROOT_URL + "/enterprise/api/v1/"
+ENTERPRISE_API_URL = config("ENTERPRISE_API_URL", default=DEFAULT_ENTERPRISE_API_URL)
+
+DEFAULT_ENTERPRISE_CONSENT_API_URL = None
+if LMS_INTERNAL_ROOT_URL is not None:
+    DEFAULT_ENTERPRISE_CONSENT_API_URL = LMS_INTERNAL_ROOT_URL + "/consent/api/v1/"
+ENTERPRISE_CONSENT_API_URL = config(
+    "ENTERPRISE_CONSENT_API_URL", default=DEFAULT_ENTERPRISE_CONSENT_API_URL
+)
+
+ENTERPRISE_SERVICE_WORKER_USERNAME = config(
+    "ENTERPRISE_SERVICE_WORKER_USERNAME", default=ENTERPRISE_SERVICE_WORKER_USERNAME
+)
+ENTERPRISE_API_CACHE_TIMEOUT = config(
+    "ENTERPRISE_API_CACHE_TIMEOUT", default=ENTERPRISE_API_CACHE_TIMEOUT, formatter=int
+)
+
+############## ENTERPRISE SERVICE LMS CONFIGURATION ##################################
+# The LMS has some features embedded that are related to the Enterprise service, but
+# which are not provided by the Enterprise service. These settings override the
+# base values for the parameters as defined in common.py
+
+ENTERPRISE_PLATFORM_WELCOME_TEMPLATE = config(
+    "ENTERPRISE_PLATFORM_WELCOME_TEMPLATE", default=ENTERPRISE_PLATFORM_WELCOME_TEMPLATE
+)
+ENTERPRISE_SPECIFIC_BRANDED_WELCOME_TEMPLATE = config(
+    "ENTERPRISE_SPECIFIC_BRANDED_WELCOME_TEMPLATE",
+    default=ENTERPRISE_SPECIFIC_BRANDED_WELCOME_TEMPLATE,
+)
+ENTERPRISE_TAGLINE = config("ENTERPRISE_TAGLINE", default=ENTERPRISE_TAGLINE)
+ENTERPRISE_EXCLUDED_REGISTRATION_FIELDS = set(
+    config(
+        "ENTERPRISE_EXCLUDED_REGISTRATION_FIELDS",
+        default=ENTERPRISE_EXCLUDED_REGISTRATION_FIELDS,
+        formatter=json.loads,
+    )
+)
+BASE_COOKIE_DOMAIN = config("BASE_COOKIE_DOMAIN", default=BASE_COOKIE_DOMAIN)
+
+############## CATALOG/DISCOVERY SERVICE API CLIENT CONFIGURATION ######################
+# The LMS communicates with the Catalog service via the EdxRestApiClient class
+# The below environmental settings are utilized by the LMS when interacting with
+# the service, and override the default parameters which are defined in common.py
+
+COURSES_API_CACHE_TIMEOUT = config(
+    "COURSES_API_CACHE_TIMEOUT", default=COURSES_API_CACHE_TIMEOUT, formatter=int
+)
+
+# Add an ICP license for serving content in China if your organization is registered to do so
+ICP_LICENSE = config("ICP_LICENSE", default=None, formatter=bool)
+
+############## Settings for CourseGraph ############################
+COURSEGRAPH_JOB_QUEUE = config("COURSEGRAPH_JOB_QUEUE", default=LOW_PRIORITY_QUEUE)
+
+########################## Parental controls config  #######################
+
+# The age at which a learner no longer requires parental consent, or None
+# if parental consent is never required.
+PARENTAL_CONSENT_AGE_LIMIT = config(
+    "PARENTAL_CONSENT_AGE_LIMIT", default=PARENTAL_CONSENT_AGE_LIMIT, formatter=int
+)
+
+# Do NOT calculate this dynamically at startup with git because it's *slow*.
+EDX_PLATFORM_REVISION = config("EDX_PLATFORM_REVISION", default=EDX_PLATFORM_REVISION)
+
+########################## Extra middleware classes  #######################
+
+# Allow extra middleware classes to be added to the app through configuration.
+MIDDLEWARE_CLASSES.extend(
+    config("EXTRA_MIDDLEWARE_CLASSES", default=[], formatter=json.loads)
+)
+
+########################## Settings for Completion API #####################
+
+# Once a user has watched this percentage of a video, mark it as complete:
+# (0.0 = 0%, 1.0 = 100%)
+COMPLETION_VIDEO_COMPLETE_PERCENTAGE = config(
+    "COMPLETION_VIDEO_COMPLETE_PERCENTAGE",
+    default=COMPLETION_VIDEO_COMPLETE_PERCENTAGE,
+    formatter=float,
+)
+# The time a block needs to be viewed to be considered complete, in milliseconds.
+COMPLETION_BY_VIEWING_DELAY_MS = config(
+    "COMPLETION_BY_VIEWING_DELAY_MS",
+    default=COMPLETION_BY_VIEWING_DELAY_MS,
+    formatter=int,
+)
+
+############### Settings for django-fernet-fields ##################
+FERNET_KEYS = config("FERNET_KEYS", default=FERNET_KEYS, formatter=json.loads)
+
+################# Settings for the maintenance banner #################
+MAINTENANCE_BANNER_TEXT = config("MAINTENANCE_BANNER_TEXT", default=None)
+
+############### Settings for Retirement #####################
+RETIRED_USERNAME_PREFIX = config(
+    "RETIRED_USERNAME_PREFIX", default=RETIRED_USERNAME_PREFIX
+)
+RETIRED_EMAIL_PREFIX = config("RETIRED_EMAIL_PREFIX", default=RETIRED_EMAIL_PREFIX)
+RETIRED_EMAIL_DOMAIN = config("RETIRED_EMAIL_DOMAIN", default=RETIRED_EMAIL_DOMAIN)
+RETIREMENT_SERVICE_WORKER_USERNAME = config(
+    "RETIREMENT_SERVICE_WORKER_USERNAME", default=RETIREMENT_SERVICE_WORKER_USERNAME
+)
+RETIREMENT_STATES = config(
+    "RETIREMENT_STATES", default=RETIREMENT_STATES, formatter=json.loads
+)
+
+############################### Plugin Settings ###############################
+
+from openedx.core.djangoapps.plugins import (
+    plugin_settings,
+    constants as plugin_constants,
+)
+
+plugin_settings.add_plugins(
+    __name__, plugin_constants.ProjectType.LMS, plugin_constants.SettingsType.AWS
+)
+
+########################## Derive Any Derived Settings  #######################
+
+derive_settings(__name__)

--- a/releases/ironwood/2/oee/config/lms/docker_run_staging.py
+++ b/releases/ironwood/2/oee/config/lms/docker_run_staging.py
@@ -1,0 +1,14 @@
+# This file includes overrides to build the `staging` environment for the LMS starting from the
+# settings of the `production` environment
+
+from docker_run_production import *
+from .utils import Configuration
+
+# Load custom configuration parameters from yaml files
+config = Configuration(os.path.dirname(__file__))
+
+LOGGING["handlers"]["sentry"]["environment"] = "staging"
+
+EMAIL_BACKEND = config(
+    "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"
+)

--- a/releases/ironwood/2/oee/config/lms/root_urls.py
+++ b/releases/ironwood/2/oee/config/lms/root_urls.py
@@ -1,0 +1,16 @@
+"""
+OEE urls
+We define this file as root url (ROOT_URLCONF) to override and extend
+edx-platform's LMS routes
+"""
+from __future__ import absolute_import, unicode_literals
+
+from django.conf.urls import include, url
+
+from lms.urls import urlpatterns  # pylint: disable=import-error
+
+
+urlpatterns += [
+    # Fonzie API urls
+    url(r"^api/", include("fonzie.urls", namespace="fonzie")),
+]

--- a/releases/ironwood/2/oee/config/lms/storage.py
+++ b/releases/ironwood/2/oee/config/lms/storage.py
@@ -1,0 +1,18 @@
+"""Django static file storage backend for OpenEdX."""
+from django.conf import settings
+
+from openedx.core.storage import ProductionStorage
+
+
+class CDNProductionStorage(ProductionStorage):
+    """Open edX production static files storage backend that can be placed behing a CDN."""
+
+    def url(self, name, force=False):
+        """Prepend static files path by the CDN base url when configured in settings."""
+        url = super(CDNProductionStorage, self).url(name, force=force)
+
+        cdn_base_url = getattr(settings, "CDN_BASE_URL", None)
+        if cdn_base_url:
+            url = "{:s}{:s}".format(cdn_base_url, url)
+
+        return url

--- a/releases/ironwood/2/oee/config/lms/utils.py
+++ b/releases/ironwood/2/oee/config/lms/utils.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+
+import yaml
+import os
+
+from django.core.exceptions import ImproperlyConfigured
+
+
+class Configuration(dict):
+    """
+    Try getting a setting from the settings.yml or secrets.yml files placed in
+    the directory passed when initializing the configuration instance.
+    """
+
+    def __init__(self, dir=None, *args, **kwargs):
+        """
+        Initialize with the path to the directory in which the configuration is
+        to be found.
+        """
+        super(Configuration, self).__init__(*args, **kwargs)
+
+        if dir is None:
+            self.settings = {}
+
+        else:
+            # Load the content of a `settings.yml` file placed in the current
+            # directory if any. This file is where customizable settings are stored
+            # for a given environment.
+            try:
+                with open(os.path.join(dir, "settings.yml")) as f:
+                    settings = yaml.load(f.read()) or {}
+            except IOError:
+                settings = {}
+
+            # Load the content of a `secrets.yml` file placed in the current
+            # directory if any. This file is where sensitive credentials are stored
+            # for a given environment.
+            try:
+                with open(os.path.join(dir, "secrets.yml")) as f:
+                    credentials = yaml.load(f.read()) or {}
+            except IOError:
+                credentials = {}
+
+            settings.update(credentials)
+            self.settings = settings
+
+    def __call__(self, var_name, formatter=str, *args, **kwargs):
+        """
+        The config returns in order of priority:
+
+            - the value set in the secrets.yml file,
+            - the value set in the settings.yml file,
+            - the value set as environment variable
+            - the value passed as default.
+
+        If the value is passed as a string, a type is forced via the function passed in
+        the "formatter" kwarg.
+
+        Raise an "ImproperlyConfigured" error if the name is not found, except
+        if the `default` key is given in kwargs (using kwargs allows to pass a
+        default to None, which is different from not passing any default):
+
+            $ config = Configuration('path/to/config/directory')
+            $ config('foo')  # raise ImproperlyConfigured error if `foo` is not defined
+            $ config('foo', default='bar')  # return 'bar' if `foo` is not defined
+            $ config('foo', default=None)  # return `None` if `foo` is not defined
+        """
+        try:
+            value = self.settings[var_name]
+        except KeyError:
+            try:
+                value = formatter(os.environ[var_name])
+            except KeyError:
+                if "default" in kwargs:
+                    value = kwargs["default"]
+                else:
+                    raise ImproperlyConfigured(
+                        'Please set the "{:s}" variable in a settings.yml file, a secrets.yml '
+                        "file or an environment variable.".format(var_name)
+                    )
+        # If a formatter is specified, force the value but only if it was passed as a string
+        if isinstance(value, basestring):
+            value = formatter(value.encode("utf-8"))
+
+        return value
+
+    def get(self, name, *args, **kwargs):
+        """
+        edX is loading the content of 2 json files to settings.ENV_TOKEN and settings.AUTH_TOKEN
+        They have started calling these attributes anywhere in the code base, so we must make
+        sure that the following call works (and the same for AUTH_TOKEN):
+
+            settings.ENV_TOKEN.get('ANY_SETTING_NAME')
+
+        That's what this method will do after we add this to our settings:
+           ```
+           config = Configuration('path/to/my/settings/directory.yml')
+           ENV_TOKEN = config
+           AUTH_TOKEN = config
+           ```
+        """
+        try:
+            default = args[0]
+        except IndexError:
+            # As a first approach, all defaults that are not provided by Open edX are set to None.
+            # If this creates a problem, we can either:
+            #    - make sure we provide a value for this setting in our yaml files,
+            #    - make a PR to Open edX to provide a better default for this setting.
+            default = None
+        return self(name, default=default)

--- a/releases/ironwood/2/oee/entrypoint.sh
+++ b/releases/ironwood/2/oee/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# Development entrypoint
+#
+
+# Activate user's virtualenv
+source /edx/app/edxapp/venv/bin/activate
+
+# Override default lms root_urls
+ln -sf /config/lms/root_urls.py /edx/app/edxapp/edx-platform/lms/
+
+exec "$@"

--- a/releases/ironwood/2/oee/ironwood.2-oee.patch
+++ b/releases/ironwood/2/oee/ironwood.2-oee.patch
@@ -1,0 +1,38 @@
+diff --git a/cms/djangoapps/contentstore/views/component.py b/cms/djangoapps/contentstore/views/component.py
+index f65f281151..af47c239de 100644
+--- a/cms/djangoapps/contentstore/views/component.py
++++ b/cms/djangoapps/contentstore/views/component.py
+@@ -27,6 +27,15 @@ from xblock_django.models import XBlockStudioConfigurationFlag
+ from xmodule.modulestore.django import modulestore
+ from xmodule.modulestore.exceptions import ItemNotFoundError
+ 
++# Try to import the configurable LTI consumer xblock that overrides Open edX
++# default LTI xblock. It has no effect if this alternative xblock is not
++# installed.
++try:
++    from configurable_lti_consumer import add_dynamic_components
++except ImportError:
++    add_dynamic_components = None
++
++
+ __all__ = [
+     'container_handler',
+     'component_handler'
+@@ -359,6 +368,17 @@ def get_component_templates(courselike, library=False):
+         "support_legend": create_support_legend_dict()
+     }
+     advanced_component_types = _advanced_component_types(allow_unsupported)
++
++    # Read LTI_XBLOCK_CONFIGURATIONS setting to add links to the `Advanced` component button
++    if add_dynamic_components:
++        add_dynamic_components(
++            getattr(settings, "LTI_XBLOCK_CONFIGURATIONS"),
++            advanced_component_templates,
++            categories,
++            create_template_dict,
++            course_advanced_keys
++        )
++
+     # Set component types according to course policy file
+     if isinstance(course_advanced_keys, list):
+         for category in course_advanced_keys:

--- a/releases/ironwood/2/oee/requirements.txt
+++ b/releases/ironwood/2/oee/requirements.txt
@@ -8,6 +8,9 @@ configurable_lti_consumer-xblock==1.2.3
 
 # ==== third-party apps ====
 celery-redis-sentinel==0.3.0
+# django-django-redis-sentinel-redux is not compatible with
+# django-redis > 4.5.0
+django-redis==4.5.0
 django-redis-sentinel-redux==0.2.0
 django-redis-sessions==0.6.1
 raven==6.9.0

--- a/releases/ironwood/2/oee/requirements.txt
+++ b/releases/ironwood/2/oee/requirements.txt
@@ -1,0 +1,15 @@
+# Open edX extended: dependencies
+
+# ==== core ====
+fonzie==0.2.1
+
+# ==== xblocks ====
+configurable_lti_consumer-xblock==1.2.3
+
+# ==== third-party apps ====
+celery-redis-sentinel==0.3.0
+django-redis-sentinel-redux==0.2.0
+django-redis-sessions==0.6.1
+raven==6.9.0
+redis==2.10.6
+gunicorn==19.9.0


### PR DESCRIPTION
## Purpose

This PR will add a new flavor based on the ironwood 2 release from edx.
The work here is vastly inspired from the current work done in master/bare flavor at the moment of this commit.

Compare to hawthorn, not many settings have changed so not a lot of things should differ.

Release Note from edx: <https://edx.readthedocs.io/projects/open-edx-release-notes/en/latest/ironwood.html>

New settings from hawthorn to ironwood:
```python
# List of logout URIs for each IDA that the learner should be logged out of when they logout of
# Studio. Only applies to IDA for which the social auth flow uses DOT (Django OAuth Toolkit).
IDA_LOGOUT_URI_LIST = ENV_TOKENS.get('IDA_LOGOUT_URI_LIST', [])

########## Settings for video transcript migration tasks ############
VIDEO_TRANSCRIPT_MIGRATIONS_JOB_QUEUE = ENV_TOKENS.get('VIDEO_TRANSCRIPT_MIGRATIONS_JOB_QUEUE', DEFAULT_PRIORITY_QUEUE)

########## Settings youtube thumbnails scraper tasks ############
SCRAPE_YOUTUBE_THUMBNAILS_JOB_QUEUE = ENV_TOKENS.get('SCRAPE_YOUTUBE_THUMBNAILS_JOB_QUEUE', DEFAULT_PRIORITY_QUEUE)

# A default dictionary to be used for filtering out enterprise customer catalog.
ENTERPRISE_CUSTOMER_CATALOG_DEFAULT_CONTENT_FILTER = ENV_TOKENS.get(
    'ENTERPRISE_CUSTOMER_CATALOG_DEFAULT_CONTENT_FILTER',
    ENTERPRISE_CUSTOMER_CATALOG_DEFAULT_CONTENT_FILTER
)

RETIRED_USER_SALTS = ENV_TOKENS.get('RETIRED_USER_SALTS', RETIRED_USER_SALTS)

COURSE_ENROLLMENT_MODES = ENV_TOKENS.get('COURSE_ENROLLMENT_MODES', COURSE_ENROLLMENT_MODES)
```
