### PR TITLE
♻️(dogwood/3/fun) revert to building the image from scratch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,9 @@ jobs:
   #
   # Note that the job name should match the EDX_RELEASE value
 
-  # No changes detected for dogwood.3-fun
+  # Run jobs for the dogwood.3-fun release
+  dogwood.3-fun:
+    <<: [*defaults, *build_steps]
   # No changes detected for eucalyptus.3-bare
   # No changes detected for eucalyptus.3-wb
   # No changes detected for hawthorn.1-bare
@@ -259,7 +261,13 @@ workflows:
 
       # Build jobs
 
-      # No changes detected so no job to run for dogwood.3-fun
+      # Run jobs for the dogwood.3-fun release
+      - dogwood.3-fun:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
       # No changes detected so no job to run for eucalyptus.3-bare
       # No changes detected so no job to run for eucalyptus.3-wb
       # No changes detected so no job to run for hawthorn.1-bare

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,14 +7,9 @@
 version: 2
 
 # Templates
-defaults: &defaults # We use the machine executor, i.e. a VM, not a container
+defaults: &defaults
   machine:
-    # Cache docker layers so that we strongly speed up this job execution
-    # This cache will be available to future jobs (although because jobs run
-    # in parallel, CircleCI does not guarantee that a given job will see a
-    # specific version of the cache. See documentation for details)
-    docker_layer_caching: true
-
+    image: ubuntu-2004:202111-02
   working_directory: ~/fun
 
 build_steps: &build_steps
@@ -150,14 +145,12 @@ jobs:
             test $(cat CHANGELOG.md | grep -Ev "^\[.*\]: https://github.com/openfun" | wc -L) -le 80
 
   check-configuration:
-    machine:
-        docker_layer_caching: true
+    <<: *defaults
     steps:
       - checkout
       - run:
           name: Check that the circle-ci config.yml file has been updated in the current branch
           command: bin/ci check_configuration
-    working_directory: ~/fun
 
   # Build jobs
   #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,8 +159,12 @@ jobs:
   # Run jobs for the dogwood.3-fun release
   dogwood.3-fun:
     <<: [*defaults, *build_steps]
-  # No changes detected for eucalyptus.3-bare
-  # No changes detected for eucalyptus.3-wb
+  # Run jobs for the eucalyptus.3-bare release
+  eucalyptus.3-bare:
+    <<: [*defaults, *build_steps]
+  # Run jobs for the eucalyptus.3-wb release
+  eucalyptus.3-wb:
+    <<: [*defaults, *build_steps]
   # No changes detected for hawthorn.1-bare
   # No changes detected for hawthorn.1-oee
   # No changes detected for ironwood.2-bare
@@ -261,8 +265,20 @@ workflows:
           filters:
             tags:
               ignore: /.*/
-      # No changes detected so no job to run for eucalyptus.3-bare
-      # No changes detected so no job to run for eucalyptus.3-wb
+      # Run jobs for the eucalyptus.3-bare release
+      - eucalyptus.3-bare:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
+      # Run jobs for the eucalyptus.3-wb release
+      - eucalyptus.3-wb:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
       # No changes detected so no job to run for hawthorn.1-bare
       # No changes detected so no job to run for hawthorn.1-oee
       # No changes detected so no job to run for ironwood.2-bare

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,11 +165,21 @@ jobs:
   # Run jobs for the eucalyptus.3-wb release
   eucalyptus.3-wb:
     <<: [*defaults, *build_steps]
-  # No changes detected for hawthorn.1-bare
-  # No changes detected for hawthorn.1-oee
-  # No changes detected for ironwood.2-bare
-  # No changes detected for ironwood.2-oee
-  # No changes detected for master.0-bare
+  # Run jobs for the hawthorn.1-bare release
+  hawthorn.1-bare:
+    <<: [*defaults, *build_steps]
+  # Run jobs for the hawthorn.1-oee release
+  hawthorn.1-oee:
+    <<: [*defaults, *build_steps]
+  # Run jobs for the ironwood.2-bare release
+  ironwood.2-bare:
+    <<: [*defaults, *build_steps]
+  # Run jobs for the ironwood.2-oee release
+  ironwood.2-oee:
+    <<: [*defaults, *build_steps]
+  # Run jobs for the master.0-bare release
+  master.0-bare:
+    <<: [*defaults, *build_steps]
 
   # Hub job
   hub:
@@ -279,11 +289,41 @@ workflows:
           filters:
             tags:
               ignore: /.*/
-      # No changes detected so no job to run for hawthorn.1-bare
-      # No changes detected so no job to run for hawthorn.1-oee
-      # No changes detected so no job to run for ironwood.2-bare
-      # No changes detected so no job to run for ironwood.2-oee
-      # No changes detected so no job to run for master.0-bare
+      # Run jobs for the hawthorn.1-bare release
+      - hawthorn.1-bare:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
+      # Run jobs for the hawthorn.1-oee release
+      - hawthorn.1-oee:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
+      # Run jobs for the ironwood.2-bare release
+      - ironwood.2-bare:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
+      # Run jobs for the ironwood.2-oee release
+      - ironwood.2-oee:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
+      # Run jobs for the master.0-bare release
+      - master.0-bare:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
 
       # We are pushing to Docker only images that are the result of a tag respecting the pattern:
       #    **{branch-name}-x.y.z**

--- a/.circleci/src/config.tpl
+++ b/.circleci/src/config.tpl
@@ -3,14 +3,9 @@
 version: 2
 
 # Templates
-defaults: &defaults # We use the machine executor, i.e. a VM, not a container
+defaults: &defaults
   machine:
-    # Cache docker layers so that we strongly speed up this job execution
-    # This cache will be available to future jobs (although because jobs run
-    # in parallel, CircleCI does not guarantee that a given job will see a
-    # specific version of the cache. See documentation for details)
-    docker_layer_caching: true
-
+    image: ubuntu-2004:202111-02
   working_directory: ~/fun
 
 build_steps: &build_steps
@@ -146,14 +141,12 @@ jobs:
             test $(cat CHANGELOG.md | grep -Ev "^\[.*\]: https://github.com/openfun" | wc -L) -le 80
 
   check-configuration:
-    machine:
-        docker_layer_caching: true
+    <<: *defaults
     steps:
       - checkout
       - run:
           name: Check that the circle-ci config.yml file has been updated in the current branch
           command: bin/ci check_configuration
-    working_directory: ~/fun
 
   # Build jobs
   #

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Changed
+
+- Revert to building the image directly from the plain Ubuntu 12.04 image
+
 ## [dogwood.3-fun-2.3.2] - 2021-09-28
 
 ### Fixed

--- a/releases/dogwood/3/fun/Dockerfile
+++ b/releases/dogwood/3/fun/Dockerfile
@@ -236,7 +236,7 @@ RUN groupadd --gid ${DOCKER_GID} edx || \
     git config --global user.name edx && \
     git config --global user.email edx@example.com
 
-# To prevent permission issues related to the non-priviledged user running in
+# To prevent permission issues related to the non-privileged user running in
 # development, we will install development dependencies in a python virtual
 # environment belonging to that user
 RUN pip install virtualenv==16.7.9
@@ -261,7 +261,7 @@ RUN chown -R ${DOCKER_UID}:${DOCKER_GID} /tmp/sass-cache
 # issues with volumes (host folders)
 USER ${DOCKER_UID}:${DOCKER_GID}
 
-# Create the virtualenv with a non-priviledged user
+# Create the virtualenv with a non-privileged user
 RUN virtualenv -p python2.7 --system-site-packages /edx/app/edxapp/venv
 
 # Install development dependencies in a virtualenv (we need to downgrade pip

--- a/releases/dogwood/3/fun/Dockerfile
+++ b/releases/dogwood/3/fun/Dockerfile
@@ -1,32 +1,149 @@
 # EDX-PLATFORM multi-stage docker build
 
+# Change release to build, by providing the EDX_RELEASE_REF build argument to
+# your build command:
+#
+# $ docker build \
+#     --build-arg EDX_RELEASE_REF="named-release/dogwood.3" \
+#     -t edxapp:dogwood.3-fun \
+#     .
 ARG DOCKER_UID=1000
 ARG DOCKER_GID=1000
-ARG EDX_BASE_IMAGE=fundocker/edxapp:dogwood.3-fun-2.1.1
+ARG EDX_RELEASE_REF=dogwood.3-fun-5.3.3
+ARG EDX_ARCHIVE_URL=https://github.com/openfun/edx-platform/archive/dogwood.3-fun-5.3.3.tar.gz
 ARG EDXAPP_STATIC_ROOT=/edx/app/edxapp/staticfiles
 ARG NGINX_IMAGE_NAME=fundocker/openshift-nginx
 ARG NGINX_IMAGE_TAG=1.13
+ARG PYTHON_VERSION=2.7.18
+
 
 # === BASE ===
-FROM ${EDX_BASE_IMAGE} as base
+FROM ubuntu:12.04 as base
 
-# Update config files
-COPY ./config /config
-
-# === BUILDER ===
-FROM base as builder
-
-USER root:root
-
-# Install builder system dependencies
+# System dependencies
 RUN sed -i.bak -r 's/(archive|security).ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list && \
     apt-get update && \
+    apt-get install -y \
+      gcc \
+      gettext \
+      libssl-dev \
+      locales \
+      make \
+      tzdata \
+      zlib1g-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+# Configure locales and timezone
+RUN echo 'en_US.UTF-8 UTF-8' > /var/lib/locales/supported.d/local && \
+    dpkg-reconfigure locales
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+# Upgrade Python 2.7 to its latest version from source
+WORKDIR /tmp/
+
+ARG PYTHON_VERSION
+RUN curl -sLo Python-${PYTHON_VERSION}.tgz https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz \
+  && tar --extract -f Python-${PYTHON_VERSION}.tgz \
+  && cd ./Python-${PYTHON_VERSION}/ \
+  && ./configure --enable-optimizations --prefix=/usr/local \
+  && make && make install \
+  && cd ../ \
+  && rm -r ./Python-${PYTHON_VERSION}*
+
+
+# === DOWNLOAD ===
+FROM base as downloads
+
+WORKDIR /downloads
+
+# Download pip installer for python 2.7
+RUN curl -sLo get-pip.py https://bootstrap.pypa.io/pip/2.7/get-pip.py
+
+# Download edxapp release
+ARG EDX_ARCHIVE_URL
+RUN curl -sLo edxapp.tgz $EDX_ARCHIVE_URL && \
+    tar xzf edxapp.tgz
+
+
+# === EDXAPP ===
+FROM base as edxapp
+
+# Install apt https support (required to use node sources repository)
+RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y \
+      apt-transport-https
+
+# Add a recent release of nodejs to apt sources (ubuntu package for precise is
+# broken)
+RUN echo "deb https://deb.nodesource.com/node_10.x trusty main" \
+	> /etc/apt/sources.list.d/nodesource.list && \
+    curl -s 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key' | apt-key add -
+
+# Install base system dependencies
+RUN apt-get update && \
+    apt-get install -y \
+      nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /edx/app/edxapp/edx-platform
+
+COPY --from=downloads /downloads/edx-platform-* .
+
+COPY ./requirements.txt /edx/app/edxapp/edx-platform/requirements/edx/fun.txt
+
+# We copy default configuration files to "/config" and we point to them via
+# symlinks. That allows to easily override default configurations by mounting a
+# docker volume.
+COPY ./config /config
+RUN ln -sf /config/lms /edx/app/edxapp/edx-platform/lms/envs/fun && \
+    ln -sf /config/cms /edx/app/edxapp/edx-platform/cms/envs/fun
+
+# Add node_modules/.bin to the PATH so that paver-related commands can execute
+# node scripts
+ENV PATH="/edx/app/edxapp/edx-platform/node_modules/.bin:${PATH}"
+
+# OpenEdx requires this environment variable to be defined, or else, it will
+# try to get the current Git reference. Since we don't use a Git clone to
+# build this release, we force the revision to be the release reference.
+ARG EDX_RELEASE_REF
+ENV EDX_PLATFORM_REVISION=${EDX_RELEASE_REF:-named-release/dogwood.3}
+
+
+# === BUILDER ===
+FROM edxapp as builder
+
+WORKDIR /builder
+
+# Install builder system dependencies
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y \
+      build-essential \
+      gfortran \
+      git-core \
+      graphviz \
+      graphviz-dev \
+      language-pack-en \
+      libffi-dev \
+      libfreetype6-dev \
+      libgeos-dev \
+      libjpeg8-dev \
+      liblapack-dev \
+      libmysqlclient-dev \
+      libxml2-dev \
+      libxmlsec1-dev \
+      libxslt1-dev \
+      pkg-config \
       rdfind \
       ruby1.9.1-dev \
-      rubygems1.9.1 && \
+      software-properties-common \
+      swig && \
     rm -rf /var/lib/apt/lists/*
+
+WORKDIR /edx/app/edxapp/edx-platform
 
 # Install Javascript requirements
 RUN npm install
@@ -35,11 +152,34 @@ RUN npm install
 RUN gem install bundler -v 1.17.3 && \
     bundle install
 
-# Update only fun requirements
-COPY ./requirements.txt /edx/app/edxapp/edx-platform/requirements/edx/fun.txt
+COPY --from=downloads /downloads/get-pip.py ./get-pip.py
+RUN python get-pip.py
+
+# Install python dependencies
+#
+RUN pip install -r requirements/edx/pre.txt
+# We need specific versions of pip and setuptools to handle the different
+# ways to declare Python dependencies in OpenEdX 😅
+RUN pip install \
+    pip==9.0.3 \
+    setuptools==44.1.1
+
+RUN pip install --src /usr/local/src -r requirements/edx/github.txt
+# Uninstall django==1.4.22 which gets installed because of django-wiki.
+# Otherwise 1.8.12 is installed on top of 1.4.22 in the next step and causes
+# a build failure.
+RUN pip uninstall --yes django
+RUN pip install -r requirements/edx/base.txt
+RUN pip install -r requirements/edx/paver.txt
+RUN pip install -r requirements/edx/post.txt
+# Upgrade pip once again so that eggs (local.txt) are properly installed
+RUN pip install --upgrade pip
+RUN pip install -r requirements/edx/local.txt
+# Installing FUN requirements needs a recent pip release (we are using
+# setup.cfg declarative packages)
 RUN pip install -r requirements/edx/fun.txt
 
-# Update assets skipping collectstatic
+# Update assets skipping collectstatic (it should be done during deployment)
 RUN NO_PREREQ_INSTALL=1 \
     paver update_assets --settings=fun.docker_build_production --skip-collect
 
@@ -55,6 +195,7 @@ RUN python manage.py lms collectstatic --link --noinput --settings=fun.docker_bu
 # final image
 RUN rdfind -makesymlinks true -followsymlinks true ${EDXAPP_STATIC_ROOT}
 
+
 # === STATIC FILES COLLECTOR ===
 FROM builder as files_collector
 
@@ -67,12 +208,12 @@ RUN python manage.py lms collectstatic --noinput --settings=fun.docker_build_pro
 # final image
 RUN rdfind -makesymlinks true ${EDXAPP_STATIC_ROOT}
 
+
 # === DEVELOPMENT ===
 FROM builder as development
 
 ARG DOCKER_UID
 ARG DOCKER_GID
-ARG EDX_RELEASE_REF
 
 # Install system dependencies
 RUN apt-get update && \
@@ -95,9 +236,22 @@ RUN groupadd --gid ${DOCKER_GID} edx || \
     git config --global user.name edx && \
     git config --global user.email edx@example.com
 
+# To prevent permission issues related to the non-priviledged user running in
+# development, we will install development dependencies in a python virtual
+# environment belonging to that user
+RUN pip install virtualenv==16.7.9
+
+# Create the virtualenv directory where we will install python development
+# dependencies
+RUN mkdir -p /edx/app/edxapp/venv && \
+    chown -R ${DOCKER_UID}:${DOCKER_GID} /edx/app/edxapp/venv
+
 # Change edxapp directory owner to allow the development image docker user to
 # perform installations from edxapp sources (yeah, I know...)
 RUN chown -R ${DOCKER_UID}:${DOCKER_GID} /edx/app/edxapp
+
+# Copy the entrypoint that will activate the virtualenv
+COPY ./entrypoint.sh /usr/local/bin/entrypoint.sh
 
 # Change sass-cache owner so that the development user has write permission.
 # This is required to run the update_assets paver task in development.
@@ -107,17 +261,39 @@ RUN chown -R ${DOCKER_UID}:${DOCKER_GID} /tmp/sass-cache
 # issues with volumes (host folders)
 USER ${DOCKER_UID}:${DOCKER_GID}
 
+# Create the virtualenv with a non-priviledged user
+RUN virtualenv -p python2.7 --system-site-packages /edx/app/edxapp/venv
+
+# Install development dependencies in a virtualenv (we need to downgrade pip
+# for that)
+RUN bash -c "source /edx/app/edxapp/venv/bin/activate && \
+    pip install --upgrade pip==9.0.3 && \
+    pip install --no-cache-dir -r requirements/edx/development.txt"
+
+# Re-upgrade pip in the virtualenv for further install (when using sources with
+# volumes)
+RUN bash -c "source /edx/app/edxapp/venv/bin/activate && \
+    pip install --upgrade pip"
+
+ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]
+
+
 # === PRODUCTION ===
-FROM base as production
+FROM edxapp as production
 
 ARG EDXAPP_STATIC_ROOT
 
-USER root:root
-
-# Apply security updates
-RUN sed -i.bak -r 's/(archive|security).ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list && \
-    apt-get update && \
+# Install runner system dependencies
+RUN apt-get update && \
     apt-get upgrade -y && \
+    apt-get install -y \
+    libgeos-dev \
+    libjpeg8 \
+    libmysqlclient18 \
+    libxml2 \
+    libxmlsec1-dev \
+    lynx \
+    tzdata && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy installed dependencies
@@ -132,6 +308,36 @@ COPY --from=links_collector ${EDXAPP_STATIC_ROOT} ${EDXAPP_STATIC_ROOT}
 # Now that dependencies are installed and configuration has been set, the above
 # statements will run with a un-privileged user.
 USER 10000
+
+# To start the CMS, inject the SERVICE_VARIANT=cms environment variable
+# (defaults to "lms")
+ENV SERVICE_VARIANT=lms
+
+# Gunicorn configuration
+#
+# As some synchronous requests may be quite long (e.g. courses import), we
+# should make timeout rather high and configurable so that it could be
+# increased without having to make a new release of this image
+#
+ENV GUNICORN_TIMEOUT 300
+
+# In docker we must increase the number of workers and threads created
+# by gunicorn.
+# This blogpost explains why and how to do that https://pythonspeed.com/articles/gunicorn-in-docker/
+ENV GUNICORN_WORKERS 3
+ENV GUNICORN_THREADS 6
+
+# Use Gunicorn in production as web server
+CMD DJANGO_SETTINGS_MODULE=${SERVICE_VARIANT}.envs.fun.docker_run \
+    gunicorn \
+      --name=${SERVICE_VARIANT} \
+      --bind=0.0.0.0:8000 \
+      --max-requests=1000 \
+      --timeout=${GUNICORN_TIMEOUT} \
+      --workers=${GUNICORN_WORKERS} \
+      --threads=${GUNICORN_THREADS} \
+      ${SERVICE_VARIANT}.wsgi:application
+
 
 # === NGINX ===
 FROM ${NGINX_IMAGE_NAME}:${NGINX_IMAGE_TAG} as nginx

--- a/releases/eucalyptus/3/bare/Dockerfile
+++ b/releases/eucalyptus/3/bare/Dockerfile
@@ -205,7 +205,7 @@ RUN groupadd --gid ${DOCKER_GID} edx || \
       edx || \
     echo "Skip user creation (user with ID ${DOCKER_UID} already exists?)"
 
-# To prevent permission issues related to the non-priviledged user running in
+# To prevent permission issues related to the non-privileged user running in
 # development, we will install development dependencies in a python virtual
 # environment belonging to that user
 RUN pip install virtualenv
@@ -230,7 +230,7 @@ RUN pip uninstall -y pyOpenSSL
 # issues with volumes (host folders)
 USER ${DOCKER_UID}:${DOCKER_GID}
 
-# Create the virtualenv with a non-priviledged user
+# Create the virtualenv with a non-privileged user
 RUN virtualenv -p python2.7 --system-site-packages /edx/app/edxapp/venv
 
 # Install development dependencies in a virtualenv

--- a/releases/eucalyptus/3/bare/Dockerfile
+++ b/releases/eucalyptus/3/bare/Dockerfile
@@ -126,6 +126,9 @@ WORKDIR /edx/app/edxapp/edx-platform
 # trying to install a python 2.7 incompatible release
 RUN pip install -r requirements/edx/pre.txt
 RUN pip install \
+    django-braces==1.14.0 \
+    wrapt==1.12.1 \
+    lazy-object-proxy==1.5.2 \
     astroid==1.6.0 \
     django==1.8.15 \
     pip==9.0.3

--- a/releases/eucalyptus/3/wb/Dockerfile
+++ b/releases/eucalyptus/3/wb/Dockerfile
@@ -130,6 +130,9 @@ WORKDIR /edx/app/edxapp/edx-platform
 # trying to install a python 2.7 incompatible release
 RUN pip install -r requirements/edx/pre.txt
 RUN pip install \
+    django-braces==1.14.0 \
+    wrapt==1.12.1 \
+    lazy-object-proxy==1.5.2 \
     astroid==1.6.0 \
     django==1.8.15 \
     pip==9.0.3

--- a/releases/eucalyptus/3/wb/Dockerfile
+++ b/releases/eucalyptus/3/wb/Dockerfile
@@ -207,7 +207,7 @@ RUN groupadd --gid ${DOCKER_GID} edx || \
       edx || \
     echo "Skip user creation (user with ID ${DOCKER_UID} already exists?)"
 
-# To prevent permission issues related to the non-priviledged user running in
+# To prevent permission issues related to the non-privileged user running in
 # development, we will install development dependencies in a python virtual
 # environment belonging to that user
 RUN pip install virtualenv
@@ -228,7 +228,7 @@ COPY ./entrypoint.sh /usr/local/bin/entrypoint.sh
 # issues with volumes (host folders)
 USER ${DOCKER_UID}:${DOCKER_GID}
 
-# Create the virtualenv with a non-priviledged user
+# Create the virtualenv with a non-privileged user
 RUN virtualenv -p python2.7 --system-site-packages /edx/app/edxapp/venv
 
 # Install development dependencies in a virtualenv

--- a/releases/hawthorn/1/bare/Dockerfile
+++ b/releases/hawthorn/1/bare/Dockerfile
@@ -182,7 +182,7 @@ RUN groupadd --gid ${DOCKER_GID} edx || \
       edx || \
     echo "Skip user creation (user with ID ${DOCKER_UID} already exists?)"
 
-# To prevent permission issues related to the non-priviledged user running in
+# To prevent permission issues related to the non-privileged user running in
 # development, we will install development dependencies in a python virtual
 # environment belonging to that user
 RUN pip install virtualenv
@@ -203,7 +203,7 @@ COPY ./entrypoint.sh /usr/local/bin/entrypoint.sh
 # issues with volumes (host folders)
 USER ${DOCKER_UID}:${DOCKER_GID}
 
-# Create the virtualenv with a non-priviledged user
+# Create the virtualenv with a non-privileged user
 RUN virtualenv -p python2.7 --system-site-packages /edx/app/edxapp/venv
 
 # Install development dependencies in a virtualenv

--- a/releases/hawthorn/1/oee/Dockerfile
+++ b/releases/hawthorn/1/oee/Dockerfile
@@ -191,7 +191,7 @@ RUN groupadd --gid ${DOCKER_GID} edx || \
       edx || \
     echo "Skip user creation (user with ID ${DOCKER_UID} already exists?)"
 
-# To prevent permission issues related to the non-priviledged user running in
+# To prevent permission issues related to the non-privileged user running in
 # development, we will install development dependencies in a python virtual
 # environment belonging to that user
 RUN pip install virtualenv
@@ -212,7 +212,7 @@ COPY ./entrypoint.sh /usr/local/bin/entrypoint.sh
 # issues with volumes (host folders)
 USER ${DOCKER_UID}:${DOCKER_GID}
 
-# Create the virtualenv with a non-priviledged user
+# Create the virtualenv with a non-privileged user
 RUN virtualenv -p python2.7 --system-site-packages /edx/app/edxapp/venv
 
 # Install development dependencies in a virtualenv

--- a/releases/ironwood/2/bare/Dockerfile
+++ b/releases/ironwood/2/bare/Dockerfile
@@ -182,7 +182,7 @@ RUN groupadd --gid ${DOCKER_GID} edx || \
       edx || \
     echo "Skip user creation (user with ID ${DOCKER_UID} already exists?)"
 
-# To prevent permission issues related to the non-priviledged user running in
+# To prevent permission issues related to the non-privileged user running in
 # development, we will install development dependencies in a python virtual
 # environment belonging to that user
 RUN pip install virtualenv
@@ -203,7 +203,7 @@ COPY ./entrypoint.sh /usr/local/bin/entrypoint.sh
 # issues with volumes (host folders)
 USER ${DOCKER_UID}:${DOCKER_GID}
 
-# Create the virtualenv with a non-priviledged user
+# Create the virtualenv with a non-privileged user
 RUN virtualenv -p python2.7 --system-site-packages /edx/app/edxapp/venv
 
 # Install development dependencies in a virtualenv

--- a/releases/ironwood/2/oee/Dockerfile
+++ b/releases/ironwood/2/oee/Dockerfile
@@ -192,7 +192,7 @@ RUN groupadd --gid ${DOCKER_GID} edx || \
       edx || \
     echo "Skip user creation (user with ID ${DOCKER_UID} already exists?)"
 
-# To prevent permission issues related to the non-priviledged user running in
+# To prevent permission issues related to the non-privileged user running in
 # development, we will install development dependencies in a python virtual
 # environment belonging to that user
 RUN pip install virtualenv
@@ -213,7 +213,7 @@ COPY ./entrypoint.sh /usr/local/bin/entrypoint.sh
 # issues with volumes (host folders)
 USER ${DOCKER_UID}:${DOCKER_GID}
 
-# Create the virtualenv with a non-priviledged user
+# Create the virtualenv with a non-privileged user
 RUN virtualenv -p python2.7 --system-site-packages /edx/app/edxapp/venv
 
 # Install development dependencies in a virtualenv

--- a/releases/master/0/bare/Dockerfile
+++ b/releases/master/0/bare/Dockerfile
@@ -182,7 +182,7 @@ RUN groupadd --gid ${DOCKER_GID} edx || \
       edx || \
     echo "Skip user creation (user with ID ${DOCKER_UID} already exists?)"
 
-# To prevent permission issues related to the non-priviledged user running in
+# To prevent permission issues related to the non-privileged user running in
 # development, we will install development dependencies in a python virtual
 # environment belonging to that user
 RUN pip install virtualenv
@@ -203,7 +203,7 @@ COPY ./entrypoint.sh /usr/local/bin/entrypoint.sh
 # issues with volumes (host folders)
 USER ${DOCKER_UID}:${DOCKER_GID}
 
-# Create the virtualenv with a non-priviledged user
+# Create the virtualenv with a non-privileged user
 RUN virtualenv -p python2.7 --system-site-packages /edx/app/edxapp/venv
 
 # Install development dependencies in a virtualenv


### PR DESCRIPTION
### Purpose

Since pypi banned clients that don't support SNI, we did not manage to build the image from scratch and tried to build each image on top of the previous image.

This strategy causes our images to inflate and is not sustainable.

### Proposal

We now propose to revert building the image from a plain  Ubuntu 12.04 image and upgrade its Python 2 to 2.7.18, the last version available which supports SNI.

Following @jbpenrath's suggestion to fix a typo, all images had to rebuild so I also added a fix of the Eucalpytus images.
