### PR TITLE
Update config files to recover missing videofront CDN setting and release fix

### DIFF
--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-2.3.1] - 2021-08-19
+
 ### Fixed
 
 - Update config files in DockerFile even starting from an existing image
@@ -429,7 +431,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.3.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.3.1...HEAD
+[dogwood.3-fun-2.3.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.3.0...dogwood.3-fun-2.3.1
 [dogwood.3-fun-2.3.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.2.0...dogwood.3-fun-2.3.0
 [dogwood.3-fun-2.2.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.1.1...dogwood.3-fun-2.2.0
 [dogwood.3-fun-2.1.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.1.0...dogwood.3-fun-2.1.1

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Update config files in DockerFile even starting from an existing image
+
 ## [dogwood.3-fun-2.3.0] - 2021-08-18
 
 ### Changed

--- a/releases/dogwood/3/fun/Dockerfile
+++ b/releases/dogwood/3/fun/Dockerfile
@@ -10,6 +10,9 @@ ARG NGINX_IMAGE_TAG=1.13
 # === BASE ===
 FROM ${EDX_BASE_IMAGE} as base
 
+# Update config files
+COPY ./config /config
+
 # === BUILDER ===
 FROM base as builder
 


### PR DESCRIPTION
### Fixed

- Update config files in DockerFile even starting from an existing image
