### PR TITLE
[hawthorn][ironwood] Fix assets broken while fixing ORA2 urls + release fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,9 @@ jobs:
   # No changes detected for eucalyptus.3-bare
   # No changes detected for eucalyptus.3-wb
   # No changes detected for hawthorn.1-bare
-  # No changes detected for hawthorn.1-oee
+  # Run jobs for the hawthorn.1-oee release
+  hawthorn.1-oee:
+    <<: [*defaults, *build_steps]
   # No changes detected for ironwood.2-bare
   # Run jobs for the ironwood.2-oee release
   ironwood.2-oee:
@@ -267,7 +269,13 @@ workflows:
       # No changes detected so no job to run for eucalyptus.3-bare
       # No changes detected so no job to run for eucalyptus.3-wb
       # No changes detected so no job to run for hawthorn.1-bare
-      # No changes detected so no job to run for hawthorn.1-oee
+      # Run jobs for the hawthorn.1-oee release
+      - hawthorn.1-oee:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
       # No changes detected so no job to run for ironwood.2-bare
       # Run jobs for the ironwood.2-oee release
       - ironwood.2-oee:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,15 +164,15 @@ jobs:
   # Note that the job name should match the EDX_RELEASE value
 
   # No changes detected for dogwood.3-bare
-  # Run jobs for the dogwood.3-fun release
-  dogwood.3-fun:
-    <<: [*defaults, *build_steps]
+  # No changes detected for dogwood.3-fun
   # No changes detected for eucalyptus.3-bare
   # No changes detected for eucalyptus.3-wb
   # No changes detected for hawthorn.1-bare
   # No changes detected for hawthorn.1-oee
   # No changes detected for ironwood.2-bare
-  # No changes detected for ironwood.2-oee
+  # Run jobs for the ironwood.2-oee release
+  ironwood.2-oee:
+    <<: [*defaults, *build_steps]
   # No changes detected for master.0-bare
 
   # Hub job
@@ -263,19 +263,19 @@ workflows:
       # Build jobs
 
       # No changes detected so no job to run for dogwood.3-bare
-      # Run jobs for the dogwood.3-fun release
-      - dogwood.3-fun:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
+      # No changes detected so no job to run for dogwood.3-fun
       # No changes detected so no job to run for eucalyptus.3-bare
       # No changes detected so no job to run for eucalyptus.3-wb
       # No changes detected so no job to run for hawthorn.1-bare
       # No changes detected so no job to run for hawthorn.1-oee
       # No changes detected so no job to run for ironwood.2-bare
-      # No changes detected so no job to run for ironwood.2-oee
+      # Run jobs for the ironwood.2-oee release
+      - ironwood.2-oee:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
       # No changes detected so no job to run for master.0-bare
 
       # We are pushing to Docker only images that are the result of a tag respecting the pattern:

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [hawthorn.1-oee-3.3.4] - 2021-03-04
+
 ### Fixed
 
 - Fix ORA2 urls that were breaking assets
@@ -319,7 +321,8 @@ First release of OpenEdx extended.
 
 - Add a configurable LTI consumer xblock
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.3.3..HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.3.4..HEAD
+[hawthorn.1-oee-3.3.4]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.3.3...hawthorn.1-oee-3.3.4
 [hawthorn.1-oee-3.3.3]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.3.2...hawthorn.1-oee-3.3.3
 [hawthorn.1-oee-3.3.2]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.3.1...hawthorn.1-oee-3.3.2
 [hawthorn.1-oee-3.3.1]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.3.0...hawthorn.1-oee-3.3.1

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -9,6 +9,9 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix ORA2 urls that were breaking assets
 - Fix pip install for python 2.7
 
 ## [hawthorn.1-oee-3.3.3] - 2020-11-20

--- a/releases/hawthorn/1/oee/config/cms/root_urls.py
+++ b/releases/hawthorn/1/oee/config/cms/root_urls.py
@@ -5,8 +5,11 @@ edx-platform's CMS routes
 """
 from __future__ import absolute_import, unicode_literals
 
+from django.conf.urls import include, url
+
 from cms.urls import urlpatterns  # pylint: disable=import-error
-from openassessment.fileupload.urls import urlpatterns as ora_urlpatterns
 
 
-urlpatterns += ora_urlpatterns
+urlpatterns += [
+    url(r'^openassessment/fileupload/', include('openassessment.fileupload.urls')),
+]

--- a/releases/hawthorn/1/oee/config/lms/root_urls.py
+++ b/releases/hawthorn/1/oee/config/lms/root_urls.py
@@ -8,11 +8,9 @@ from __future__ import absolute_import, unicode_literals
 from django.conf.urls import include, url
 
 from lms.urls import urlpatterns  # pylint: disable=import-error
-from openassessment.fileupload.urls import urlpatterns as ora_urlpatterns
 
 
 urlpatterns += [
     # Fonzie API urls
     url(r"^api/", include("fonzie.urls", namespace="fonzie")),
 ]
-urlpatterns += ora_urlpatterns

--- a/releases/ironwood/2/oee/CHANGELOG.md
+++ b/releases/ironwood/2/oee/CHANGELOG.md
@@ -9,6 +9,9 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix ORA2 urls that were breaking assets
 - Fix pip install for python 2.7
 
 ## [ironwood.2-oee-1.0.3] - 2020-11-20

--- a/releases/ironwood/2/oee/CHANGELOG.md
+++ b/releases/ironwood/2/oee/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [ironwood.2-oee-1.0.4] - 2021-03-04
+
 ### Fixed
 
 - Fix ORA2 urls that were breaking assets
@@ -36,7 +38,8 @@ release.
 
 - First release of an `ironwood.2-oee` Docker image.
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/ironwood.2-oee-1.0.3...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/ironwood.2-oee-1.0.4...HEAD
+[ironwood.2-oee-1.0.4]: https://github.com/openfun/openedx-docker/compare/ironwood.2-oee-1.0.3...ironwood.2-oee-1.0.4
 [ironwood.2-oee-1.0.3]: https://github.com/openfun/openedx-docker/compare/ironwood.2-oee-1.0.2...ironwood.2-oee-1.0.3
 [ironwood.2-oee-1.0.2]: https://github.com/openfun/openedx-docker/compare/ironwood.2-oee-1.0.1...ironwood.2-oee-1.0.2
 [ironwood.2-oee-1.0.1]: https://github.com/openfun/openedx-docker/compare/ironwood.2-oee-1.0.0...ironwood.2-oee-1.0.1

--- a/releases/ironwood/2/oee/config/cms/root_urls.py
+++ b/releases/ironwood/2/oee/config/cms/root_urls.py
@@ -5,8 +5,11 @@ edx-platform's CMS routes
 """
 from __future__ import absolute_import, unicode_literals
 
+from django.conf.urls import include, url
+
 from cms.urls import urlpatterns  # pylint: disable=import-error
-from openassessment.fileupload.urls import urlpatterns as ora_urlpatterns
 
 
-urlpatterns += ora_urlpatterns
+urlpatterns += [
+    url(r'^openassessment/fileupload/', include('openassessment.fileupload.urls')),
+]

--- a/releases/ironwood/2/oee/config/lms/root_urls.py
+++ b/releases/ironwood/2/oee/config/lms/root_urls.py
@@ -8,11 +8,9 @@ from __future__ import absolute_import, unicode_literals
 from django.conf.urls import include, url
 
 from lms.urls import urlpatterns  # pylint: disable=import-error
-from openassessment.fileupload.urls import urlpatterns as ora_urlpatterns
 
 
 urlpatterns += [
     # Fonzie API urls
     url(r"^api/", include("fonzie.urls", namespace="fonzie")),
 ]
-urlpatterns+= ora_urlpatterns


### PR DESCRIPTION
## Purpose

ORA2 urls were declared without any prefix and were matching too many url patterns, breaking (at least) assets.

## [hawthorn.1-oee-3.3.4](https://github.com/openfun/openedx-docker/releases/tag/hawthorn.1-oee-3.3.4)

### Fixed

- Fix ORA2 urls that were breaking assets
- Fix pip install for python 2.7


## [ironwood.2-oee-1.0.4](https://github.com/openfun/openedx-docker/releases/tag/ironwood.2-oee-1.0.4)

### Fixed

- Fix ORA2 urls that were breaking assets
- Fix pip install for python 2.7
