### PR TITLE
[dogwood/3/fun] Upgrade fun apps to 5.5.1 and release fix dogwood.3-fun-1.15.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,9 @@ jobs:
   # Note that the job name should match the EDX_RELEASE value
 
   # No changes detected for dogwood.3-bare
-  # No changes detected for dogwood.3-fun
+  # Run jobs for the dogwood.3-fun release
+  dogwood.3-fun:
+    <<: [*defaults, *build_steps]
   # No changes detected for eucalyptus.3-bare
   # No changes detected for eucalyptus.3-wb
   # No changes detected for hawthorn.1-bare
@@ -257,7 +259,13 @@ workflows:
       # Build jobs
 
       # No changes detected so no job to run for dogwood.3-bare
-      # No changes detected so no job to run for dogwood.3-fun
+      # Run jobs for the dogwood.3-fun release
+      - dogwood.3-fun:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
       # No changes detected so no job to run for eucalyptus.3-bare
       # No changes detected so no job to run for eucalyptus.3-wb
       # No changes detected so no job to run for hawthorn.1-bare

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-1.15.1] - 2020-10-22
+
 ### Fixed
 
 - Upgrade to fun-apps v5.5.1 to fix `update_courses` command when some course
@@ -328,7 +330,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.15.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.15.1...HEAD
+[dogwood.3-fun-1.15.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.15.0...dogwood.3-fun-1.15.1
 [dogwood.3-fun-1.15.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.14.2...dogwood.3-fun-1.15.0
 [dogwood.3-fun-1.14.2]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.14.1...dogwood.3-fun-1.14.2
 [dogwood.3-fun-1.14.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.14.0...dogwood.3-fun-1.14.1

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,11 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Upgrade to fun-apps v5.5.1 to fix `update_courses` command when some course
+  have an invalid key
+
 ## [dogwood.3-fun-1.15.0] - 2020-10-02
 
 ### Added

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -4,7 +4,7 @@
 # ==== core ====
 edx-gea==0.2.0
 fonzie==0.2.0
-fun-apps==5.5.0
+fun-apps==5.5.1
 
 # ==== xblocks ====
 configurable_lti_consumer-xblock==1.3.0


### PR DESCRIPTION
## Purpose

We want to fix the `update_courses` command that is failing badly when a course happens to have an invalid key.

## Proposal

Bump [fun-apps](https://github.com/openfun/fun-apps) to [5.5.1](https://github.com/openfun/fun-apps/releases/tag/v5.5.1)