### PR TITLE
➕(dogwood/3/fun) add gelf support for logging

### DIFF
--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-1.14.0] - 2020-09-07
+
 ### Added
 
 - Add Gelf support for logging
@@ -302,7 +304,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.13.2...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.14.0...HEAD
+[dogwood.3-fun-1.14.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.13.2...dogwood.3-fun-1.14.0
 [dogwood.3-fun-1.13.2]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.13.1...dogwood.3-fun-1.13.2
 [dogwood.3-fun-1.13.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.13.0...dogwood.3-fun-1.13.1
 [dogwood.3-fun-1.13.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.12.1...dogwood.3-fun-1.13.0

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Added
+
+- Add Gelf support for logging
+
 ## [dogwood.3-fun-1.13.2] - 2020-09-01
 
 ### Fixed

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -23,6 +23,8 @@ celery-redis-sentinel==0.3.0
 django-redis==4.5.0
 django-redis-sentinel-redux==0.2.0
 django-redis-sessions==0.6.1
+# Add Gelf support for logging
+djehouty==0.1.5
 raven==6.9.0
 redis==2.10.6
 # Upgrade requests and urllib3 to prevent SSL certificate validation failure


### PR DESCRIPTION
## Purpose

On fun-mooc.fr, we want to use the gelf format to log events.
We need the djehouty library installed on this image.

## Proposal

- [x] Add djehouty dependency
- [x] bump to dogwood.3-fun-1.14.0
