### PR TITLE
Fix eucalyptus builds after `get-pip.py` script moved location

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,11 +164,13 @@ jobs:
   # Note that the job name should match the EDX_RELEASE value
 
   # No changes detected for dogwood.3-bare
-  # Run jobs for the dogwood.3-fun release
-  dogwood.3-fun:
+  # No changes detected for dogwood.3-fun
+  # Run jobs for the eucalyptus.3-bare release
+  eucalyptus.3-bare:
     <<: [*defaults, *build_steps]
-  # No changes detected for eucalyptus.3-bare
-  # No changes detected for eucalyptus.3-wb
+  # Run jobs for the eucalyptus.3-wb release
+  eucalyptus.3-wb:
+    <<: [*defaults, *build_steps]
   # No changes detected for hawthorn.1-bare
   # No changes detected for hawthorn.1-oee
   # No changes detected for ironwood.2-bare
@@ -263,15 +265,21 @@ workflows:
       # Build jobs
 
       # No changes detected so no job to run for dogwood.3-bare
-      # Run jobs for the dogwood.3-fun release
-      - dogwood.3-fun:
+      # No changes detected so no job to run for dogwood.3-fun
+      # Run jobs for the eucalyptus.3-bare release
+      - eucalyptus.3-bare:
           requires:
             - check-configuration
           filters:
             tags:
               ignore: /.*/
-      # No changes detected so no job to run for eucalyptus.3-bare
-      # No changes detected so no job to run for eucalyptus.3-wb
+      # Run jobs for the eucalyptus.3-wb release
+      - eucalyptus.3-wb:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
       # No changes detected so no job to run for hawthorn.1-bare
       # No changes detected so no job to run for hawthorn.1-oee
       # No changes detected so no job to run for ironwood.2-bare

--- a/releases/eucalyptus/3/bare/CHANGELOG.md
+++ b/releases/eucalyptus/3/bare/CHANGELOG.md
@@ -9,7 +9,9 @@ release.
 
 ## [Unreleased]
 
-- Fix pip install for python 2.7
+### Fixed
+
+- Fix build after get-pip.py script moved location
 
 ## [eucalyptus.3-1.2.0] - 2020-05-14
 

--- a/releases/eucalyptus/3/bare/Dockerfile
+++ b/releases/eucalyptus/3/bare/Dockerfile
@@ -42,7 +42,7 @@ RUN apt-get update && \
     apt-get install -y curl
 
 # Download pip installer for python 2.7
-RUN curl -sLo get-pip.py https://bootstrap.pypa.io/2.7/get-pip.py
+RUN curl -sLo get-pip.py https://bootstrap.pypa.io/pip/2.7/get-pip.py
 
 # Download edxapp release
 # Get default EDX_RELEASE_REF value (defined on top)
@@ -128,8 +128,9 @@ RUN pip install -r requirements/edx/pre.txt
 RUN pip install \
       astroid==1.6.0 \
       django==1.8.15 \
-      pip==9.0.3
+      pip==19.3.1
 RUN pip install --src /usr/local/src -r requirements/edx/github.txt
+RUN pip install pip==9.0.3
 RUN pip install -r requirements/edx/base.txt
 RUN pip install -r requirements/edx/paver.txt
 RUN pip install -r requirements/edx/post.txt

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix build after get-pip.py script moved location
+
 ## [eucalyptus.3-wb-1.9.4] - 2021-02-11
 
 ### Fixed

--- a/releases/eucalyptus/3/wb/Dockerfile
+++ b/releases/eucalyptus/3/wb/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get update && \
     apt-get install -y curl
 
 # Download pip installer for python 2.7
-RUN curl -sLo get-pip.py https://bootstrap.pypa.io/2.7/get-pip.py
+RUN curl -sLo get-pip.py https://bootstrap.pypa.io/pip/2.7/get-pip.py
 
 # Download edxapp release
 # Get default EDX_RELEASE_REF value (defined on top)
@@ -132,8 +132,9 @@ RUN pip install -r requirements/edx/pre.txt
 RUN pip install \
       astroid==1.6.0 \
       django==1.8.15 \
-      pip==9.0.3
+      pip==19.3.1
 RUN pip install --src /usr/local/src -r requirements/edx/github.txt
+RUN pip install pip==9.0.3
 RUN pip install -r requirements/edx/base.txt
 RUN pip install -r requirements/edx/paver.txt
 RUN pip install -r requirements/edx/post.txt

--- a/releases/eucalyptus/3/wb/requirements.txt
+++ b/releases/eucalyptus/3/wb/requirements.txt
@@ -1,6 +1,9 @@
 # FUN dependencies
 --extra-index-url https://pypi.fury.io/openfun/
 
+# ==== compatibility pinning ====
+rsa<4.7
+
 # ==== core ====
 configurable-lti-consumer-xblock==1.3.0
 edx-gea==0.2.0


### PR DESCRIPTION
## Purpose

The eucalyptus builds were broken after the `get-pip.py` script moved location.

## Proposal

- Modify url where the `get-pip.py` script is fetched
- Install the `github.txt` requirements with a newer version of pip than the other requirements files which require an older version...