### PR TITLE
[hawthorn][ironwood] Release fix for ORA2 with filesystem backend

### DIFF
--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [hawthorn.1-oee-3.3.2] - 2020-11-09
+
 ### Fixed
 
 - Make ORA2 work with the filesystem backend
@@ -306,7 +308,8 @@ First release of OpenEdx extended.
 
 - Add a configurable LTI consumer xblock
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.3.1..HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.3.2..HEAD
+[hawthorn.1-oee-3.3.2]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.3.1...hawthorn.1-oee-3.3.2
 [hawthorn.1-oee-3.3.1]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.3.0...hawthorn.1-oee-3.3.1
 [hawthorn.1-oee-3.3.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.2.0...hawthorn.1-oee-3.3.0
 [hawthorn.1-oee-3.2.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.1.2...hawthorn.1-oee-3.2.0

--- a/releases/ironwood/2/oee/CHANGELOG.md
+++ b/releases/ironwood/2/oee/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [ironwood.2-oee-1.0.2] - 2020-11-09
+
 ### Fixed
 
 - Make ORA2 work with the filesystem backend
@@ -23,6 +25,7 @@ release.
 
 - First release of an `ironwood.2-oee` Docker image.
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/ironwood.2-oee-1.0.1...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/ironwood.2-oee-1.0.2...HEAD
+[ironwood.2-oee-1.0.2]: https://github.com/openfun/openedx-docker/compare/ironwood.2-oee-1.0.1...ironwood.2-oee-1.0.2
 [ironwood.2-oee-1.0.1]: https://github.com/openfun/openedx-docker/compare/ironwood.2-oee-1.0.0...ironwood.2-oee-1.0.1
 [ironwood.2-oee-1.0.0]: https://github.com/openfun/openedx-docker/releases/tag/ironwood.2-oee-1.0.0


### PR DESCRIPTION
## hawthorn.1-oee-3.3.2

### Fixed

- Make ORA2 work with the filesystem backend

## ironwood.2-oee-1.0.2

### Fixed

- Make ORA2 work with the filesystem backend
