### PR TITLE
Upgrade xblock proctorexam to fix api change and release fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,9 @@ jobs:
   # Note that the job name should match the EDX_RELEASE value
 
   # No changes detected for dogwood.3-bare
-  # No changes detected for dogwood.3-fun
+  # Run jobs for the dogwood.3-fun release
+  dogwood.3-fun:
+    <<: [*defaults, *build_steps]
   # No changes detected for eucalyptus.3-bare
   # No changes detected for eucalyptus.3-wb
   # No changes detected for hawthorn.1-bare
@@ -261,7 +263,13 @@ workflows:
       # Build jobs
 
       # No changes detected so no job to run for dogwood.3-bare
-      # No changes detected so no job to run for dogwood.3-fun
+      # Run jobs for the dogwood.3-fun release
+      - dogwood.3-fun:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
       # No changes detected so no job to run for eucalyptus.3-bare
       # No changes detected so no job to run for eucalyptus.3-wb
       # No changes detected so no job to run for hawthorn.1-bare

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,9 @@ jobs:
   dogwood.3-fun:
     <<: [*defaults, *build_steps]
   # No changes detected for eucalyptus.3-bare
-  # No changes detected for eucalyptus.3-wb
+  # Run jobs for the eucalyptus.3-wb release
+  eucalyptus.3-wb:
+    <<: [*defaults, *build_steps]
   # No changes detected for hawthorn.1-bare
   # No changes detected for hawthorn.1-oee
   # No changes detected for ironwood.2-bare
@@ -271,7 +273,13 @@ workflows:
             tags:
               ignore: /.*/
       # No changes detected so no job to run for eucalyptus.3-bare
-      # No changes detected so no job to run for eucalyptus.3-wb
+      # Run jobs for the eucalyptus.3-wb release
+      - eucalyptus.3-wb:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
       # No changes detected so no job to run for hawthorn.1-bare
       # No changes detected so no job to run for hawthorn.1-oee
       # No changes detected so no job to run for ironwood.2-bare

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,9 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Upgrade to xblock-proctor-exam to 1.0.0 to fix proctoring after API change
 - Fix pip install for python 2.7
 
 ## [dogwood.3-fun-1.18.2] - 2021-01-18

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-1.18.3] - 2021-02-11
+
 ### Fixed
 
 - Upgrade to xblock-proctor-exam to 1.0.0 to fix proctoring after API change
@@ -380,7 +382,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.18.2...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.18.3...HEAD
+[dogwood.3-fun-1.18.3]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.18.2...dogwood.3-fun-1.18.3
 [dogwood.3-fun-1.18.2]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.18.1...dogwood.3-fun-1.18.2
 [dogwood.3-fun-1.18.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.18.0...dogwood.3-fun-1.18.1
 [dogwood.3-fun-1.18.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.17.0...dogwood.3-fun-1.18.0

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -13,7 +13,7 @@ ipython-xblock==0.2.0
 libcast-xblock==0.5.0
 password-container-xblock==0.3.0
 proctoru-xblock==1.2.0
-xblock-proctor-exam==0.9.0b0
+xblock-proctor-exam==1.0.0
 xblock-utils2==0.3.0
 
 # ==== third-party apps ====

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [eucalyptus.3-wb-1.9.4] - 2021-02-11
+
 ### Fixed
 
 - Upgrade to xblock-proctor-exam to 1.0.0 to fix proctoring after API change
@@ -255,7 +257,8 @@ release.
 - Set replicaSet and read_preference in mongodb connection
 - Add missing support for redis sentinel
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.9.3...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.9.4...HEAD
+[eucalyptus.3-wb-1.9.4]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.9.3...eucalyptus.3-wb-1.9.4
 [eucalyptus.3-wb-1.9.3]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.9.2...eucalyptus.3-wb-1.9.3
 [eucalyptus.3-wb-1.9.2]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.9.1...eucalyptus.3-wb-1.9.2
 [eucalyptus.3-wb-1.9.1]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.9.0...eucalyptus.3-wb-1.9.1

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,9 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Upgrade to xblock-proctor-exam to 1.0.0 to fix proctoring after API change
 - Fix pip install for python 2.7
 
 ## [eucalyptus.3-wb-1.9.3] - 2020-09-08

--- a/releases/eucalyptus/3/wb/requirements.txt
+++ b/releases/eucalyptus/3/wb/requirements.txt
@@ -7,7 +7,7 @@ edx-gea==0.2.0
 fun-apps==2.4.2+wb
 libcast-xblock==0.6.1
 password-container-xblock==0.3.0
-xblock-proctor-exam==0.9.0b0
+xblock-proctor-exam==1.0.0
 xblock-utils2==0.3.0
 
 # ==== third-party apps ====


### PR DESCRIPTION
## dogwood.3-fun-1.18.3

### Fixed

- Upgrade to xblock-proctor-exam to 1.0.0 to fix proctoring after API change
- Fix pip install for python 2.7



## eucalyptus.3-wb-1.9.4

### Fixed

- Upgrade to xblock-proctor-exam to 1.0.0 to fix proctoring after API change
- Fix pip install for python 2.7
