### PR TITLE
📝(README) update demo credentials

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,9 +160,7 @@ jobs:
   # Note that the job name should match the EDX_RELEASE value
 
   # No changes detected for dogwood.3-bare
-  # Run jobs for the dogwood.3-fun release
-  dogwood.3-fun:
-    <<: [*defaults, *build_steps]
+  # No changes detected for dogwood.3-fun
   # No changes detected for eucalyptus.3-bare
   # No changes detected for eucalyptus.3-wb
   # No changes detected for hawthorn.1-bare
@@ -259,13 +257,7 @@ workflows:
       # Build jobs
 
       # No changes detected so no job to run for dogwood.3-bare
-      # Run jobs for the dogwood.3-fun release
-      - dogwood.3-fun:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
+      # No changes detected so no job to run for dogwood.3-fun
       # No changes detected so no job to run for eucalyptus.3-bare
       # No changes detected so no job to run for eucalyptus.3-wb
       # No changes detected so no job to run for hawthorn.1-bare

--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ Two users are available for testing:
 - admin: `admin@example.com`/`admin`
 - student: `edx@example.com`/`edx`
 
-The database is regularly flushed.
+Richie's admin is available at https://demo.richie.education/admin/ and can be
+accessed via the following user account: `admin`/`admin`.
+
+The demonstration databases are regularly flushed.
 
 ## Approach
 


### PR DESCRIPTION

## Purpose

Connecting to Richie and to OpenEdX is now done with separate accounts:

- in richie, users are here to edit CMS pages ;
- in OpenEdX, users are either students or teachers in the LMS.

## Proposal

Modify README to explain new credentials to the demo site.
