### PR TITLE
Fix dogwood default course about image url for cms and publish fix releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,18 +159,18 @@ jobs:
   #
   # Note that the job name should match the EDX_RELEASE value
 
-  # No changes detected for dogwood.3-bare
-  # No changes detected for dogwood.3-fun
+  # Run jobs for the dogwood.3-bare release
+  dogwood.3-bare:
+    <<: [*defaults, *build_steps]
+  # Run jobs for the dogwood.3-fun release
+  dogwood.3-fun:
+    <<: [*defaults, *build_steps]
   # No changes detected for eucalyptus.3-bare
   # No changes detected for eucalyptus.3-wb
   # No changes detected for hawthorn.1-bare
-  # Run jobs for the hawthorn.1-oee release
-  hawthorn.1-oee:
-    <<: [*defaults, *build_steps]
+  # No changes detected for hawthorn.1-oee
   # No changes detected for ironwood.2-bare
-  # Run jobs for the ironwood.2-oee release
-  ironwood.2-oee:
-    <<: [*defaults, *build_steps]
+  # No changes detected for ironwood.2-oee
   # No changes detected for master.0-bare
 
   # Hub job
@@ -260,26 +260,26 @@ workflows:
 
       # Build jobs
 
-      # No changes detected so no job to run for dogwood.3-bare
-      # No changes detected so no job to run for dogwood.3-fun
+      # Run jobs for the dogwood.3-bare release
+      - dogwood.3-bare:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
+      # Run jobs for the dogwood.3-fun release
+      - dogwood.3-fun:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
       # No changes detected so no job to run for eucalyptus.3-bare
       # No changes detected so no job to run for eucalyptus.3-wb
       # No changes detected so no job to run for hawthorn.1-bare
-      # Run jobs for the hawthorn.1-oee release
-      - hawthorn.1-oee:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
+      # No changes detected so no job to run for hawthorn.1-oee
       # No changes detected so no job to run for ironwood.2-bare
-      # Run jobs for the ironwood.2-oee release
-      - ironwood.2-oee:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
+      # No changes detected so no job to run for ironwood.2-oee
       # No changes detected so no job to run for master.0-bare
 
       # We are pushing to Docker only images that are the result of a tag respecting the pattern:

--- a/releases/dogwood/3/bare/CHANGELOG.md
+++ b/releases/dogwood/3/bare/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-1.3.1] - 2020-11-10
+
 ### Fixed
 
 - Fix missing `DEFAULT_COURSE_ABOUT_IMAGE_URL` setting in cms config
@@ -108,7 +110,8 @@ release.
 
 First experimental release of OpenEdx `dogwood.3` (bare flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-1.3.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-1.3.1...HEAD
+[dogwood.3-1.3.1]: https://github.com/openfun/openedx-docker/compare/tag/dogwood.3-1.3.0...dogwood.3-1.3.1
 [dogwood.3-1.3.0]: https://github.com/openfun/openedx-docker/compare/tag/dogwood.3-1.2.2...dogwood.3-1.3.0
 [dogwood.3-1.2.2]: https://github.com/openfun/openedx-docker/compare/tag/dogwood.3-1.2.1...dogwood.3-1.2.2
 [dogwood.3-1.2.1]: https://github.com/openfun/openedx-docker/compare/tag/dogwood.3-1.2.0...dogwood.3-1.2.1

--- a/releases/dogwood/3/bare/CHANGELOG.md
+++ b/releases/dogwood/3/bare/CHANGELOG.md
@@ -11,6 +11,7 @@ release.
 
 ### Fixed
 
+- Fix missing `DEFAULT_COURSE_ABOUT_IMAGE_URL` setting in cms config
 - Pin splinter to 0.13.0 to avoid breaking change in 0.14.0
 
 ## [dogwood.3-1.3.0] - 2020-05-14

--- a/releases/dogwood/3/bare/config/cms/docker_run_production.py
+++ b/releases/dogwood/3/bare/config/cms/docker_run_production.py
@@ -120,6 +120,12 @@ GITHUB_REPO_ROOT = config(
     "GITHUB_REPO_ROOT", default=path("/edx/app/edxapp/data"), formatter=path
 )
 
+# DEFAULT_COURSE_ABOUT_IMAGE_URL specifies the default image to show for
+# courses that don't provide one
+DEFAULT_COURSE_ABOUT_IMAGE_URL = config(
+    "DEFAULT_COURSE_ABOUT_IMAGE_URL", default="images/pencils.jpg"
+)
+
 STATIC_URL_BASE = "/static/"
 STATIC_URL = "/static/studio/"
 STATIC_ROOT_BASE = path("/edx/app/edxapp/staticfiles")

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-1.15.2] - 2020-11-10
+
 ### Fixed
 
 - Fix missing `DEFAULT_COURSE_ABOUT_IMAGE_URL` setting in cms config
@@ -334,7 +336,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.15.1...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.15.2...HEAD
+[dogwood.3-fun-1.15.2]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.15.1...dogwood.3-fun-1.15.2
 [dogwood.3-fun-1.15.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.15.0...dogwood.3-fun-1.15.1
 [dogwood.3-fun-1.15.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.14.2...dogwood.3-fun-1.15.0
 [dogwood.3-fun-1.14.2]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.14.1...dogwood.3-fun-1.14.2

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix missing `DEFAULT_COURSE_ABOUT_IMAGE_URL` setting in cms config
+
 ## [dogwood.3-fun-1.15.1] - 2020-10-22
 
 ### Fixed

--- a/releases/dogwood/3/fun/config/cms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/cms/docker_run_production.py
@@ -128,6 +128,12 @@ GITHUB_REPO_ROOT = config(
     "GITHUB_REPO_ROOT", default=path("/edx/app/edxapp/data"), formatter=path
 )
 
+# DEFAULT_COURSE_ABOUT_IMAGE_URL specifies the default image to show for
+# courses that don't provide one
+DEFAULT_COURSE_ABOUT_IMAGE_URL = config(
+    "DEFAULT_COURSE_ABOUT_IMAGE_URL", default="images/pencils.jpg"
+)
+
 STATIC_URL_BASE = "/static/"
 STATIC_URL = "/static/studio/"
 STATIC_ROOT_BASE = path("/edx/app/edxapp/staticfiles")


### PR DESCRIPTION
## Purpose

The `DEFAULT_COURSE_ABOUT_IMAGE_URL` setting is missing in the cms configuration of our `dogwood` images, generating 500 errors.

## Proposal

Add the missing setting and publish fix releases.