### PR TITLE
Dogwood.3 fun upgrade to fun apps 5.10.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,17 +164,15 @@ jobs:
   # Note that the job name should match the EDX_RELEASE value
 
   # No changes detected for dogwood.3-bare
-  # No changes detected for dogwood.3-fun
+  # Run jobs for the dogwood.3-fun release
+  dogwood.3-fun:
+    <<: [*defaults, *build_steps]
   # No changes detected for eucalyptus.3-bare
   # No changes detected for eucalyptus.3-wb
   # No changes detected for hawthorn.1-bare
   # No changes detected for hawthorn.1-oee
-  # Run jobs for the ironwood.2-bare release
-  ironwood.2-bare:
-    <<: [*defaults, *build_steps]
-  # Run jobs for the ironwood.2-oee release
-  ironwood.2-oee:
-    <<: [*defaults, *build_steps]
+  # No changes detected for ironwood.2-bare
+  # No changes detected for ironwood.2-oee
   # No changes detected for master.0-bare
 
   # Hub job
@@ -265,25 +263,19 @@ workflows:
       # Build jobs
 
       # No changes detected so no job to run for dogwood.3-bare
-      # No changes detected so no job to run for dogwood.3-fun
+      # Run jobs for the dogwood.3-fun release
+      - dogwood.3-fun:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
       # No changes detected so no job to run for eucalyptus.3-bare
       # No changes detected so no job to run for eucalyptus.3-wb
       # No changes detected so no job to run for hawthorn.1-bare
       # No changes detected so no job to run for hawthorn.1-oee
-      # Run jobs for the ironwood.2-bare release
-      - ironwood.2-bare:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
-      # Run jobs for the ironwood.2-oee release
-      - ironwood.2-oee:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
+      # No changes detected so no job to run for ironwood.2-bare
+      # No changes detected so no job to run for ironwood.2-oee
       # No changes detected so no job to run for master.0-bare
 
       # We are pushing to Docker only images that are the result of a tag respecting the pattern:

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade fun-apps to v5.10.0 to stop synchronizing Elasticsearch index
+
 ## [dogwood.3-fun-2.1.1] - 2021-04-13
 
 ### Fixed

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-2.2.0] - 2021-07-08
+
 ### Changed
 
 - Upgrade fun-apps to v5.10.0 to stop synchronizing Elasticsearch index
@@ -409,7 +411,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.1.1...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.2.0...HEAD
+[dogwood.3-fun-2.2.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.1.1...dogwood.3-fun-2.2.0
 [dogwood.3-fun-2.1.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.1.0...dogwood.3-fun-2.1.1
 [dogwood.3-fun-2.1.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.0.0...dogwood.3-fun-2.1.0
 [dogwood.3-fun-2.0.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.18.3...dogwood.3-fun-2.0.0

--- a/releases/dogwood/3/fun/Dockerfile
+++ b/releases/dogwood/3/fun/Dockerfile
@@ -16,7 +16,8 @@ FROM base as builder
 USER root:root
 
 # Install builder system dependencies
-RUN apt-get update && \
+RUN sed -i.bak -r 's/(archive|security).ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list && \
+    apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y \
       rdfind \

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -4,7 +4,7 @@
 # ==== core ====
 edx-gea==0.2.0
 fonzie==0.2.0
-fun-apps==5.9.0
+fun-apps==5.10.0
 
 # ==== xblocks ====
 configurable_lti_consumer-xblock==1.3.0


### PR DESCRIPTION
### Changed
    
- Upgrade fun-apps to [v5.10.0](https://github.com/openfun/fun-apps/releases/tag/v5.10.0) to stop synchronizing Elasticsearch index

