### PR TITLE
♻️(all) use Nginx Inc's unprivileged image instead of our own

### DIFF
--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -11,6 +11,7 @@ release.
 
 ### Changed
 
+- Use Nginx Inc's unprivileged image instead of our custom image for OpenShift
 - Revert to building the image directly from the plain Ubuntu 12.04 image
 
 ## [dogwood.3-fun-2.3.2] - 2021-09-28

--- a/releases/dogwood/3/fun/Dockerfile
+++ b/releases/dogwood/3/fun/Dockerfile
@@ -12,8 +12,8 @@ ARG DOCKER_GID=1000
 ARG EDX_RELEASE_REF=dogwood.3-fun-5.3.3
 ARG EDX_ARCHIVE_URL=https://github.com/openfun/edx-platform/archive/dogwood.3-fun-5.3.3.tar.gz
 ARG EDXAPP_STATIC_ROOT=/edx/app/edxapp/staticfiles
-ARG NGINX_IMAGE_NAME=fundocker/openshift-nginx
-ARG NGINX_IMAGE_TAG=1.13
+ARG NGINX_IMAGE_NAME=nginxinc/nginx-unprivileged
+ARG NGINX_IMAGE_TAG=1.20
 ARG PYTHON_VERSION=2.7.18
 
 
@@ -344,6 +344,12 @@ FROM ${NGINX_IMAGE_NAME}:${NGINX_IMAGE_TAG} as nginx
 
 ARG EDXAPP_STATIC_ROOT
 
+# Switch back to the root user to include static files in the container
+USER root:root
+
 RUN mkdir -p ${EDXAPP_STATIC_ROOT}
 
 COPY --from=files_collector ${EDXAPP_STATIC_ROOT} ${EDXAPP_STATIC_ROOT}
+
+# Now that everything is included, run the container with a un-privileged user
+USER 10000

--- a/releases/eucalyptus/3/bare/CHANGELOG.md
+++ b/releases/eucalyptus/3/bare/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Changed
+
+- Use Nginx Inc's unprivileged image instead of our custom image for OpenShift
+
 ## [eucalyptus.3-1.2.1] - 2021-08-28
 
 ### Fixed

--- a/releases/eucalyptus/3/bare/Dockerfile
+++ b/releases/eucalyptus/3/bare/Dockerfile
@@ -11,8 +11,8 @@ ARG DOCKER_UID=1000
 ARG DOCKER_GID=1000
 ARG EDX_RELEASE_REF=open-release/eucalyptus.3
 ARG EDXAPP_STATIC_ROOT=/edx/app/edxapp/staticfiles
-ARG NGINX_IMAGE_NAME=fundocker/openshift-nginx
-ARG NGINX_IMAGE_TAG=1.13
+ARG NGINX_IMAGE_NAME=nginxinc/nginx-unprivileged
+ARG NGINX_IMAGE_TAG=1.20
 
 # === BASE ===
 FROM ubuntu:16.04 as base
@@ -306,6 +306,12 @@ FROM ${NGINX_IMAGE_NAME}:${NGINX_IMAGE_TAG} as nginx
 
 ARG EDXAPP_STATIC_ROOT
 
+# Switch back to the root user to include static files in the container
+USER root:root
+
 RUN mkdir -p ${EDXAPP_STATIC_ROOT}
 
 COPY --from=files_collector ${EDXAPP_STATIC_ROOT} ${EDXAPP_STATIC_ROOT}
+
+# Now that everything is included, run the container with a un-privileged user
+USER 10000

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Changed
+
+- Use Nginx Inc's unprivileged image instead of our custom image for OpenShift
+
 ## [eucalyptus.3-wb-1.10.1] - 2021-09-28
 
 ### Fixed

--- a/releases/eucalyptus/3/wb/Dockerfile
+++ b/releases/eucalyptus/3/wb/Dockerfile
@@ -12,8 +12,8 @@ ARG DOCKER_GID=1000
 ARG EDX_RELEASE_REF=eucalyptus.3-wb
 ARG EDX_ARCHIVE_URL=https://github.com/openfun/edx-platform/archive/eucalyptus.3-wb.tar.gz
 ARG EDXAPP_STATIC_ROOT=/edx/app/edxapp/staticfiles
-ARG NGINX_IMAGE_NAME=fundocker/openshift-nginx
-ARG NGINX_IMAGE_TAG=1.13
+ARG NGINX_IMAGE_NAME=nginxinc/nginx-unprivileged
+ARG NGINX_IMAGE_TAG=1.20
 
 # === BASE ===
 FROM ubuntu:16.04 as base
@@ -304,6 +304,12 @@ FROM ${NGINX_IMAGE_NAME}:${NGINX_IMAGE_TAG} as nginx
 
 ARG EDXAPP_STATIC_ROOT
 
+# Switch back to the root user to include static files in the container
+USER root:root
+
 RUN mkdir -p ${EDXAPP_STATIC_ROOT}
 
 COPY --from=files_collector ${EDXAPP_STATIC_ROOT} ${EDXAPP_STATIC_ROOT}
+
+# Now that everything is included, run the container with a un-privileged user
+USER 10000

--- a/releases/hawthorn/1/bare/CHANGELOG.md
+++ b/releases/hawthorn/1/bare/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Changed
+
+- Use Nginx Inc's unprivileged image instead of our custom image for OpenShift
+
 ## [hawthorn.1-3.3.1] - 2021-09-28
 
 ### Fixed

--- a/releases/hawthorn/1/bare/Dockerfile
+++ b/releases/hawthorn/1/bare/Dockerfile
@@ -11,8 +11,8 @@ ARG DOCKER_UID=1000
 ARG DOCKER_GID=1000
 ARG EDX_RELEASE_REF=open-release/hawthorn.1
 ARG EDXAPP_STATIC_ROOT=/edx/app/edxapp/staticfiles
-ARG NGINX_IMAGE_NAME=fundocker/openshift-nginx
-ARG NGINX_IMAGE_TAG=1.13
+ARG NGINX_IMAGE_NAME=nginxinc/nginx-unprivileged
+ARG NGINX_IMAGE_TAG=1.20
 
 # === BASE ===
 FROM ubuntu:16.04 as base
@@ -275,6 +275,12 @@ FROM ${NGINX_IMAGE_NAME}:${NGINX_IMAGE_TAG} as nginx
 
 ARG EDXAPP_STATIC_ROOT
 
+# Switch back to the root user to include static files in the container
+USER root:root
+
 RUN mkdir -p ${EDXAPP_STATIC_ROOT}
 
 COPY --from=files_collector ${EDXAPP_STATIC_ROOT} ${EDXAPP_STATIC_ROOT}
+
+# Now that everything is included, run the container with a un-privileged user
+USER 10000

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Changed
+
+- Use Nginx Inc's unprivileged image instead of our custom image for OpenShift
+
 ## [hawthorn.1-oee-3.3.5] - 2021-09-28
 
 ### Fixed

--- a/releases/hawthorn/1/oee/Dockerfile
+++ b/releases/hawthorn/1/oee/Dockerfile
@@ -11,8 +11,8 @@ ARG DOCKER_UID=1000
 ARG DOCKER_GID=1000
 ARG EDX_RELEASE_REF=open-release/hawthorn.1
 ARG EDXAPP_STATIC_ROOT=/edx/app/edxapp/staticfiles
-ARG NGINX_IMAGE_NAME=fundocker/openshift-nginx
-ARG NGINX_IMAGE_TAG=1.13
+ARG NGINX_IMAGE_NAME=nginxinc/nginx-unprivileged
+ARG NGINX_IMAGE_TAG=1.20
 
 # === BASE ===
 FROM ubuntu:16.04 as base
@@ -284,6 +284,12 @@ FROM ${NGINX_IMAGE_NAME}:${NGINX_IMAGE_TAG} as nginx
 
 ARG EDXAPP_STATIC_ROOT
 
+# Switch back to the root user to include static files in the container
+USER root:root
+
 RUN mkdir -p ${EDXAPP_STATIC_ROOT}
 
 COPY --from=files_collector ${EDXAPP_STATIC_ROOT} ${EDXAPP_STATIC_ROOT}
+
+# Now that everything is included, run the container with a un-privileged user
+USER 10000

--- a/releases/ironwood/2/bare/CHANGELOG.md
+++ b/releases/ironwood/2/bare/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Changed
+
+- Use Nginx Inc's unprivileged image instead of our custom image for OpenShift
+
 ## [ironwood.2-1.0.1] - 2021-09-28
 
 ### Fixed

--- a/releases/ironwood/2/bare/Dockerfile
+++ b/releases/ironwood/2/bare/Dockerfile
@@ -11,8 +11,8 @@ ARG DOCKER_UID=1000
 ARG DOCKER_GID=1000
 ARG EDX_RELEASE_REF=open-release/ironwood.2
 ARG EDXAPP_STATIC_ROOT=/edx/app/edxapp/staticfiles
-ARG NGINX_IMAGE_NAME=fundocker/openshift-nginx
-ARG NGINX_IMAGE_TAG=1.13
+ARG NGINX_IMAGE_NAME=nginxinc/nginx-unprivileged
+ARG NGINX_IMAGE_TAG=1.20
 
 # === BASE ===
 FROM ubuntu:16.04 as base
@@ -275,6 +275,12 @@ FROM ${NGINX_IMAGE_NAME}:${NGINX_IMAGE_TAG} as nginx
 
 ARG EDXAPP_STATIC_ROOT
 
+# Switch back to the root user to include static files in the container
+USER root:root
+
 RUN mkdir -p ${EDXAPP_STATIC_ROOT}
 
 COPY --from=files_collector ${EDXAPP_STATIC_ROOT} ${EDXAPP_STATIC_ROOT}
+
+# Now that everything is included, run the container with a un-privileged user
+USER 10000

--- a/releases/ironwood/2/oee/CHANGELOG.md
+++ b/releases/ironwood/2/oee/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Changed
+
+- Use Nginx Inc's unprivileged image instead of our custom image for OpenShift
+
 ## [ironwood.2-oee-1.0.5] - 2021-09-28
 
 ### Fixed

--- a/releases/ironwood/2/oee/Dockerfile
+++ b/releases/ironwood/2/oee/Dockerfile
@@ -11,8 +11,8 @@ ARG DOCKER_UID=1000
 ARG DOCKER_GID=1000
 ARG EDX_RELEASE_REF=open-release/ironwood.2
 ARG EDXAPP_STATIC_ROOT=/edx/app/edxapp/staticfiles
-ARG NGINX_IMAGE_NAME=fundocker/openshift-nginx
-ARG NGINX_IMAGE_TAG=1.13
+ARG NGINX_IMAGE_NAME=nginxinc/nginx-unprivileged
+ARG NGINX_IMAGE_TAG=1.20
 
 # === BASE ===
 FROM ubuntu:16.04 as base
@@ -285,6 +285,12 @@ FROM ${NGINX_IMAGE_NAME}:${NGINX_IMAGE_TAG} as nginx
 
 ARG EDXAPP_STATIC_ROOT
 
+# Switch back to the root user to include static files in the container
+USER root:root
+
 RUN mkdir -p ${EDXAPP_STATIC_ROOT}
 
 COPY --from=files_collector ${EDXAPP_STATIC_ROOT} ${EDXAPP_STATIC_ROOT}
+
+# Now that everything is included, run the container with a un-privileged user
+USER 10000

--- a/releases/master/0/bare/Dockerfile
+++ b/releases/master/0/bare/Dockerfile
@@ -11,8 +11,8 @@ ARG DOCKER_UID=1000
 ARG DOCKER_GID=1000
 ARG EDX_RELEASE_REF=release-2018-08-29-14.14
 ARG EDXAPP_STATIC_ROOT=/edx/app/edxapp/staticfiles
-ARG NGINX_IMAGE_NAME=fundocker/openshift-nginx
-ARG NGINX_IMAGE_TAG=1.13
+ARG NGINX_IMAGE_NAME=nginxinc/nginx-unprivileged
+ARG NGINX_IMAGE_TAG=1.20
 
 # === BASE ===
 FROM ubuntu:16.04 as base
@@ -275,6 +275,12 @@ FROM ${NGINX_IMAGE_NAME}:${NGINX_IMAGE_TAG} as nginx
 
 ARG EDXAPP_STATIC_ROOT
 
+# Switch back to the root user to include static files in the container
+USER root:root
+
 RUN mkdir -p ${EDXAPP_STATIC_ROOT}
 
 COPY --from=files_collector ${EDXAPP_STATIC_ROOT} ${EDXAPP_STATIC_ROOT}
+
+# Now that everything is included, run the container with a un-privileged user
+USER 10000


### PR DESCRIPTION
### Purpose

We were building our own specific image able to run as a non-root user. Since Nginx Inc is building an official unprivileged image, we should use it.

## Proposal

Use the following default definition for the nginx image:
- ARG NGINX_IMAGE_NAME=nginxinc/nginx-unprivileged
- ARG NGINX_IMAGE_TAG=1.20