### PR TITLE
Upgrade to fun apps 5.5.0 and release dogwood.3-fun-1.15.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,7 +304,7 @@ superuser: ## Create an admin user with password "admin"
 	@$(COMPOSE) up -d mysql
 	@echo "Wait for services to be up..."
 	@$(WAIT_DB)
-	$(COMPOSE_RUN) lms-prod python manage.py lms createsuperuser
+	$(COMPOSE_RUN) lms python manage.py lms createsuperuser
 .PHONY: superuser
 
 test: \

--- a/bin/ci
+++ b/bin/ci
@@ -110,10 +110,7 @@ function update_sources() {
 
         # Conditions to run a release's workflow
         if \
-            check_changes "^docker-compose.yml$" || \
-            check_changes "^Makefile$" || \
             check_changes "^docker/$" || \
-            check_changes "^env.d/$" || \
             check_changes "^${release_path}/config/" || \
             check_changes "^${release_path}/activate" || \
             check_changes "^${release_path}/Dockerfile" || \

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-1.15.0] - 2020-10-02
+
 ### Added
 
 - Upgrade to fun-apps v5.5.0 to allow placing thumbnail related media files
@@ -321,7 +323,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.14.2...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.15.0...HEAD
+[dogwood.3-fun-1.15.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.14.2...dogwood.3-fun-1.15.0
 [dogwood.3-fun-1.14.2]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.14.1...dogwood.3-fun-1.14.2
 [dogwood.3-fun-1.14.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.14.0...dogwood.3-fun-1.14.1
 [dogwood.3-fun-1.14.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.13.2...dogwood.3-fun-1.14.0

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,11 @@ release.
 
 ## [Unreleased]
 
+### Added
+
+- Upgrade to fun-apps v5.5.0 to allow placing thumbnail related media files
+  behind the CDN
+
 ## [dogwood.3-fun-1.14.2] - 2020-10-01
 
 ### Fixed

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -4,7 +4,7 @@
 # ==== core ====
 edx-gea==0.2.0
 fonzie==0.2.0
-fun-apps==5.4.2
+fun-apps==5.5.0
 
 # ==== xblocks ====
 configurable_lti_consumer-xblock==1.3.0


### PR DESCRIPTION
## Purpose

Thumbnails are heavily queried and should be placed behind the CDN.

## Proposal

Upgrade to [fun-apps v5.5.0](https://github.com/openfun/fun-apps/releases/tag/v5.5.0).