### PR TITLE
Fix/master & hawthorn builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,16 +164,20 @@ jobs:
   # Note that the job name should match the EDX_RELEASE value
 
   # No changes detected for dogwood.3-bare
-  # Run jobs for the dogwood.3-fun release
-  dogwood.3-fun:
-    <<: [*defaults, *build_steps]
+  # No changes detected for dogwood.3-fun
   # No changes detected for eucalyptus.3-bare
   # No changes detected for eucalyptus.3-wb
-  # No changes detected for hawthorn.1-bare
-  # No changes detected for hawthorn.1-oee
+  # Run jobs for the hawthorn.1-bare release
+  hawthorn.1-bare:
+    <<: [*defaults, *build_steps]
+  # Run jobs for the hawthorn.1-oee release
+  hawthorn.1-oee:
+    <<: [*defaults, *build_steps]
   # No changes detected for ironwood.2-bare
   # No changes detected for ironwood.2-oee
-  # No changes detected for master.0-bare
+  # Run jobs for the master.0-bare release
+  master.0-bare:
+    <<: [*defaults, *build_steps]
 
   # Hub job
   hub:
@@ -263,20 +267,32 @@ workflows:
       # Build jobs
 
       # No changes detected so no job to run for dogwood.3-bare
-      # Run jobs for the dogwood.3-fun release
-      - dogwood.3-fun:
+      # No changes detected so no job to run for dogwood.3-fun
+      # No changes detected so no job to run for eucalyptus.3-bare
+      # No changes detected so no job to run for eucalyptus.3-wb
+      # Run jobs for the hawthorn.1-bare release
+      - hawthorn.1-bare:
           requires:
             - check-configuration
           filters:
             tags:
               ignore: /.*/
-      # No changes detected so no job to run for eucalyptus.3-bare
-      # No changes detected so no job to run for eucalyptus.3-wb
-      # No changes detected so no job to run for hawthorn.1-bare
-      # No changes detected so no job to run for hawthorn.1-oee
+      # Run jobs for the hawthorn.1-oee release
+      - hawthorn.1-oee:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
       # No changes detected so no job to run for ironwood.2-bare
       # No changes detected so no job to run for ironwood.2-oee
-      # No changes detected so no job to run for master.0-bare
+      # Run jobs for the master.0-bare release
+      - master.0-bare:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
 
       # We are pushing to Docker only images that are the result of a tag respecting the pattern:
       #    **{branch-name}-x.y.z**

--- a/releases/hawthorn/1/bare/CHANGELOG.md
+++ b/releases/hawthorn/1/bare/CHANGELOG.md
@@ -9,6 +9,9 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix build after get-pip.py script moved location
 - Fix pip install for python 2.7
 
 ## [hawthorn.1-3.3.0] - 2020-05-14

--- a/releases/hawthorn/1/bare/CHANGELOG.md
+++ b/releases/hawthorn/1/bare/CHANGELOG.md
@@ -11,6 +11,7 @@ release.
 
 ### Fixed
 
+- Fix build by installing py2neo 3.1.2 from its github repository
 - Fix build after get-pip.py script moved location
 - Fix pip install for python 2.7
 

--- a/releases/hawthorn/1/bare/Dockerfile
+++ b/releases/hawthorn/1/bare/Dockerfile
@@ -40,7 +40,7 @@ RUN apt-get update && \
     apt-get install -y curl
 
 # Download pip installer for python 2.7
-RUN curl -sLo get-pip.py https://bootstrap.pypa.io/2.7/get-pip.py
+RUN curl -sLo get-pip.py https://bootstrap.pypa.io/pip/2.7/get-pip.py
 
 # Download edxapp release
 # Get default EDX_RELEASE_REF value (defined on top)

--- a/releases/hawthorn/1/bare/Dockerfile
+++ b/releases/hawthorn/1/bare/Dockerfile
@@ -115,6 +115,13 @@ RUN python get-pip.py
 
 WORKDIR /edx/app/edxapp/edx-platform
 
+# Patches
+COPY patches/* /tmp/
+
+# Patches pre-install
+# Patch requirements to install py2neo==3.1.2 from github as this version has been removed from pypi.org
+RUN patch -p1 < /tmp/edx-platform_hawthorn.1-bare_requirements-py2neo.patch
+
 # Install python dependencies
 RUN pip install --src /usr/local/src -r requirements/edx/base.txt
 RUN pip install gunicorn==19.9.0

--- a/releases/hawthorn/1/bare/patches/edx-platform_hawthorn.1-bare_requirements-py2neo.patch
+++ b/releases/hawthorn/1/bare/patches/edx-platform_hawthorn.1-bare_requirements-py2neo.patch
@@ -1,0 +1,45 @@
+diff --git a/requirements/edx/base.txt b/requirements/edx/base.txt
+index f90b796..b5a7d62 100644
+--- a/requirements/edx/base.txt
++++ b/requirements/edx/base.txt
+@@ -183,7 +183,8 @@ piexif==1.0.2
+ pillow==3.4.0
+ polib==1.1.0              # via edx-i18n-tools
+ psutil==1.2.1
+-py2neo==3.1.2
++# install py2neo==3.1.2 from github repository as 3.1.2 has been removed from pypi.org
++git+https://github.com/technige/py2neo@py2neo-3.1.2#egg=py2neo==3.1.2
+ pycontracts==1.7.1
+ pycountry==1.20
+ pycparser==2.18
+
+diff --git a/requirements/edx/development.txt b/requirements/edx/development.txt
+index 4d69e60..c4662b0 100644
+--- a/requirements/edx/development.txt
++++ b/requirements/edx/development.txt
+@@ -238,7 +238,8 @@ pip-tools==2.0.2
+ pluggy==0.6.0
+ polib==1.1.0
+ psutil==1.2.1
+-py2neo==3.1.2
++# install py2neo==3.1.2 from github repository as 3.1.2 has been removed from pypi.org
++git+https://github.com/technige/py2neo@py2neo-3.1.2#egg=py2neo==3.1.2
+ py==1.5.4
+ pyasn1-modules==0.2.2
+ pyasn1==0.4.3
+
+
+diff --git a/requirements/edx/testing.txt b/requirements/edx/testing.txt
+index 23dd44a..44ed71e 100644
+--- a/requirements/edx/testing.txt
++++ b/requirements/edx/testing.txt
+@@ -227,7 +227,8 @@ pillow==3.4.0
+ pluggy==0.6.0             # via pytest, tox
+ polib==1.1.0
+ psutil==1.2.1
+-py2neo==3.1.2
++# install py2neo==3.1.2 from github repository as 3.1.2 has been removed from pypi.org
++git+https://github.com/technige/py2neo@py2neo-3.1.2#egg=py2neo==3.1.2
+ py==1.5.4                 # via pytest, tox
+ pyasn1-modules==0.2.2     # via service-identity
+ pyasn1==0.4.3             # via pyasn1-modules, service-identity

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -11,6 +11,7 @@ release.
 
 ### Fixed
 
+- Fix build by installing py2neo 3.1.2 from its github repository
 - Fix build after get-pip.py script moved location
 
 ## [hawthorn.1-oee-3.3.4] - 2021-03-04

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix build after get-pip.py script moved location
+
 ## [hawthorn.1-oee-3.3.4] - 2021-03-04
 
 ### Fixed

--- a/releases/hawthorn/1/oee/Dockerfile
+++ b/releases/hawthorn/1/oee/Dockerfile
@@ -40,7 +40,7 @@ RUN apt-get update && \
     apt-get install -y curl
 
 # Download pip installer for python 2.7
-RUN curl -sLo get-pip.py https://bootstrap.pypa.io/2.7/get-pip.py
+RUN curl -sLo get-pip.py https://bootstrap.pypa.io/pip/2.7/get-pip.py
 
 # Download edxapp release
 # Get default EDX_RELEASE_REF value (defined on top)

--- a/releases/hawthorn/1/oee/Dockerfile
+++ b/releases/hawthorn/1/oee/Dockerfile
@@ -119,12 +119,17 @@ RUN python get-pip.py
 
 WORKDIR /edx/app/edxapp/edx-platform
 
+# Patches
+COPY patches/* /tmp/
+
+# Patches pre-install
+# Patch requirements to install py2neo==3.1.2 from github as this version has been removed from pypi.org
+RUN patch -p1 < /tmp/edx-platform_hawthorn.1-oee_requirements-py2neo.patch
+
 # Install python dependencies
 RUN pip install --src /usr/local/src -r requirements/edx/base.txt && \
     pip install -r requirements/edx/extend.txt
 
-# Patches
-COPY patches/* /tmp/
 # Patch the CMS to activate our customizable LTI Xblock
 RUN patch -p1 < /tmp/edx-platform_hawthorn.1-oee.patch
 # Patch ORA2 to hide empty file links

--- a/releases/hawthorn/1/oee/patches/edx-platform_hawthorn.1-oee_requirements-py2neo.patch
+++ b/releases/hawthorn/1/oee/patches/edx-platform_hawthorn.1-oee_requirements-py2neo.patch
@@ -1,0 +1,45 @@
+diff --git a/requirements/edx/base.txt b/requirements/edx/base.txt
+index f90b796..b5a7d62 100644
+--- a/requirements/edx/base.txt
++++ b/requirements/edx/base.txt
+@@ -183,7 +183,8 @@ piexif==1.0.2
+ pillow==3.4.0
+ polib==1.1.0              # via edx-i18n-tools
+ psutil==1.2.1
+-py2neo==3.1.2
++# install py2neo==3.1.2 from github repository as 3.1.2 has been removed from pypi.org
++git+https://github.com/technige/py2neo@py2neo-3.1.2#egg=py2neo==3.1.2
+ pycontracts==1.7.1
+ pycountry==1.20
+ pycparser==2.18
+
+diff --git a/requirements/edx/development.txt b/requirements/edx/development.txt
+index 4d69e60..c4662b0 100644
+--- a/requirements/edx/development.txt
++++ b/requirements/edx/development.txt
+@@ -238,7 +238,8 @@ pip-tools==2.0.2
+ pluggy==0.6.0
+ polib==1.1.0
+ psutil==1.2.1
+-py2neo==3.1.2
++# install py2neo==3.1.2 from github repository as 3.1.2 has been removed from pypi.org
++git+https://github.com/technige/py2neo@py2neo-3.1.2#egg=py2neo==3.1.2
+ py==1.5.4
+ pyasn1-modules==0.2.2
+ pyasn1==0.4.3
+
+
+diff --git a/requirements/edx/testing.txt b/requirements/edx/testing.txt
+index 23dd44a..44ed71e 100644
+--- a/requirements/edx/testing.txt
++++ b/requirements/edx/testing.txt
+@@ -227,7 +227,8 @@ pillow==3.4.0
+ pluggy==0.6.0             # via pytest, tox
+ polib==1.1.0
+ psutil==1.2.1
+-py2neo==3.1.2
++# install py2neo==3.1.2 from github repository as 3.1.2 has been removed from pypi.org
++git+https://github.com/technige/py2neo@py2neo-3.1.2#egg=py2neo==3.1.2
+ py==1.5.4                 # via pytest, tox
+ pyasn1-modules==0.2.2     # via service-identity
+ pyasn1==0.4.3             # via pyasn1-modules, service-identity

--- a/releases/master/0/bare/CHANGELOG.md
+++ b/releases/master/0/bare/CHANGELOG.md
@@ -13,6 +13,9 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix build after get-pip.py script moved location
 - Fix pip install for python 2.7
 
 [unreleased]: https://github.com/openfun/openedx-docker

--- a/releases/master/0/bare/CHANGELOG.md
+++ b/releases/master/0/bare/CHANGELOG.md
@@ -15,6 +15,7 @@ release.
 
 ### Fixed
 
+- Fix build by installing py2neo 3.1.2 from its github repository
 - Fix build after get-pip.py script moved location
 - Fix pip install for python 2.7
 

--- a/releases/master/0/bare/Dockerfile
+++ b/releases/master/0/bare/Dockerfile
@@ -40,7 +40,7 @@ RUN apt-get update && \
     apt-get install -y curl
 
 # Download pip installer for python 2.7
-RUN curl -sLo get-pip.py https://bootstrap.pypa.io/2.7/get-pip.py
+RUN curl -sLo get-pip.py https://bootstrap.pypa.io/pip/2.7/get-pip.py
 
 # Download edxapp release
 # Get default EDX_RELEASE_REF value (defined on top)

--- a/releases/master/0/bare/Dockerfile
+++ b/releases/master/0/bare/Dockerfile
@@ -115,6 +115,13 @@ RUN python get-pip.py
 
 WORKDIR /edx/app/edxapp/edx-platform
 
+# Patches
+COPY patches/* /tmp/
+
+# Patches pre-install
+# Patch requirements to install py2neo==3.1.2 from github as this version has been removed from pypi.org
+RUN patch -p1 < /tmp/edx-platform_master.0-bare_requirements-py2neo.patch
+
 # Install python dependencies
 RUN pip install --src /usr/local/src -r requirements/edx/base.txt
 RUN pip install gunicorn==19.9.0

--- a/releases/master/0/bare/patches/edx-platform_master.0-bare_requirements-py2neo.patch
+++ b/releases/master/0/bare/patches/edx-platform_master.0-bare_requirements-py2neo.patch
@@ -1,0 +1,44 @@
+diff --git a/requirements/edx/base.txt b/requirements/edx/base.txt
+index 3860575..8dc42d3 100644
+--- a/requirements/edx/base.txt
++++ b/requirements/edx/base.txt
+@@ -184,7 +184,8 @@ piexif==1.0.2
+ pillow==5.2.0
+ polib==1.1.0              # via edx-i18n-tools
+ psutil==1.2.1
+-py2neo==3.1.2
++# install py2neo==3.1.2 from github repository as 3.1.2 has been removed from pypi.org
++git+https://github.com/technige/py2neo@py2neo-3.1.2#egg=py2neo==3.1.2
+ pycontracts==1.7.1
+ pycountry==1.20
+ pycparser==2.18
+
+diff --git a/./requirements/edx/development.txt b/./requirements/edx/development.txt
+index 66adefa..37cb757 100644
+--- a/./requirements/edx/development.txt
++++ b/./requirements/edx/development.txt
+@@ -237,7 +237,8 @@ pip-tools==2.0.2
+ pluggy==0.6.0
+ polib==1.1.0
+ psutil==1.2.1
+-py2neo==3.1.2
++# install py2neo==3.1.2 from github repository as 3.1.2 has been removed from pypi.org
++git+https://github.com/technige/py2neo@py2neo-3.1.2#egg=py2neo==3.1.2
+ py==1.5.4
+ pyasn1-modules==0.2.2
+ pyasn1==0.4.4
+
+diff --git a/requirements/edx/testing.txt b/requirements/edx/testing.txt
+index 3b35060..b9ff4cf 100644
+--- a/requirements/edx/testing.txt
++++ b/requirements/edx/testing.txt
+@@ -226,7 +226,8 @@ pillow==5.2.0
+ pluggy==0.6.0             # via pytest, tox
+ polib==1.1.0
+ psutil==1.2.1
+-py2neo==3.1.2
++# install py2neo==3.1.2 from github repository as 3.1.2 has been removed from pypi.org
++git+https://github.com/technige/py2neo@py2neo-3.1.2#egg=py2neo==3.1.2
+ py==1.5.4                 # via pytest, tox
+ pyasn1-modules==0.2.2     # via service-identity
+ pyasn1==0.4.4             # via pyasn1-modules, service-identity


### PR DESCRIPTION
## Purpose

Master and Hawthorn images are currently not able to build correctly for two reasons:
- path to retrieve get-pip.py for python 2.7 is outdated
- py2neo 3.1.2 is no more available from pypi

## Proposal

- [x] Update path to download get-pip.py
- [x] Patch requirements to install py2neo 3.1.2 from github
