### PR TITLE
Release session cookie secure fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,30 +163,14 @@ jobs:
   #
   # Note that the job name should match the EDX_RELEASE value
 
-  # Run jobs for the dogwood.3-fun release
-  dogwood.3-fun:
-    <<: [*defaults, *build_steps]
-  # Run jobs for the eucalyptus.3-bare release
-  eucalyptus.3-bare:
-    <<: [*defaults, *build_steps]
-  # Run jobs for the eucalyptus.3-wb release
-  eucalyptus.3-wb:
-    <<: [*defaults, *build_steps]
-  # Run jobs for the hawthorn.1-bare release
-  hawthorn.1-bare:
-    <<: [*defaults, *build_steps]
-  # Run jobs for the hawthorn.1-oee release
-  hawthorn.1-oee:
-    <<: [*defaults, *build_steps]
-  # Run jobs for the ironwood.2-bare release
-  ironwood.2-bare:
-    <<: [*defaults, *build_steps]
-  # Run jobs for the ironwood.2-oee release
-  ironwood.2-oee:
-    <<: [*defaults, *build_steps]
-  # Run jobs for the master.0-bare release
-  master.0-bare:
-    <<: [*defaults, *build_steps]
+  # No changes detected for dogwood.3-fun
+  # No changes detected for eucalyptus.3-bare
+  # No changes detected for eucalyptus.3-wb
+  # No changes detected for hawthorn.1-bare
+  # No changes detected for hawthorn.1-oee
+  # No changes detected for ironwood.2-bare
+  # No changes detected for ironwood.2-oee
+  # No changes detected for master.0-bare
 
   # Hub job
   hub:
@@ -275,62 +259,14 @@ workflows:
 
       # Build jobs
 
-      # Run jobs for the dogwood.3-fun release
-      - dogwood.3-fun:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
-      # Run jobs for the eucalyptus.3-bare release
-      - eucalyptus.3-bare:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
-      # Run jobs for the eucalyptus.3-wb release
-      - eucalyptus.3-wb:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
-      # Run jobs for the hawthorn.1-bare release
-      - hawthorn.1-bare:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
-      # Run jobs for the hawthorn.1-oee release
-      - hawthorn.1-oee:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
-      # Run jobs for the ironwood.2-bare release
-      - ironwood.2-bare:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
-      # Run jobs for the ironwood.2-oee release
-      - ironwood.2-oee:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
-      # Run jobs for the master.0-bare release
-      - master.0-bare:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
+      # No changes detected so no job to run for dogwood.3-fun
+      # No changes detected so no job to run for eucalyptus.3-bare
+      # No changes detected so no job to run for eucalyptus.3-wb
+      # No changes detected so no job to run for hawthorn.1-bare
+      # No changes detected so no job to run for hawthorn.1-oee
+      # No changes detected so no job to run for ironwood.2-bare
+      # No changes detected so no job to run for ironwood.2-oee
+      # No changes detected so no job to run for master.0-bare
 
       # We are pushing to Docker only images that are the result of a tag respecting the pattern:
       #    **{branch-name}-x.y.z**

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-2.3.2] - 2021-09-28
+
 ### Fixed
 
 - Set `SESSION_COOKIE_SECURE` to True by default
@@ -435,7 +437,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.3.1...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.3.2...HEAD
+[dogwood.3-fun-2.3.2]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.3.1...dogwood.3-fun-2.3.2
 [dogwood.3-fun-2.3.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.3.0...dogwood.3-fun-2.3.1
 [dogwood.3-fun-2.3.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.2.0...dogwood.3-fun-2.3.0
 [dogwood.3-fun-2.2.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.1.1...dogwood.3-fun-2.2.0

--- a/releases/eucalyptus/3/bare/CHANGELOG.md
+++ b/releases/eucalyptus/3/bare/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [eucalyptus.3-1.2.1] - 2021-08-28
+
 ### Fixed
 
 - Set `SESSION_COOKIE_SECURE` to True by default
@@ -99,7 +101,8 @@ release.
 
 - First experimental release of OpenEdx `eucalyptus.3` (bare flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.2.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.2.1...HEAD
+[eucalyptus.3-1.2.1]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.2.0...eucalyptus.3-1.2.1
 [eucalyptus.3-1.2.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.1.2...eucalyptus.3-1.2.0
 [eucalyptus.3-1.1.2]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.1.1...eucalyptus.3-1.1.2
 [eucalyptus.3-1.1.1]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-1.1.0...eucalyptus.3-1.1.1

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [eucalyptus.3-wb-1.10.1] - 2021-09-28
+
 ### Fixed
 
 - Set `SESSION_COOKIE_SECURE` to True by default
@@ -271,7 +273,8 @@ release.
 - Set replicaSet and read_preference in mongodb connection
 - Add missing support for redis sentinel
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.10.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.10.1...HEAD
+[eucalyptus.3-wb-1.10.1]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.10.0...eucalyptus.3-wb-1.10.1
 [eucalyptus.3-wb-1.10.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.9.4...eucalyptus.3-wb-1.10.0
 [eucalyptus.3-wb-1.9.4]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.9.3...eucalyptus.3-wb-1.9.4
 [eucalyptus.3-wb-1.9.3]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.9.2...eucalyptus.3-wb-1.9.3

--- a/releases/hawthorn/1/bare/CHANGELOG.md
+++ b/releases/hawthorn/1/bare/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [hawthorn.1-3.3.1] - 2021-09-28
+
 ### Fixed
 
 - Set `SESSION_COOKIE_SECURE` to True by default
@@ -252,7 +254,8 @@ result of updating our OpenEdX images from `ginkgo` to `hawthorn.1`. It is not
 functional and is intended for development and debugging work in
 [Arnold](https://github.com/openfun/arnold).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-3.3.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-3.3.1...HEAD
+[hawthorn.1-3.3.1]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-3.3.0...hawthorn.1-3.3.1
 [hawthorn.1-3.3.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-3.2.0...hawthorn.1-3.3.0
 [hawthorn.1-3.2.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-3.1.1...hawthorn.1-3.2.0
 [hawthorn.1-3.1.1]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-3.1.0...hawthorn.1-3.1.1

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [hawthorn.1-oee-3.3.5] - 2021-09-28
+
 ### Fixed
 
 - Set `SESSION_COOKIE_SECURE` to True by default
@@ -327,7 +329,8 @@ First release of OpenEdx extended.
 
 - Add a configurable LTI consumer xblock
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.3.4..HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.3.5..HEAD
+[hawthorn.1-oee-3.3.5]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.3.4...hawthorn.1-oee-3.3.5
 [hawthorn.1-oee-3.3.4]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.3.3...hawthorn.1-oee-3.3.4
 [hawthorn.1-oee-3.3.3]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.3.2...hawthorn.1-oee-3.3.3
 [hawthorn.1-oee-3.3.2]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.3.1...hawthorn.1-oee-3.3.2

--- a/releases/ironwood/2/bare/CHANGELOG.md
+++ b/releases/ironwood/2/bare/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [ironwood.2-1.0.1] - 2021-09-28
+
 ### Fixed
 
 - Set `SESSION_COOKIE_SECURE` to True by default
@@ -18,3 +20,6 @@ release.
 ## [ironwood.2-1.0.0] - 2020-09-10
 
 - First release of an `ironwood.2-bare` Docker image.
+
+[unreleased]: https://github.com/openfun/openedx-docker/compare/ironwood.2-1.0.1...HEAD
+[ironwood.2-1.0.1]: https://github.com/openfun/openedx-docker/compare/ironwood.2-1.0.0...ironwood.2-1.0.1

--- a/releases/ironwood/2/oee/CHANGELOG.md
+++ b/releases/ironwood/2/oee/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [ironwood.2-oee-1.0.5] - 2021-09-28
+
 ### Fixed
 
 - Set `SESSION_COOKIE_SECURE` to True by default
@@ -43,7 +45,8 @@ release.
 
 - First release of an `ironwood.2-oee` Docker image.
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/ironwood.2-oee-1.0.4...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/ironwood.2-oee-1.0.5...HEAD
+[ironwood.2-oee-1.0.5]: https://github.com/openfun/openedx-docker/compare/ironwood.2-oee-1.0.4...ironwood.2-oee-1.0.5
 [ironwood.2-oee-1.0.4]: https://github.com/openfun/openedx-docker/compare/ironwood.2-oee-1.0.3...ironwood.2-oee-1.0.4
 [ironwood.2-oee-1.0.3]: https://github.com/openfun/openedx-docker/compare/ironwood.2-oee-1.0.2...ironwood.2-oee-1.0.3
 [ironwood.2-oee-1.0.2]: https://github.com/openfun/openedx-docker/compare/ironwood.2-oee-1.0.1...ironwood.2-oee-1.0.2


### PR DESCRIPTION
## 🔖 ironwood.2-oee-1.0.5
    
### Fixed

- Set `SESSION_COOKIE_SECURE` to True by default
- Fix build by installing py2neo 3.1.2 from its github repository

## 🔖 ironwood.2-1.0.1

### Fixed

- Set `SESSION_COOKIE_SECURE` to True by default
- Fix build by installing py2neo 3.1.2 from its github repository
- Fix pip install for python 2.7

## 🔖 hawthorn.1-oee-3.3.5

### Fixed

- Set `SESSION_COOKIE_SECURE` to True by default
- Fix build by installing py2neo 3.1.2 from its github repository
- Fix build after get-pip.py script moved location

## 🔖 hawthorn.1-3.3.1

### Fixed

- Set `SESSION_COOKIE_SECURE` to True by default
- Fix build by installing py2neo 3.1.2 from its github repository
- Fix build after get-pip.py script moved location
- Fix pip install for python 2.7

## 🔖 eucalyptus.3-wb-1.10.1

### Fixed

- Set `SESSION_COOKIE_SECURE` to True by default

## 🔖 eucalyptus.3-1.2.1

### Fixed

- Set `SESSION_COOKIE_SECURE` to True by default
- Fix build after get-pip.py script moved location

## 🔖 dogwood.3-fun-2.3.2

### Fixed

- Set `SESSION_COOKIE_SECURE` to True by default
