### PR TITLE
[dogwood.3-fun] upgrade fun apps to 5.7.2 and release fix dogwood.3-fun-1.18.2

### DIFF
--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Upgrade fun-apps to v5.7.2 fixing course run synchronization to point to LMS
+
 ## [dogwood.3-fun-1.18.1] - 2021-01-18
 
 ### Fixed

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-1.18.2] - 2021-01-18
+
 ### Fixed
 
 - Upgrade fun-apps to v5.7.2 fixing course run synchronization to point to LMS
@@ -373,7 +375,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.18.1...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.18.2...HEAD
+[dogwood.3-fun-1.18.2]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.18.1...dogwood.3-fun-1.18.2
 [dogwood.3-fun-1.18.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.18.0...dogwood.3-fun-1.18.1
 [dogwood.3-fun-1.18.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.17.0...dogwood.3-fun-1.18.0
 [dogwood.3-fun-1.17.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.16.0...dogwood.3-fun-1.17.0

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -4,7 +4,7 @@
 # ==== core ====
 edx-gea==0.2.0
 fonzie==0.2.0
-fun-apps==5.7.1
+fun-apps==5.7.2
 
 # ==== xblocks ====
 configurable_lti_consumer-xblock==1.3.0


### PR DESCRIPTION
### Fixed

- Upgrade fun-apps to v5.7.2 fixing course run synchronization to point to LMS
