### PR TITLE
🐛(dogwood/3/fun) pin `django-classy-tags` version to 0.8.0

### DIFF
--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-1.14.1] - 2020-09-08
+
 ### Fixed
 
 - Pin django-classy-tags to 0.8.0 to avoid breaking changes
@@ -308,7 +310,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.14.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.14.1...HEAD
+[dogwood.3-fun-1.14.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.14.0...dogwood.3-fun-1.14.1
 [dogwood.3-fun-1.14.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.13.2...dogwood.3-fun-1.14.0
 [dogwood.3-fun-1.13.2]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.13.1...dogwood.3-fun-1.13.2
 [dogwood.3-fun-1.13.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.13.0...dogwood.3-fun-1.13.1

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Pin django-classy-tags to 0.8.0 to avoid breaking changes
+
 ## [dogwood.3-fun-1.14.0] - 2020-09-07
 
 ### Added

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -18,6 +18,8 @@ xblock-utils2==0.3.0
 
 # ==== third-party apps ====
 celery-redis-sentinel==0.3.0
+# django-classy-tags 2.0.0 dropped support for python 2.x
+django-classy-tags==0.8.0
 # django-django-redis-sentinel-redux is not compatible with
 # django-redis > 4.5.0
 django-redis==4.5.0

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [eucalyptus.3-wb-1.9.3] - 2020-09-08
+
 ### Fixed
 
 - Pin django-classy-tags to 0.8.0 to avoid breaking changes
@@ -248,7 +250,8 @@ release.
 - Set replicaSet and read_preference in mongodb connection
 - Add missing support for redis sentinel
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.9.2...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.9.3...HEAD
+[eucalyptus.3-wb-1.9.3]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.9.2...eucalyptus.3-wb-1.9.3
 [eucalyptus.3-wb-1.9.2]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.9.1...eucalyptus.3-wb-1.9.2
 [eucalyptus.3-wb-1.9.1]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.9.0...eucalyptus.3-wb-1.9.1
 [eucalyptus.3-wb-1.9.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.8.1...eucalyptus.3-wb-1.9.0

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Pin django-classy-tags to 0.8.0 to avoid breaking changes
+
 ## [eucalyptus.3-wb-1.9.2] - 2020-09-01
 
 ### Fixed

--- a/releases/eucalyptus/3/wb/requirements.txt
+++ b/releases/eucalyptus/3/wb/requirements.txt
@@ -12,6 +12,8 @@ xblock-utils2==0.3.0
 
 # ==== third-party apps ====
 celery-redis-sentinel==0.3.0
+# django-classy-tags 2.0.0 dropped support for python 2.x
+django-classy-tags==0.8.0
 # django-django-redis-sentinel-redux is not compatible with
 # django-redis > 4.5.0
 django-redis==4.5.0


### PR DESCRIPTION
## Purpose

Recent builds of dogwood.3-fun install `django-classy-tags` 2.0.0, that is not compatible anymore with python 2.x.

Same problem with eucalyptus flavor.

## Proposal

- [x] (eucalyptus + dogwood) pin `django-classy-tags` version to 0.8.0
- [x] bump to dogwood.3-fun-1.14.1
- [x] bump to eucalyptus.3-wb-1.9.3