### PR TITLE
[dogwood.3-fun] upgrade fun apps to 5.7.1 and release fix

### DIFF
--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-1.18.1] - 2021-01-18
+
 ### Fixed
 
 - Upgrade fun-apps to v5.7.1 to fix course run synchronization for empty dates
@@ -367,7 +369,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.18.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.18.1...HEAD
+[dogwood.3-fun-1.18.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.18.0...dogwood.3-fun-1.18.1
 [dogwood.3-fun-1.18.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.17.0...dogwood.3-fun-1.18.0
 [dogwood.3-fun-1.17.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.16.0...dogwood.3-fun-1.17.0
 [dogwood.3-fun-1.16.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.15.2...dogwood.3-fun-1.16.0

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Upgrade fun-apps to v5.7.1 to fix course run synchronization for empty dates
+
 ## [dogwood.3-fun-1.18.0] - 2021-01-06
 
 ### Added

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -4,7 +4,7 @@
 # ==== core ====
 edx-gea==0.2.0
 fonzie==0.2.0
-fun-apps==5.7.0
+fun-apps==5.7.1
 
 # ==== xblocks ====
 configurable_lti_consumer-xblock==1.3.0


### PR DESCRIPTION
### Fixed

- Upgrade fun-apps to v5.7.1 to fix course run synchronization for empty dates
