### PR TITLE
Fix dogwood.3-fun build

### DIFF
--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-2.1.1] - 2021-04-13
+
 ### Fixed
 
 - Copy newly installed dependencies and modified sources
@@ -36,7 +38,6 @@ release.
 
 - Upgrade fun-apps to v5.8.0 to automatically add users to a cohort after
   payment and pass course language to course run synchronization hook
-
 
 ## [dogwood.3-fun-1.18.2] - 2021-01-18
 
@@ -404,7 +405,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.1.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.1.1...HEAD
+[dogwood.3-fun-2.1.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.1.0...dogwood.3-fun-2.1.1
 [dogwood.3-fun-2.1.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.0.0...dogwood.3-fun-2.1.0
 [dogwood.3-fun-2.0.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.18.3...dogwood.3-fun-2.0.0
 [dogwood.3-fun-1.18.3]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.18.2...dogwood.3-fun-1.18.3

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Copy newly installed dependencies and modified sources
+
 ## [dogwood.3-fun-2.1.0] - 2021-04-12
 
 ### Added

--- a/releases/dogwood/3/fun/Dockerfile
+++ b/releases/dogwood/3/fun/Dockerfile
@@ -144,6 +144,12 @@ RUN apt-get update && \
     apt-get upgrade -y && \
     rm -rf /var/lib/apt/lists/*
 
+# Copy installed dependencies
+COPY --from=builder /usr/local /usr/local
+
+# Copy modified sources (sic!)
+COPY --from=builder /edx/app/edxapp/edx-platform  /edx/app/edxapp/edx-platform
+
 # Copy static files
 COPY --from=links_collector ${EDXAPP_STATIC_ROOT} ${EDXAPP_STATIC_ROOT}
 


### PR DESCRIPTION
## Purpose

Latest dogwood.3-fun build does not reflect expected changes (outdated dependencies).

## Proposal

The `production` stage should copy build dependencies, static files and sources from the `builder` stage.
