### PR TITLE
Upgrade dogwood.3 fun to fun apps 5.11.0 and make release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,11 +164,11 @@ jobs:
   # Note that the job name should match the EDX_RELEASE value
 
   # No changes detected for dogwood.3-bare
-  # No changes detected for dogwood.3-fun
-  # No changes detected for eucalyptus.3-bare
-  # Run jobs for the eucalyptus.3-wb release
-  eucalyptus.3-wb:
+  # Run jobs for the dogwood.3-fun release
+  dogwood.3-fun:
     <<: [*defaults, *build_steps]
+  # No changes detected for eucalyptus.3-bare
+  # No changes detected for eucalyptus.3-wb
   # No changes detected for hawthorn.1-bare
   # No changes detected for hawthorn.1-oee
   # No changes detected for ironwood.2-bare
@@ -263,15 +263,15 @@ workflows:
       # Build jobs
 
       # No changes detected so no job to run for dogwood.3-bare
-      # No changes detected so no job to run for dogwood.3-fun
-      # No changes detected so no job to run for eucalyptus.3-bare
-      # Run jobs for the eucalyptus.3-wb release
-      - eucalyptus.3-wb:
+      # Run jobs for the dogwood.3-fun release
+      - dogwood.3-fun:
           requires:
             - check-configuration
           filters:
             tags:
               ignore: /.*/
+      # No changes detected so no job to run for eucalyptus.3-bare
+      # No changes detected so no job to run for eucalyptus.3-wb
       # No changes detected so no job to run for hawthorn.1-bare
       # No changes detected so no job to run for hawthorn.1-oee
       # No changes detected so no job to run for ironwood.2-bare

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade `fun-apps` to v5.11.0 for protection against VideoFront downtimes
+
 ## [dogwood.3-fun-2.2.0] - 2021-07-29
 
 ### Fixed

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-2.3.0] - 2021-08-18
+
 ### Changed
 
 - Upgrade `fun-apps` to v5.11.0 for protection against VideoFront downtimes
@@ -423,7 +425,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.2.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.3.0...HEAD
+[dogwood.3-fun-2.3.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.2.0...dogwood.3-fun-2.3.0
 [dogwood.3-fun-2.2.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.1.1...dogwood.3-fun-2.2.0
 [dogwood.3-fun-2.1.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.1.0...dogwood.3-fun-2.1.1
 [dogwood.3-fun-2.1.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.0.0...dogwood.3-fun-2.1.0

--- a/releases/dogwood/3/fun/config/cms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/cms/docker_run_production.py
@@ -751,6 +751,8 @@ SUBTITLE_SUPPORTED_LANGUAGES = LazyChoicesSorter(
     if code not in ("zh-cn", "zh-tw")
 )
 
+VIDEOFRONT_CDN_BASE_URL = config("VIDEOFRONT_CDN_BASE_URL", default="")
+
 # Videofront subtitles cache
 CACHES["video_subtitles"] = {
     "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",

--- a/releases/dogwood/3/fun/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/lms/docker_run_production.py
@@ -1365,6 +1365,8 @@ FUN_ATTESTATION_LOGO_PATH = (
 )
 STUDENT_NAME_FOR_TEST_CERTIFICATE = "Test User"
 
+VIDEOFRONT_CDN_BASE_URL = config("VIDEOFRONT_CDN_BASE_URL", default="")
+
 # Videofront subtitles cache
 CACHES["video_subtitles"] = {
     "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -4,7 +4,7 @@
 # ==== core ====
 edx-gea==0.2.0
 fonzie==0.2.0
-fun-apps==5.10.1
+fun-apps==5.11.0
 
 # ==== xblocks ====
 configurable_lti_consumer-xblock==1.3.0


### PR DESCRIPTION
### Changed

- Upgrade `fun-apps` to 2.5.0+wb for protection against VideoFront downtimes
