### PR TITLE
🐛(master) fix make bootstrap for master/0/bare

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,33 +159,15 @@ jobs:
   #
   # Note that the job name should match the EDX_RELEASE value
 
-  # Run jobs for the dogwood.3-bare release
-  dogwood.3-bare:
-    <<: [*defaults, *build_steps]
-  # Run jobs for the dogwood.3-fun release
-  dogwood.3-fun:
-    <<: [*defaults, *build_steps]
-  # Run jobs for the eucalyptus.3-bare release
-  eucalyptus.3-bare:
-    <<: [*defaults, *build_steps]
-  # Run jobs for the eucalyptus.3-wb release
-  eucalyptus.3-wb:
-    <<: [*defaults, *build_steps]
-  # Run jobs for the hawthorn.1-bare release
-  hawthorn.1-bare:
-    <<: [*defaults, *build_steps]
-  # Run jobs for the hawthorn.1-oee release
-  hawthorn.1-oee:
-    <<: [*defaults, *build_steps]
-  # Run jobs for the ironwood.2-bare release
-  ironwood.2-bare:
-    <<: [*defaults, *build_steps]
-  # Run jobs for the ironwood.2-oee release
-  ironwood.2-oee:
-    <<: [*defaults, *build_steps]
-  # Run jobs for the master.0-bare release
-  master.0-bare:
-    <<: [*defaults, *build_steps]
+  # No changes detected for dogwood.3-bare
+  # No changes detected for dogwood.3-fun
+  # No changes detected for eucalyptus.3-bare
+  # No changes detected for eucalyptus.3-wb
+  # No changes detected for hawthorn.1-bare
+  # No changes detected for hawthorn.1-oee
+  # No changes detected for ironwood.2-bare
+  # No changes detected for ironwood.2-oee
+  # No changes detected for master.0-bare
 
   # Hub job
   hub:
@@ -274,69 +256,15 @@ workflows:
 
       # Build jobs
 
-      # Run jobs for the dogwood.3-bare release
-      - dogwood.3-bare:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
-      # Run jobs for the dogwood.3-fun release
-      - dogwood.3-fun:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
-      # Run jobs for the eucalyptus.3-bare release
-      - eucalyptus.3-bare:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
-      # Run jobs for the eucalyptus.3-wb release
-      - eucalyptus.3-wb:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
-      # Run jobs for the hawthorn.1-bare release
-      - hawthorn.1-bare:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
-      # Run jobs for the hawthorn.1-oee release
-      - hawthorn.1-oee:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
-      # Run jobs for the ironwood.2-bare release
-      - ironwood.2-bare:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
-      # Run jobs for the ironwood.2-oee release
-      - ironwood.2-oee:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
-      # Run jobs for the master.0-bare release
-      - master.0-bare:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
+      # No changes detected so no job to run for dogwood.3-bare
+      # No changes detected so no job to run for dogwood.3-fun
+      # No changes detected so no job to run for eucalyptus.3-bare
+      # No changes detected so no job to run for eucalyptus.3-wb
+      # No changes detected so no job to run for hawthorn.1-bare
+      # No changes detected so no job to run for hawthorn.1-oee
+      # No changes detected so no job to run for ironwood.2-bare
+      # No changes detected so no job to run for ironwood.2-oee
+      # No changes detected so no job to run for master.0-bare
 
       # We are pushing to Docker only images that are the result of a tag respecting the pattern:
       #    **{branch-name}-x.y.z**

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Target OpenEdx release
-EDX_RELEASE               ?= master
+EDX_RELEASE               ?= master.0
 EDX_ARCHIVE_URL           ?= https://github.com/edx/edx-platform/archive/$(EDX_RELEASE_REF).tar.gz
 FLAVOR                    ?= bare
 FLAVORED_EDX_RELEASE_PATH  = releases/$(shell echo ${EDX_RELEASE} | sed -E "s|\.|/|")/$(FLAVOR)

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ using the `bin/activate` script. An example output follows:
 ```bash
 $ bin/activate
 Select an available release to activate:
-[1] master/bare (default)
+[1] master/0/bare (default)
 [2] hawthorn/1/bare
 [3] hawthorn/1/oee
 Your choice: 3

--- a/bin/compose
+++ b/bin/compose
@@ -3,7 +3,7 @@
 DOCKER_UID=$(id -u)
 DOCKER_GID=$(id -g)
 EDXAPP_IMAGE_TAG="${EDX_RELEASE:-master}-${FLAVOR:-bare}"
-FLAVORED_EDX_RELEASE_PATH="releases/$(echo ${EDX_RELEASE:-master} | sed -E "s|\.|/|")/${FLAVOR:-bare}"
+FLAVORED_EDX_RELEASE_PATH="releases/$(echo ${EDX_RELEASE:-master.0} | sed -E "s|\.|/|")/${FLAVOR:-bare}"
 
 export DOCKER_UID
 export DOCKER_GID


### PR DESCRIPTION
### Purpose

Make bootstrap was broken for the master flavor when run as default without activating any flavor explicitly via the `bin/activate` script. This goes back to when we [moved it to master/0](https://github.com/openfun/openedx-docker/pull/245/files) to follow the same pattern as the other flavors and improve the CI.

## Proposal

Add `/0` to all variable default values where it is missing.
