### PR TITLE
🐛(dockerfiles) install pip for python 2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,17 +163,33 @@ jobs:
   #
   # Note that the job name should match the EDX_RELEASE value
 
-  # No changes detected for dogwood.3-bare
+  # Run jobs for the dogwood.3-bare release
+  dogwood.3-bare:
+    <<: [*defaults, *build_steps]
   # Run jobs for the dogwood.3-fun release
   dogwood.3-fun:
     <<: [*defaults, *build_steps]
-  # No changes detected for eucalyptus.3-bare
-  # No changes detected for eucalyptus.3-wb
-  # No changes detected for hawthorn.1-bare
-  # No changes detected for hawthorn.1-oee
-  # No changes detected for ironwood.2-bare
-  # No changes detected for ironwood.2-oee
-  # No changes detected for master.0-bare
+  # Run jobs for the eucalyptus.3-bare release
+  eucalyptus.3-bare:
+    <<: [*defaults, *build_steps]
+  # Run jobs for the eucalyptus.3-wb release
+  eucalyptus.3-wb:
+    <<: [*defaults, *build_steps]
+  # Run jobs for the hawthorn.1-bare release
+  hawthorn.1-bare:
+    <<: [*defaults, *build_steps]
+  # Run jobs for the hawthorn.1-oee release
+  hawthorn.1-oee:
+    <<: [*defaults, *build_steps]
+  # Run jobs for the ironwood.2-bare release
+  ironwood.2-bare:
+    <<: [*defaults, *build_steps]
+  # Run jobs for the ironwood.2-oee release
+  ironwood.2-oee:
+    <<: [*defaults, *build_steps]
+  # Run jobs for the master.0-bare release
+  master.0-bare:
+    <<: [*defaults, *build_steps]
 
   # Hub job
   hub:
@@ -262,7 +278,13 @@ workflows:
 
       # Build jobs
 
-      # No changes detected so no job to run for dogwood.3-bare
+      # Run jobs for the dogwood.3-bare release
+      - dogwood.3-bare:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
       # Run jobs for the dogwood.3-fun release
       - dogwood.3-fun:
           requires:
@@ -270,13 +292,55 @@ workflows:
           filters:
             tags:
               ignore: /.*/
-      # No changes detected so no job to run for eucalyptus.3-bare
-      # No changes detected so no job to run for eucalyptus.3-wb
-      # No changes detected so no job to run for hawthorn.1-bare
-      # No changes detected so no job to run for hawthorn.1-oee
-      # No changes detected so no job to run for ironwood.2-bare
-      # No changes detected so no job to run for ironwood.2-oee
-      # No changes detected so no job to run for master.0-bare
+      # Run jobs for the eucalyptus.3-bare release
+      - eucalyptus.3-bare:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
+      # Run jobs for the eucalyptus.3-wb release
+      - eucalyptus.3-wb:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
+      # Run jobs for the hawthorn.1-bare release
+      - hawthorn.1-bare:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
+      # Run jobs for the hawthorn.1-oee release
+      - hawthorn.1-oee:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
+      # Run jobs for the ironwood.2-bare release
+      - ironwood.2-bare:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
+      # Run jobs for the ironwood.2-oee release
+      - ironwood.2-oee:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
+      # Run jobs for the master.0-bare release
+      - master.0-bare:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
 
       # We are pushing to Docker only images that are the result of a tag respecting the pattern:
       #    **{branch-name}-x.y.z**

--- a/releases/dogwood/3/bare/CHANGELOG.md
+++ b/releases/dogwood/3/bare/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+- Fix pip install for python 2.7
+
 ## [dogwood.3-1.3.1] - 2020-11-10
 
 ### Fixed

--- a/releases/dogwood/3/bare/Dockerfile
+++ b/releases/dogwood/3/bare/Dockerfile
@@ -41,8 +41,8 @@ WORKDIR /downloads
 RUN apt-get update && \
     apt-get install -y curl
 
-# Download pip installer
-RUN curl -sLo get-pip.py https://bootstrap.pypa.io/get-pip.py
+# Download pip installer for python 2.7
+RUN curl -sLo get-pip.py https://bootstrap.pypa.io/2.7/get-pip.py
 
 # Download edxapp release
 # Get default EDX_RELEASE_REF value (defined on top)

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+- Fix pip install for python 2.7
+
 ## [dogwood.3-fun-1.18.2] - 2021-01-18
 
 ### Fixed

--- a/releases/dogwood/3/fun/Dockerfile
+++ b/releases/dogwood/3/fun/Dockerfile
@@ -42,8 +42,8 @@ WORKDIR /downloads
 RUN apt-get update && \
     apt-get install -y curl
 
-# Download pip installer
-RUN curl -sLo get-pip.py https://bootstrap.pypa.io/get-pip.py
+# Download pip installer for python 2.7
+RUN curl -sLo get-pip.py https://bootstrap.pypa.io/2.7/get-pip.py
 
 # Download edxapp release
 # Get default EDX_RELEASE_REF value (defined on top)

--- a/releases/eucalyptus/3/bare/CHANGELOG.md
+++ b/releases/eucalyptus/3/bare/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+- Fix pip install for python 2.7
+
 ## [eucalyptus.3-1.2.0] - 2020-05-14
 
 ### Added

--- a/releases/eucalyptus/3/bare/Dockerfile
+++ b/releases/eucalyptus/3/bare/Dockerfile
@@ -41,8 +41,8 @@ WORKDIR /downloads
 RUN apt-get update && \
     apt-get install -y curl
 
-# Download pip installer
-RUN curl -sLo get-pip.py https://bootstrap.pypa.io/get-pip.py
+# Download pip installer for python 2.7
+RUN curl -sLo get-pip.py https://bootstrap.pypa.io/2.7/get-pip.py
 
 # Download edxapp release
 # Get default EDX_RELEASE_REF value (defined on top)

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+- Fix pip install for python 2.7
+
 ## [eucalyptus.3-wb-1.9.3] - 2020-09-08
 
 ### Fixed

--- a/releases/eucalyptus/3/wb/Dockerfile
+++ b/releases/eucalyptus/3/wb/Dockerfile
@@ -42,8 +42,8 @@ WORKDIR /downloads
 RUN apt-get update && \
     apt-get install -y curl
 
-# Download pip installer
-RUN curl -sLo get-pip.py https://bootstrap.pypa.io/get-pip.py
+# Download pip installer for python 2.7
+RUN curl -sLo get-pip.py https://bootstrap.pypa.io/2.7/get-pip.py
 
 # Download edxapp release
 # Get default EDX_RELEASE_REF value (defined on top)

--- a/releases/hawthorn/1/bare/CHANGELOG.md
+++ b/releases/hawthorn/1/bare/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+- Fix pip install for python 2.7
+
 ## [hawthorn.1-3.3.0] - 2020-05-14
 
 ### Added

--- a/releases/hawthorn/1/bare/Dockerfile
+++ b/releases/hawthorn/1/bare/Dockerfile
@@ -39,8 +39,8 @@ WORKDIR /downloads
 RUN apt-get update && \
     apt-get install -y curl
 
-# Download pip installer
-RUN curl -sLo get-pip.py https://bootstrap.pypa.io/get-pip.py
+# Download pip installer for python 2.7
+RUN curl -sLo get-pip.py https://bootstrap.pypa.io/2.7/get-pip.py
 
 # Download edxapp release
 # Get default EDX_RELEASE_REF value (defined on top)

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+- Fix pip install for python 2.7
+
 ## [hawthorn.1-oee-3.3.3] - 2020-11-20
 
 ### Fixed

--- a/releases/hawthorn/1/oee/Dockerfile
+++ b/releases/hawthorn/1/oee/Dockerfile
@@ -39,8 +39,8 @@ WORKDIR /downloads
 RUN apt-get update && \
     apt-get install -y curl
 
-# Download pip installer
-RUN curl -sLo get-pip.py https://bootstrap.pypa.io/get-pip.py
+# Download pip installer for python 2.7
+RUN curl -sLo get-pip.py https://bootstrap.pypa.io/2.7/get-pip.py
 
 # Download edxapp release
 # Get default EDX_RELEASE_REF value (defined on top)

--- a/releases/ironwood/2/bare/CHANGELOG.md
+++ b/releases/ironwood/2/bare/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+- Fix pip install for python 2.7
+
 ## [ironwood.2-1.0.0] - 2020-09-10
 
 - First release of an `ironwood.2-bare` Docker image.

--- a/releases/ironwood/2/bare/Dockerfile
+++ b/releases/ironwood/2/bare/Dockerfile
@@ -39,8 +39,8 @@ WORKDIR /downloads
 RUN apt-get update && \
     apt-get install -y curl
 
-# Download pip installer
-RUN curl -sLo get-pip.py https://bootstrap.pypa.io/get-pip.py
+# Download pip installer for python 2.7
+RUN curl -sLo get-pip.py https://bootstrap.pypa.io/2.7/get-pip.py
 
 # Download edxapp release
 # Get default EDX_RELEASE_REF value (defined on top)

--- a/releases/ironwood/2/oee/CHANGELOG.md
+++ b/releases/ironwood/2/oee/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+- Fix pip install for python 2.7
+
 ## [ironwood.2-oee-1.0.3] - 2020-11-20
 
 ### Fixed

--- a/releases/ironwood/2/oee/Dockerfile
+++ b/releases/ironwood/2/oee/Dockerfile
@@ -39,8 +39,8 @@ WORKDIR /downloads
 RUN apt-get update && \
     apt-get install -y curl
 
-# Download pip installer
-RUN curl -sLo get-pip.py https://bootstrap.pypa.io/get-pip.py
+# Download pip installer for python 2.7
+RUN curl -sLo get-pip.py https://bootstrap.pypa.io/2.7/get-pip.py
 
 # Download edxapp release
 # Get default EDX_RELEASE_REF value (defined on top)

--- a/releases/master/0/bare/CHANGELOG.md
+++ b/releases/master/0/bare/CHANGELOG.md
@@ -13,4 +13,6 @@ release.
 
 ## [Unreleased]
 
+- Fix pip install for python 2.7
+
 [unreleased]: https://github.com/openfun/openedx-docker

--- a/releases/master/0/bare/Dockerfile
+++ b/releases/master/0/bare/Dockerfile
@@ -39,8 +39,8 @@ WORKDIR /downloads
 RUN apt-get update && \
     apt-get install -y curl
 
-# Download pip installer
-RUN curl -sLo get-pip.py https://bootstrap.pypa.io/get-pip.py
+# Download pip installer for python 2.7
+RUN curl -sLo get-pip.py https://bootstrap.pypa.io/2.7/get-pip.py
 
 # Download edxapp release
 # Get default EDX_RELEASE_REF value (defined on top)


### PR DESCRIPTION
## Purpose

As python 2.7 is used in all ubuntu images, we need to get matching pip version (https://github.com/pypa/get-pip/issues/82)

## Proposal

Get pip from this url : https://bootstrap.pypa.io/2.7/get-pip.py
