### PR TITLE
🔊(dogwood/3/fun) add gelf configuration for logging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,13 +164,11 @@ jobs:
   # Note that the job name should match the EDX_RELEASE value
 
   # No changes detected for dogwood.3-bare
-  # No changes detected for dogwood.3-fun
-  # Run jobs for the eucalyptus.3-bare release
-  eucalyptus.3-bare:
+  # Run jobs for the dogwood.3-fun release
+  dogwood.3-fun:
     <<: [*defaults, *build_steps]
-  # Run jobs for the eucalyptus.3-wb release
-  eucalyptus.3-wb:
-    <<: [*defaults, *build_steps]
+  # No changes detected for eucalyptus.3-bare
+  # No changes detected for eucalyptus.3-wb
   # No changes detected for hawthorn.1-bare
   # No changes detected for hawthorn.1-oee
   # No changes detected for ironwood.2-bare
@@ -265,21 +263,15 @@ workflows:
       # Build jobs
 
       # No changes detected so no job to run for dogwood.3-bare
-      # No changes detected so no job to run for dogwood.3-fun
-      # Run jobs for the eucalyptus.3-bare release
-      - eucalyptus.3-bare:
+      # Run jobs for the dogwood.3-fun release
+      - dogwood.3-fun:
           requires:
             - check-configuration
           filters:
             tags:
               ignore: /.*/
-      # Run jobs for the eucalyptus.3-wb release
-      - eucalyptus.3-wb:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
+      # No changes detected so no job to run for eucalyptus.3-bare
+      # No changes detected so no job to run for eucalyptus.3-wb
       # No changes detected so no job to run for hawthorn.1-bare
       # No changes detected so no job to run for hawthorn.1-oee
       # No changes detected so no job to run for ironwood.2-bare

--- a/releases/dogwood/3/fun/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/lms/docker_run_production.py
@@ -451,6 +451,18 @@ LOGGING = {
     },
 }
 
+GRAYLOG_HOST = config("GRAYLOG_HOST", default=None)
+if GRAYLOG_HOST:
+    LOGGING["loggers"][""]["handlers"].append("gelf")
+    LOGGING["loggers"]["tracking"]["handlers"].append("gelf")
+    LOGGING["handlers"]["gelf"] = {
+        "level": "DEBUG",
+        "class": "djehouty.libgelf.handlers.GELFTCPSocketHandler",
+        "host": GRAYLOG_HOST,
+        "port": 12201,
+        "null_character": True,
+    }
+
 SENTRY_DSN = config("SENTRY_DSN", default=None)
 if SENTRY_DSN:
     LOGGING["loggers"][""]["handlers"].append("sentry")

--- a/releases/dogwood/3/fun/config/lms/settings.yml
+++ b/releases/dogwood/3/fun/config/lms/settings.yml
@@ -263,3 +263,6 @@ CROSS_DOMAIN_CSRF_COOKIE_DOMAIN: .local.dev
 PLATFORM_RICHIE_URL: http://richie.local.dev:8070
 
 VERIFIED_COHORTS: []
+
+# Graylog
+GRAYLOG_HOST: graylog


### PR DESCRIPTION
## Purpose

`ralph`'s development imposes to get access to tracking logs in GELF format to constitute a log dataset. 

## Proposal
A `gelf` handler has been added using djehouty library already supported in this release. This modification is binded to the [learning-analytics-playground](https://github.com/openfun/learning-analytics-playground/pull/1) project.