### PR TITLE
Upgrade fun-apps to v5.7.0 and add settings for course run synchronization with richie

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,6 +135,9 @@ services:
       - ./${FLAVORED_EDX_RELEASE_PATH:-releases/master/0/bare}/config:/config
       # Add lines here to override source code in a Python module e.g.:
       #- ./src/edx-ora2/openassessment:/usr/local/lib/python2.7/dist-packages/openassessment
+    networks:
+      - default
+      - outside
     depends_on:
       - lms
     user: ${DOCKER_UID}:${DOCKER_GID}

--- a/env.d/development
+++ b/env.d/development
@@ -26,3 +26,6 @@ OAUTH_OIDC_ISSUER=http://edx:8073/oauth2
 
 # API
 EDX_API_KEY=FakeEdXAPIKey
+
+# Richie synchronization
+COURSE_HOOKS=[{"url": "https://richie:8070/api/v1.0/course-runs-sync/", "secret": "shared secret", "verify": false}]

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,13 +9,15 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-1.18.0] - 2021-01-06
+
 ### Added
 
 - Upgrade fun-apps to v5.7.0 to allow synchronizing course runs with richie
 
 ### Fixed
 
-- Force Django old-release de-installation due to recent changes in the new
+- Force Django old-release uninstallation due to recent changes in the new
   pip dependencies resolver
 
 ## [dogwood.3-fun-1.17.0] - 2020-12-10
@@ -361,7 +363,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.17.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.18.0...HEAD
+[dogwood.3-fun-1.18.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.17.0...dogwood.3-fun-1.18.0
 [dogwood.3-fun-1.17.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.16.0...dogwood.3-fun-1.17.0
 [dogwood.3-fun-1.16.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.15.2...dogwood.3-fun-1.16.0
 [dogwood.3-fun-1.15.2]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.15.1...dogwood.3-fun-1.15.2

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,9 +9,14 @@ release.
 
 ## [Unreleased]
 
+### Added
+
+- Upgrade fun-apps to v5.7.0 to allow synchronizing course runs with richie
+
 ### Fixed
 
-- Force Django old-release de-installation due to recent changes in the new pip dependencies resolver
+- Force Django old-release de-installation due to recent changes in the new
+  pip dependencies resolver
 
 ## [dogwood.3-fun-1.17.0] - 2020-12-10
 

--- a/releases/dogwood/3/fun/config/cms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/cms/docker_run_production.py
@@ -813,6 +813,11 @@ MAX_ASSET_UPLOAD_FILE_SIZE_IN_MB = config(
     "MAX_ASSET_UPLOAD_FILE_SIZE_IN_MB", default=10, formatter=int
 )
 
+# Richie synchronization
+COURSE_HOOKS = config(
+    "COURSE_HOOKS", default=[], formatter=json.loads
+)
+
 # Locale paths
 # Here we rewrite LOCAL_PATHS to give precedence to our applications above edx-platform's ones,
 # then we add xblocks which provide translations as there is no native mechanism to handle this

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -4,7 +4,7 @@
 # ==== core ====
 edx-gea==0.2.0
 fonzie==0.2.0
-fun-apps==5.6.0
+fun-apps==5.7.0
 
 # ==== xblocks ====
 configurable_lti_consumer-xblock==1.3.0


### PR DESCRIPTION
## Purpose

In [fun-apps](https://github.com/openfun/fun-apps) v5.7.0 was added the possibility to call a web hook each time a course is published, in order to synchronize its dates with a remote catalog like richie.

## Proposal

- [x] Bump fun-apps to v5.7.0 in Python dependency requirements,
- [x] Release edxapp `dogwood.3-fun-1.18.0`

I had to update the development stack to work on this feature:
- [x] Improve the docker-compose configuration to allow calling richie server-to-server from the cms,
- [x] Add configurable `COURSE_HOOK` setting with a default value that connects with the [richie development stack](https://github.com/openfun/richie),
