### PR TITLE
Fix/ironwood 2 build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,16 +165,16 @@ jobs:
 
   # No changes detected for dogwood.3-bare
   # No changes detected for dogwood.3-fun
-  # Run jobs for the eucalyptus.3-bare release
-  eucalyptus.3-bare:
-    <<: [*defaults, *build_steps]
-  # Run jobs for the eucalyptus.3-wb release
-  eucalyptus.3-wb:
-    <<: [*defaults, *build_steps]
+  # No changes detected for eucalyptus.3-bare
+  # No changes detected for eucalyptus.3-wb
   # No changes detected for hawthorn.1-bare
   # No changes detected for hawthorn.1-oee
-  # No changes detected for ironwood.2-bare
-  # No changes detected for ironwood.2-oee
+  # Run jobs for the ironwood.2-bare release
+  ironwood.2-bare:
+    <<: [*defaults, *build_steps]
+  # Run jobs for the ironwood.2-oee release
+  ironwood.2-oee:
+    <<: [*defaults, *build_steps]
   # No changes detected for master.0-bare
 
   # Hub job
@@ -266,24 +266,24 @@ workflows:
 
       # No changes detected so no job to run for dogwood.3-bare
       # No changes detected so no job to run for dogwood.3-fun
-      # Run jobs for the eucalyptus.3-bare release
-      - eucalyptus.3-bare:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
-      # Run jobs for the eucalyptus.3-wb release
-      - eucalyptus.3-wb:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
+      # No changes detected so no job to run for eucalyptus.3-bare
+      # No changes detected so no job to run for eucalyptus.3-wb
       # No changes detected so no job to run for hawthorn.1-bare
       # No changes detected so no job to run for hawthorn.1-oee
-      # No changes detected so no job to run for ironwood.2-bare
-      # No changes detected so no job to run for ironwood.2-oee
+      # Run jobs for the ironwood.2-bare release
+      - ironwood.2-bare:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
+      # Run jobs for the ironwood.2-oee release
+      - ironwood.2-oee:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
       # No changes detected so no job to run for master.0-bare
 
       # We are pushing to Docker only images that are the result of a tag respecting the pattern:

--- a/releases/ironwood/2/bare/CHANGELOG.md
+++ b/releases/ironwood/2/bare/CHANGELOG.md
@@ -9,6 +9,9 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix build by installing py2neo 3.1.2 from its github repository
 - Fix pip install for python 2.7
 
 ## [ironwood.2-1.0.0] - 2020-09-10

--- a/releases/ironwood/2/bare/Dockerfile
+++ b/releases/ironwood/2/bare/Dockerfile
@@ -40,7 +40,7 @@ RUN apt-get update && \
     apt-get install -y curl
 
 # Download pip installer for python 2.7
-RUN curl -sLo get-pip.py https://bootstrap.pypa.io/2.7/get-pip.py
+RUN curl -sLo get-pip.py https://bootstrap.pypa.io/pip/2.7/get-pip.py
 
 # Download edxapp release
 # Get default EDX_RELEASE_REF value (defined on top)
@@ -114,6 +114,13 @@ COPY --from=downloads /downloads/get-pip.py ./get-pip.py
 RUN python get-pip.py
 
 WORKDIR /edx/app/edxapp/edx-platform
+
+# Patches
+COPY patches/* /tmp/
+
+# Patches pre-install
+# Patch requirements to install py2neo==3.1.2 from github as this version has been removed from pypi.org
+RUN patch -p1 < /tmp/edx-platform_ironwood.2-bare_requirements-py2neo.patch
 
 # Install python dependencies
 RUN pip install --src /usr/local/src -r requirements/edx/base.txt

--- a/releases/ironwood/2/bare/patches/edx-platform_ironwood.2-bare_requirements-py2neo.patch
+++ b/releases/ironwood/2/bare/patches/edx-platform_ironwood.2-bare_requirements-py2neo.patch
@@ -1,0 +1,44 @@
+diff --git a/requirements/edx/base.txt b/requirements/edx/base.txt
+index 8a5f114..338d8a5 100644
+--- a/requirements/edx/base.txt
++++ b/requirements/edx/base.txt
+@@ -185,7 +185,8 @@ piexif==1.0.2
+ pillow==5.4.1
+ polib==1.1.0              # via edx-i18n-tools
+ psutil==1.2.1
+-py2neo==3.1.2
++# install py2neo==3.1.2 from github repository as 3.1.2 has been removed from pypi.org
++git+https://github.com/technige/py2neo@py2neo-3.1.2#egg=py2neo==3.1.2
+ pycontracts==1.7.1
+ pycountry==1.20
+ pycparser==2.19
+
+diff --git a/requirements/edx/development.txt b/requirements/edx/development.txt
+index 80ac873..cbb87b4 100644
+--- a/requirements/edx/development.txt
++++ b/requirements/edx/development.txt
+@@ -238,7 +238,8 @@ pip-tools==3.2.0
+ pluggy==0.8.1
+ polib==1.1.0
+ psutil==1.2.1
+-py2neo==3.1.2
++# install py2neo==3.1.2 from github repository as 3.1.2 has been removed from pypi.org
++git+https://github.com/technige/py2neo@py2neo-3.1.2#egg=py2neo==3.1.2
+ py==1.7.0
+ pyasn1-modules==0.2.3
+ pyasn1==0.4.5
+
+diff --git a/requirements/edx/testing.txt b/requirements/edx/testing.txt
+index 9d55925..0123ad4 100644
+--- a/requirements/edx/testing.txt
++++ b/requirements/edx/testing.txt
+@@ -228,7 +228,8 @@ pillow==5.4.1
+ pluggy==0.8.1             # via pytest, tox
+ polib==1.1.0
+ psutil==1.2.1
+-py2neo==3.1.2
++# install py2neo==3.1.2 from github repository as 3.1.2 has been removed from pypi.org
++git+https://github.com/technige/py2neo@py2neo-3.1.2#egg=py2neo==3.1.2
+ py==1.7.0                 # via pytest, tox
+ pyasn1-modules==0.2.3     # via service-identity
+ pyasn1==0.4.5             # via pyasn1-modules, service-identity

--- a/releases/ironwood/2/oee/CHANGELOG.md
+++ b/releases/ironwood/2/oee/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix build by installing py2neo 3.1.2 from its github repository
+
 ## [ironwood.2-oee-1.0.4] - 2021-03-04
 
 ### Fixed

--- a/releases/ironwood/2/oee/Dockerfile
+++ b/releases/ironwood/2/oee/Dockerfile
@@ -40,7 +40,7 @@ RUN apt-get update && \
     apt-get install -y curl
 
 # Download pip installer for python 2.7
-RUN curl -sLo get-pip.py https://bootstrap.pypa.io/2.7/get-pip.py
+RUN curl -sLo get-pip.py https://bootstrap.pypa.io/pip/2.7/get-pip.py
 
 # Download edxapp release
 # Get default EDX_RELEASE_REF value (defined on top)
@@ -119,12 +119,18 @@ RUN python get-pip.py
 
 WORKDIR /edx/app/edxapp/edx-platform
 
+# Patches
+COPY patches/* /tmp/
+
+# Patches pre-install
+# Patch requirements to install py2neo==3.1.2 from github as this version has been removed from pypi.org
+RUN patch -p1 < /tmp/edx-platform_ironwood.2-oee_requirements-py2neo.patch
+
 # Install python dependencies
 RUN pip install --src /usr/local/src -r requirements/edx/base.txt && \
     pip install -r requirements/edx/extend.txt
 
-# Patches
-COPY patches/* /tmp/
+# Patches post-install
 # Patch the CMS to activate our customizable LTI Xblock
 RUN patch -p1 < /tmp/edx-platform_ironwood.2-oee.patch
 # Patch ORA2 to hide empty file links

--- a/releases/ironwood/2/oee/patches/edx-platform_ironwood.2-oee_requirements-py2neo.patch
+++ b/releases/ironwood/2/oee/patches/edx-platform_ironwood.2-oee_requirements-py2neo.patch
@@ -1,0 +1,44 @@
+diff --git a/requirements/edx/base.txt b/requirements/edx/base.txt
+index 8a5f114..338d8a5 100644
+--- a/requirements/edx/base.txt
++++ b/requirements/edx/base.txt
+@@ -185,7 +185,8 @@ piexif==1.0.2
+ pillow==5.4.1
+ polib==1.1.0              # via edx-i18n-tools
+ psutil==1.2.1
+-py2neo==3.1.2
++# install py2neo==3.1.2 from github repository as 3.1.2 has been removed from pypi.org
++git+https://github.com/technige/py2neo@py2neo-3.1.2#egg=py2neo==3.1.2
+ pycontracts==1.7.1
+ pycountry==1.20
+ pycparser==2.19
+
+diff --git a/requirements/edx/development.txt b/requirements/edx/development.txt
+index 80ac873..cbb87b4 100644
+--- a/requirements/edx/development.txt
++++ b/requirements/edx/development.txt
+@@ -238,7 +238,8 @@ pip-tools==3.2.0
+ pluggy==0.8.1
+ polib==1.1.0
+ psutil==1.2.1
+-py2neo==3.1.2
++# install py2neo==3.1.2 from github repository as 3.1.2 has been removed from pypi.org
++git+https://github.com/technige/py2neo@py2neo-3.1.2#egg=py2neo==3.1.2
+ py==1.7.0
+ pyasn1-modules==0.2.3
+ pyasn1==0.4.5
+
+diff --git a/requirements/edx/testing.txt b/requirements/edx/testing.txt
+index 9d55925..0123ad4 100644
+--- a/requirements/edx/testing.txt
++++ b/requirements/edx/testing.txt
+@@ -228,7 +228,8 @@ pillow==5.4.1
+ pluggy==0.8.1             # via pytest, tox
+ polib==1.1.0
+ psutil==1.2.1
+-py2neo==3.1.2
++# install py2neo==3.1.2 from github repository as 3.1.2 has been removed from pypi.org
++git+https://github.com/technige/py2neo@py2neo-3.1.2#egg=py2neo==3.1.2
+ py==1.7.0                 # via pytest, tox
+ pyasn1-modules==0.2.3     # via service-identity
+ pyasn1==0.4.5             # via pyasn1-modules, service-identity


### PR DESCRIPTION
## Purpose

Currently it is not possible to build OpenEdX Ironwood. There are 2 causes:
- The link to download pip install for python 2.7 has changed
- This OpenEdX release used py2neo 3.1.2 but this dependency is no more available from pypi.

## Proposal

We have first to update the link to download pip install for python 2.7. Then as we cannot install py2neo==3.1.2 from pypi, we have to patch requirement files to download this dependency version directly from its github repository.

- [x] Fix ironwood/2/bare build
- [x] Fix ironwood/2/oee build
