### PR TITLE
Fix dogwood/3/fun Docker build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,9 @@ jobs:
   # Note that the job name should match the EDX_RELEASE value
 
   # No changes detected for dogwood.3-bare
-  # No changes detected for dogwood.3-fun
+  # Run jobs for the dogwood.3-fun release
+  dogwood.3-fun:
+    <<: [*defaults, *build_steps]
   # No changes detected for eucalyptus.3-bare
   # No changes detected for eucalyptus.3-wb
   # No changes detected for hawthorn.1-bare
@@ -261,7 +263,13 @@ workflows:
       # Build jobs
 
       # No changes detected so no job to run for dogwood.3-bare
-      # No changes detected so no job to run for dogwood.3-fun
+      # Run jobs for the dogwood.3-fun release
+      - dogwood.3-fun:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
       # No changes detected so no job to run for eucalyptus.3-bare
       # No changes detected so no job to run for eucalyptus.3-wb
       # No changes detected so no job to run for hawthorn.1-bare

--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ create-symlinks:  ## create symlinks to local configuration (mounted via a volum
 	  rm -f /edx/app/edxapp/edx-platform/cms/envs/fun && \
 	  ln -sf /config/lms /edx/app/edxapp/edx-platform/lms/envs/fun && \
 	  ln -sf /config/cms /edx/app/edxapp/edx-platform/cms/envs/fun && \
-	  ln -sf /config/lms/root_urls.py /edx/app/edxapp/edx-platform/lms/" && \
+	  ln -sf /config/lms/root_urls.py /edx/app/edxapp/edx-platform/lms/ && \
 	  ln -sf /config/cms/root_urls.py /edx/app/edxapp/edx-platform/cms/"
 .PHONY: create-symlinks
 

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Force Django old-release de-installation due to recent changes in the new pip dependencies resolver
+
 ## [dogwood.3-fun-1.17.0] - 2020-12-10
 
 ### Added

--- a/releases/dogwood/3/fun/Dockerfile
+++ b/releases/dogwood/3/fun/Dockerfile
@@ -156,10 +156,12 @@ RUN python get-pip.py
 RUN pip install -r requirements/edx/pre.txt
 RUN pip install \
       astroid==1.6.0 \
-      django==1.8.12 \
       pip==9.0.3 \
       splinter==0.13.0
 RUN pip install --src /usr/local/src -r requirements/edx/github.txt
+# Uninstall django==1.4.22 which gets installed because of django-wiki. Otherwise 1.8.12 is installed on top of 1.4.22
+# in the next step and causes a build failure.
+RUN pip uninstall --yes django
 RUN pip install -r requirements/edx/base.txt
 RUN pip install -r requirements/edx/paver.txt
 RUN pip install -r requirements/edx/post.txt


### PR DESCRIPTION
## Purpose

Fix building the dogwood/3/fun Docker image.

## Proposal

Uninstall django 1.4.22 prior to re-installing it.

Building the dogwood/3/fun Docker fails with the following error:

    Step 51/51 : RUN NO_PREREQ_INSTALL=1     paver update_assets --settings=fun.docker_build_production --skip-collect
    ...
      File "/usr/local/lib/python2.7/dist-packages/django/contrib/auth/decorators.py", line 6, in <module>
	from django.shortcuts import resolve_url
    ImportError: cannot import name resolve_url

The root cause is unknown; what happens is that django==1.8.12 is installed on
top of django==1.4.22 and the shortcuts.py module finds itself right next to
the (obsolete) shortcuts/__init__.py module. The latter does not contain the
`resolve_url` function and causes the failure.

To resolve (pun intended) this, we explicitly uninstall django=1.4.22. This
*should not* cause any new issue, because django==1.8.12 is already the version
currently installed on FUN.

Close #270.