### PR TITLE
Dogwood.3 fun upgrade fun apps to 5.6.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,17 +160,15 @@ jobs:
   # Note that the job name should match the EDX_RELEASE value
 
   # No changes detected for dogwood.3-bare
-  # No changes detected for dogwood.3-fun
+  # Run jobs for the dogwood.3-fun release
+  dogwood.3-fun:
+    <<: [*defaults, *build_steps]
   # No changes detected for eucalyptus.3-bare
   # No changes detected for eucalyptus.3-wb
   # No changes detected for hawthorn.1-bare
-  # Run jobs for the hawthorn.1-oee release
-  hawthorn.1-oee:
-    <<: [*defaults, *build_steps]
+  # No changes detected for hawthorn.1-oee
   # No changes detected for ironwood.2-bare
-  # Run jobs for the ironwood.2-oee release
-  ironwood.2-oee:
-    <<: [*defaults, *build_steps]
+  # No changes detected for ironwood.2-oee
   # No changes detected for master.0-bare
 
   # Hub job
@@ -261,25 +259,19 @@ workflows:
       # Build jobs
 
       # No changes detected so no job to run for dogwood.3-bare
-      # No changes detected so no job to run for dogwood.3-fun
+      # Run jobs for the dogwood.3-fun release
+      - dogwood.3-fun:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
       # No changes detected so no job to run for eucalyptus.3-bare
       # No changes detected so no job to run for eucalyptus.3-wb
       # No changes detected so no job to run for hawthorn.1-bare
-      # Run jobs for the hawthorn.1-oee release
-      - hawthorn.1-oee:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
+      # No changes detected so no job to run for hawthorn.1-oee
       # No changes detected so no job to run for ironwood.2-bare
-      # Run jobs for the ironwood.2-oee release
-      - ironwood.2-oee:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
+      # No changes detected so no job to run for ironwood.2-oee
       # No changes detected so no job to run for master.0-bare
 
       # We are pushing to Docker only images that are the result of a tag respecting the pattern:

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-1.16.0] - 2020-12-04
+
 ### Changed
 
 - Upgrade fun-apps to v5.6.0 to enable connection with richie
@@ -340,7 +342,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.15.2...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.16.0...HEAD
+[dogwood.3-fun-1.16.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.15.2...dogwood.3-fun-1.16.0
 [dogwood.3-fun-1.15.2]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.15.1...dogwood.3-fun-1.15.2
 [dogwood.3-fun-1.15.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.15.0...dogwood.3-fun-1.15.1
 [dogwood.3-fun-1.15.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.14.2...dogwood.3-fun-1.15.0

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade fun-apps to v5.6.0 to enable connection with richie
+
 ## [dogwood.3-fun-1.15.2] - 2020-11-10
 
 ### Fixed
@@ -19,7 +23,7 @@ release.
 
 ### Fixed
 
-- Upgrade to fun-apps v5.5.1 to fix `update_courses` command when some course
+- Upgrade fun-apps to v5.5.1 to fix `update_courses` command when some course
   have an invalid key
 
 ## [dogwood.3-fun-1.15.0] - 2020-10-02

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -4,7 +4,7 @@
 # ==== core ====
 edx-gea==0.2.0
 fonzie==0.2.0
-fun-apps==5.5.1
+fun-apps==5.6.0
 
 # ==== xblocks ====
 configurable_lti_consumer-xblock==1.3.0


### PR DESCRIPTION
### Purpose

We want to enable the richie connector on the dogwood.3-fun image.

### Proposal

Bump fun-apps to v5.6.0 in the dogwood.3-fun image.
