### PR TITLE
Dogwood.3 fun upgrade to fun apps 5.10.1 and release dogwood.3-fun-2.2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,17 +164,15 @@ jobs:
   # Note that the job name should match the EDX_RELEASE value
 
   # No changes detected for dogwood.3-bare
-  # No changes detected for dogwood.3-fun
+  # Run jobs for the dogwood.3-fun release
+  dogwood.3-fun:
+    <<: [*defaults, *build_steps]
   # No changes detected for eucalyptus.3-bare
   # No changes detected for eucalyptus.3-wb
   # No changes detected for hawthorn.1-bare
   # No changes detected for hawthorn.1-oee
-  # Run jobs for the ironwood.2-bare release
-  ironwood.2-bare:
-    <<: [*defaults, *build_steps]
-  # Run jobs for the ironwood.2-oee release
-  ironwood.2-oee:
-    <<: [*defaults, *build_steps]
+  # No changes detected for ironwood.2-bare
+  # No changes detected for ironwood.2-oee
   # No changes detected for master.0-bare
 
   # Hub job
@@ -265,25 +263,19 @@ workflows:
       # Build jobs
 
       # No changes detected so no job to run for dogwood.3-bare
-      # No changes detected so no job to run for dogwood.3-fun
+      # Run jobs for the dogwood.3-fun release
+      - dogwood.3-fun:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
       # No changes detected so no job to run for eucalyptus.3-bare
       # No changes detected so no job to run for eucalyptus.3-wb
       # No changes detected so no job to run for hawthorn.1-bare
       # No changes detected so no job to run for hawthorn.1-oee
-      # Run jobs for the ironwood.2-bare release
-      - ironwood.2-bare:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
-      # Run jobs for the ironwood.2-oee release
-      - ironwood.2-oee:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
+      # No changes detected so no job to run for ironwood.2-bare
+      # No changes detected so no job to run for ironwood.2-oee
       # No changes detected so no job to run for master.0-bare
 
       # We are pushing to Docker only images that are the result of a tag respecting the pattern:

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix sources.list for Ubuntu 12.04 moved to old releases
+
 ### Changed
 
 - Upgrade fun-apps to v5.10.1 to stop synchronizing Elasticsearch index

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-2.2.0] - 2021-07-29
+
 ### Fixed
 
 - Fix sources.list for Ubuntu 12.04 moved to old releases
@@ -417,7 +419,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.1.1...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.2.0...HEAD
+[dogwood.3-fun-2.2.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.1.1...dogwood.3-fun-2.2.0
 [dogwood.3-fun-2.1.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.1.0...dogwood.3-fun-2.1.1
 [dogwood.3-fun-2.1.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.0.0...dogwood.3-fun-2.1.0
 [dogwood.3-fun-2.0.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.18.3...dogwood.3-fun-2.0.0

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade fun-apps to v5.10.1 to stop synchronizing Elasticsearch index
+
 ## [dogwood.3-fun-2.1.1] - 2021-04-13
 
 ### Fixed

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -13,6 +13,10 @@ release.
 
 - Fix sources.list for Ubuntu 12.04 moved to old releases
 
+### Removed
+
+- Broken Python development dependencies in Docker development image
+
 ### Changed
 
 - Upgrade fun-apps to v5.10.1 to stop synchronizing Elasticsearch index

--- a/releases/dogwood/3/fun/Dockerfile
+++ b/releases/dogwood/3/fun/Dockerfile
@@ -16,7 +16,8 @@ FROM base as builder
 USER root:root
 
 # Install builder system dependencies
-RUN apt-get update && \
+RUN sed -i.bak -r 's/(archive|security).ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list && \
+    apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y \
       rdfind \
@@ -140,7 +141,8 @@ ARG EDXAPP_STATIC_ROOT
 USER root:root
 
 # Apply security updates
-RUN apt-get update && \
+RUN sed -i.bak -r 's/(archive|security).ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list && \
+    apt-get update && \
     apt-get upgrade -y && \
     rm -rf /var/lib/apt/lists/*
 

--- a/releases/dogwood/3/fun/Dockerfile
+++ b/releases/dogwood/3/fun/Dockerfile
@@ -92,22 +92,9 @@ RUN groupadd --gid ${DOCKER_GID} edx || \
     git config --global user.name edx && \
     git config --global user.email edx@example.com
 
-# To prevent permission issues related to the non-priviledged user running in
-# development, we will install development dependencies in a python virtual
-# environment belonging to that user
-RUN pip install virtualenv==16.7.9
-
-# Create the virtualenv directory where we will install python development
-# dependencies
-RUN mkdir -p /edx/app/edxapp/venv && \
-    chown -R ${DOCKER_UID}:${DOCKER_GID} /edx/app/edxapp/venv
-
 # Change edxapp directory owner to allow the development image docker user to
 # perform installations from edxapp sources (yeah, I know...)
 RUN chown -R ${DOCKER_UID}:${DOCKER_GID} /edx/app/edxapp
-
-# Copy the entrypoint that will activate the virtualenv
-COPY ./entrypoint.sh /usr/local/bin/entrypoint.sh
 
 # Change sass-cache owner so that the development user has write permission.
 # This is required to run the update_assets paver task in development.
@@ -116,22 +103,6 @@ RUN chown -R ${DOCKER_UID}:${DOCKER_GID} /tmp/sass-cache
 # Switch to an un-privileged user matching the host user to prevent permission
 # issues with volumes (host folders)
 USER ${DOCKER_UID}:${DOCKER_GID}
-
-# Create the virtualenv with a non-priviledged user
-RUN virtualenv -p python2.7 --system-site-packages /edx/app/edxapp/venv
-
-# Install development dependencies in a virtualenv (we need to downgrade pip
-# for that)
-RUN bash -c "source /edx/app/edxapp/venv/bin/activate && \
-    pip install --upgrade pip==9.0.3 && \
-    pip install --no-cache-dir -r requirements/edx/development.txt"
-
-# Re-upgrade pip in the virtualenv for further install (when using sources with
-# volumes)
-RUN bash -c "source /edx/app/edxapp/venv/bin/activate && \
-    pip install --upgrade pip"
-
-ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]
 
 # === PRODUCTION ===
 FROM base as production

--- a/releases/dogwood/3/fun/Dockerfile
+++ b/releases/dogwood/3/fun/Dockerfile
@@ -2,7 +2,7 @@
 
 ARG DOCKER_UID=1000
 ARG DOCKER_GID=1000
-ARG EDX_BASE_IMAGE=fundocker/edxapp:dogwood.3-fun-1.18.3
+ARG EDX_BASE_IMAGE=fundocker/edxapp:dogwood.3-fun-2.1.1
 ARG EDXAPP_STATIC_ROOT=/edx/app/edxapp/staticfiles
 ARG NGINX_IMAGE_NAME=fundocker/openshift-nginx
 ARG NGINX_IMAGE_TAG=1.13

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -4,7 +4,7 @@
 # ==== core ====
 edx-gea==0.2.0
 fonzie==0.2.0
-fun-apps==5.9.0
+fun-apps==5.10.1
 
 # ==== xblocks ====
 configurable_lti_consumer-xblock==1.3.0


### PR DESCRIPTION

### Fixed

- Fix sources.list for Ubuntu 12.04 moved to old releases

### Removed

- Broken Python development dependencies in Docker development image

### Changed

- Upgrade fun-apps to v5.10.1 to stop synchronizing Elasticsearch index
