### PR TITLE
🔨(project) warn user when running make bootstrap from root user

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,15 +159,33 @@ jobs:
   #
   # Note that the job name should match the EDX_RELEASE value
 
-  # No changes detected for dogwood.3-bare
-  # No changes detected for dogwood.3-fun
-  # No changes detected for eucalyptus.3-bare
-  # No changes detected for eucalyptus.3-wb
-  # No changes detected for hawthorn.1-bare
-  # No changes detected for hawthorn.1-oee
-  # No changes detected for ironwood.2-bare
-  # No changes detected for ironwood.2-oee
-  # No changes detected for master.0-bare
+  # Run jobs for the dogwood.3-bare release
+  dogwood.3-bare:
+    <<: [*defaults, *build_steps]
+  # Run jobs for the dogwood.3-fun release
+  dogwood.3-fun:
+    <<: [*defaults, *build_steps]
+  # Run jobs for the eucalyptus.3-bare release
+  eucalyptus.3-bare:
+    <<: [*defaults, *build_steps]
+  # Run jobs for the eucalyptus.3-wb release
+  eucalyptus.3-wb:
+    <<: [*defaults, *build_steps]
+  # Run jobs for the hawthorn.1-bare release
+  hawthorn.1-bare:
+    <<: [*defaults, *build_steps]
+  # Run jobs for the hawthorn.1-oee release
+  hawthorn.1-oee:
+    <<: [*defaults, *build_steps]
+  # Run jobs for the ironwood.2-bare release
+  ironwood.2-bare:
+    <<: [*defaults, *build_steps]
+  # Run jobs for the ironwood.2-oee release
+  ironwood.2-oee:
+    <<: [*defaults, *build_steps]
+  # Run jobs for the master.0-bare release
+  master.0-bare:
+    <<: [*defaults, *build_steps]
 
   # Hub job
   hub:
@@ -256,15 +274,69 @@ workflows:
 
       # Build jobs
 
-      # No changes detected so no job to run for dogwood.3-bare
-      # No changes detected so no job to run for dogwood.3-fun
-      # No changes detected so no job to run for eucalyptus.3-bare
-      # No changes detected so no job to run for eucalyptus.3-wb
-      # No changes detected so no job to run for hawthorn.1-bare
-      # No changes detected so no job to run for hawthorn.1-oee
-      # No changes detected so no job to run for ironwood.2-bare
-      # No changes detected so no job to run for ironwood.2-oee
-      # No changes detected so no job to run for master.0-bare
+      # Run jobs for the dogwood.3-bare release
+      - dogwood.3-bare:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
+      # Run jobs for the dogwood.3-fun release
+      - dogwood.3-fun:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
+      # Run jobs for the eucalyptus.3-bare release
+      - eucalyptus.3-bare:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
+      # Run jobs for the eucalyptus.3-wb release
+      - eucalyptus.3-wb:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
+      # Run jobs for the hawthorn.1-bare release
+      - hawthorn.1-bare:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
+      # Run jobs for the hawthorn.1-oee release
+      - hawthorn.1-oee:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
+      # Run jobs for the ironwood.2-bare release
+      - ironwood.2-bare:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
+      # Run jobs for the ironwood.2-oee release
+      - ironwood.2-oee:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
+      # Run jobs for the master.0-bare release
+      - master.0-bare:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
 
       # We are pushing to Docker only images that are the result of a tag respecting the pattern:
       #    **{branch-name}-x.y.z**

--- a/releases/dogwood/3/bare/Dockerfile
+++ b/releases/dogwood/3/bare/Dockerfile
@@ -222,13 +222,14 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN groupadd --gid ${DOCKER_GID} edx || \
-      echo "Group with ID ${DOCKER_GID} already exists." && \
+    echo "Group with ID ${DOCKER_GID} already exists." && \
     useradd \
       --create-home \
       --home-dir /home/edx \
       --uid ${DOCKER_UID} \
       --gid ${DOCKER_GID} \
-      edx && \
+      edx || \
+    echo "Skip user creation (user with ID ${DOCKER_UID} already exists?)" && \
     git config --global user.name edx && \
     git config --global user.email edx@example.com
 

--- a/releases/dogwood/3/fun/Dockerfile
+++ b/releases/dogwood/3/fun/Dockerfile
@@ -214,13 +214,14 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN groupadd --gid ${DOCKER_GID} edx || \
-      echo "Group with ID ${DOCKER_GID} already exists." && \
+    echo "Group with ID ${DOCKER_GID} already exists." && \
     useradd \
       --create-home \
       --home-dir /home/edx \
       --uid ${DOCKER_UID} \
       --gid ${DOCKER_GID} \
-      edx && \
+      edx || \
+    echo "Skip user creation (user with ID ${DOCKER_UID} already exists?)" && \
     git config --global user.name edx && \
     git config --global user.email edx@example.com
 

--- a/releases/eucalyptus/3/bare/Dockerfile
+++ b/releases/eucalyptus/3/bare/Dockerfile
@@ -192,13 +192,14 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN groupadd --gid ${DOCKER_GID} edx || \
-      echo "Group with ID ${DOCKER_GID} already exists." && \
+    echo "Group with ID ${DOCKER_GID} already exists." && \
     useradd \
       --create-home \
       --home-dir /home/edx \
       --uid ${DOCKER_UID} \
       --gid ${DOCKER_GID} \
-      edx
+      edx || \
+    echo "Skip user creation (user with ID ${DOCKER_UID} already exists?)"
 
 # To prevent permission issues related to the non-priviledged user running in
 # development, we will install development dependencies in a python virtual

--- a/releases/eucalyptus/3/wb/Dockerfile
+++ b/releases/eucalyptus/3/wb/Dockerfile
@@ -194,13 +194,14 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN groupadd --gid ${DOCKER_GID} edx || \
-      echo "Group with ID ${DOCKER_GID} already exists." && \
+    echo "Group with ID ${DOCKER_GID} already exists." && \
     useradd \
       --create-home \
       --home-dir /home/edx \
       --uid ${DOCKER_UID} \
       --gid ${DOCKER_GID} \
-      edx
+      edx || \
+    echo "Skip user creation (user with ID ${DOCKER_UID} already exists?)"
 
 # To prevent permission issues related to the non-priviledged user running in
 # development, we will install development dependencies in a python virtual

--- a/releases/hawthorn/1/bare/Dockerfile
+++ b/releases/hawthorn/1/bare/Dockerfile
@@ -166,13 +166,14 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN groupadd --gid ${DOCKER_GID} edx || \
-      echo "Group with ID ${DOCKER_GID} already exists." && \
+    echo "Group with ID ${DOCKER_GID} already exists." && \
     useradd \
       --create-home \
       --home-dir /home/edx \
       --uid ${DOCKER_UID} \
       --gid ${DOCKER_GID} \
-      edx
+      edx || \
+    echo "Skip user creation (user with ID ${DOCKER_UID} already exists?)"
 
 # To prevent permission issues related to the non-priviledged user running in
 # development, we will install development dependencies in a python virtual

--- a/releases/hawthorn/1/oee/Dockerfile
+++ b/releases/hawthorn/1/oee/Dockerfile
@@ -173,13 +173,14 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN groupadd --gid ${DOCKER_GID} edx || \
-      echo "Group with ID ${DOCKER_GID} already exists." && \
+    echo "Group with ID ${DOCKER_GID} already exists." && \
     useradd \
       --create-home \
       --home-dir /home/edx \
       --uid ${DOCKER_UID} \
       --gid ${DOCKER_GID} \
-      edx
+      edx || \
+    echo "Skip user creation (user with ID ${DOCKER_UID} already exists?)"
 
 # To prevent permission issues related to the non-priviledged user running in
 # development, we will install development dependencies in a python virtual

--- a/releases/ironwood/2/bare/Dockerfile
+++ b/releases/ironwood/2/bare/Dockerfile
@@ -172,7 +172,8 @@ RUN groupadd --gid ${DOCKER_GID} edx || \
       --home-dir /home/edx \
       --uid ${DOCKER_UID} \
       --gid ${DOCKER_GID} \
-      edx
+      edx || \
+    echo "Skip user creation (user with ID ${DOCKER_UID} already exists?)"
 
 # To prevent permission issues related to the non-priviledged user running in
 # development, we will install development dependencies in a python virtual

--- a/releases/ironwood/2/oee/Dockerfile
+++ b/releases/ironwood/2/oee/Dockerfile
@@ -179,7 +179,8 @@ RUN groupadd --gid ${DOCKER_GID} edx || \
       --home-dir /home/edx \
       --uid ${DOCKER_UID} \
       --gid ${DOCKER_GID} \
-      edx
+      edx || \
+    echo "Skip user creation (user with ID ${DOCKER_UID} already exists?)"
 
 # To prevent permission issues related to the non-priviledged user running in
 # development, we will install development dependencies in a python virtual

--- a/releases/master/0/bare/Dockerfile
+++ b/releases/master/0/bare/Dockerfile
@@ -166,13 +166,14 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN groupadd --gid ${DOCKER_GID} edx || \
-      echo "Group with ID ${DOCKER_GID} already exists." && \
+    echo "Group with ID ${DOCKER_GID} already exists." && \
     useradd \
       --create-home \
       --home-dir /home/edx \
       --uid ${DOCKER_UID} \
       --gid ${DOCKER_GID} \
-      edx
+      edx || \
+    echo "Skip user creation (user with ID ${DOCKER_UID} already exists?)"
 
 # To prevent permission issues related to the non-priviledged user running in
 # development, we will install development dependencies in a python virtual
@@ -242,7 +243,7 @@ ENV SERVICE_VARIANT=lms
 
 # Gunicorn configuration
 #
-# We want to be able to easily increase gunicorn if needed 
+# We want to be able to easily increase gunicorn if needed
 ENV GUNICORN_TIMEOUT 300
 
 # In docker we must increase the number of workers and threads created


### PR DESCRIPTION
## Purpose

In order to not mess up user filesystem, the build should not be run as a root user.
This commit add a `check-root-user` make target that will check if the user running the make is not with an id = 0 (root).

## Proposal

To guard any make target from being run as root, a `check-root-user` target can be called first. If the user is root, then the command will fail with a warning message. The warning/fail behavior can be override by setting a `ALLOW_ROOT` variable like: 
```
$ sudo ALLOW_ROOT=1 make bootstrap
```

Fixes https://github.com/openfun/openedx-docker/issues/204