### PR TITLE
Dogwood and eucalypsus upgrade fun apps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,7 +156,9 @@ jobs:
   #
   # Note that the job name should match the EDX_RELEASE value
 
-  # No changes detected for dogwood.3-fun
+  # Run jobs for the dogwood.3-fun release
+  dogwood.3-fun:
+    <<: [*defaults, *build_steps]
   # No changes detected for eucalyptus.3-bare
   # Run jobs for the eucalyptus.3-wb release
   eucalyptus.3-wb:
@@ -254,7 +256,13 @@ workflows:
 
       # Build jobs
 
-      # No changes detected so no job to run for dogwood.3-fun
+      # Run jobs for the dogwood.3-fun release
+      - dogwood.3-fun:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
       # No changes detected so no job to run for eucalyptus.3-bare
       # Run jobs for the eucalyptus.3-wb release
       - eucalyptus.3-wb:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,30 +156,16 @@ jobs:
   #
   # Note that the job name should match the EDX_RELEASE value
 
-  # Run jobs for the dogwood.3-fun release
-  dogwood.3-fun:
-    <<: [*defaults, *build_steps]
-  # Run jobs for the eucalyptus.3-bare release
-  eucalyptus.3-bare:
-    <<: [*defaults, *build_steps]
+  # No changes detected for dogwood.3-fun
+  # No changes detected for eucalyptus.3-bare
   # Run jobs for the eucalyptus.3-wb release
   eucalyptus.3-wb:
     <<: [*defaults, *build_steps]
-  # Run jobs for the hawthorn.1-bare release
-  hawthorn.1-bare:
-    <<: [*defaults, *build_steps]
-  # Run jobs for the hawthorn.1-oee release
-  hawthorn.1-oee:
-    <<: [*defaults, *build_steps]
-  # Run jobs for the ironwood.2-bare release
-  ironwood.2-bare:
-    <<: [*defaults, *build_steps]
-  # Run jobs for the ironwood.2-oee release
-  ironwood.2-oee:
-    <<: [*defaults, *build_steps]
-  # Run jobs for the master.0-bare release
-  master.0-bare:
-    <<: [*defaults, *build_steps]
+  # No changes detected for hawthorn.1-bare
+  # No changes detected for hawthorn.1-oee
+  # No changes detected for ironwood.2-bare
+  # No changes detected for ironwood.2-oee
+  # No changes detected for master.0-bare
 
   # Hub job
   hub:
@@ -268,20 +254,8 @@ workflows:
 
       # Build jobs
 
-      # Run jobs for the dogwood.3-fun release
-      - dogwood.3-fun:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
-      # Run jobs for the eucalyptus.3-bare release
-      - eucalyptus.3-bare:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
+      # No changes detected so no job to run for dogwood.3-fun
+      # No changes detected so no job to run for eucalyptus.3-bare
       # Run jobs for the eucalyptus.3-wb release
       - eucalyptus.3-wb:
           requires:
@@ -289,41 +263,11 @@ workflows:
           filters:
             tags:
               ignore: /.*/
-      # Run jobs for the hawthorn.1-bare release
-      - hawthorn.1-bare:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
-      # Run jobs for the hawthorn.1-oee release
-      - hawthorn.1-oee:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
-      # Run jobs for the ironwood.2-bare release
-      - ironwood.2-bare:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
-      # Run jobs for the ironwood.2-oee release
-      - ironwood.2-oee:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
-      # Run jobs for the master.0-bare release
-      - master.0-bare:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
+      # No changes detected so no job to run for hawthorn.1-bare
+      # No changes detected so no job to run for hawthorn.1-oee
+      # No changes detected so no job to run for ironwood.2-bare
+      # No changes detected so no job to run for ironwood.2-oee
+      # No changes detected so no job to run for master.0-bare
 
       # We are pushing to Docker only images that are the result of a tag respecting the pattern:
       #    **{branch-name}-x.y.z**

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-2.4.0] - 2022-01-27
+
 ### Changed
 
 - Use Nginx Inc's unprivileged image instead of our custom image for OpenShift
@@ -444,7 +446,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.3.2...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.4.0...HEAD
+[dogwood.3-fun-2.4.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.3.2...dogwood.3-fun-2.4.0
 [dogwood.3-fun-2.3.2]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.3.1...dogwood.3-fun-2.3.2
 [dogwood.3-fun-2.3.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.3.0...dogwood.3-fun-2.3.1
 [dogwood.3-fun-2.3.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.2.0...dogwood.3-fun-2.3.0

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -12,6 +12,8 @@ release.
 ### Changed
 
 - Use Nginx Inc's unprivileged image instead of our custom image for OpenShift
+- Upgrade `fun-apps` to 5.13.0 to synchronize course runs with Richie on
+  each enrollment with the count and add an API endpoint for grades
 - Revert to building the image directly from the plain Ubuntu 12.04 image
 
 ## [dogwood.3-fun-2.3.2] - 2021-09-28

--- a/releases/dogwood/3/fun/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/lms/docker_run_production.py
@@ -1512,6 +1512,11 @@ FUN_ECOMMERCE_DEBUG_NO_NOTIFICATION = config(
 ECOMMERCE_NOTIFICATION_URL = config("ECOMMERCE_NOTIFICATION_URL", default=None)
 PAYMENT_ADMIN = "paybox@fun-mooc.fr"
 
+# Richie synchronization
+COURSE_HOOKS = config(
+    "COURSE_HOOKS", default=[], formatter=json.loads
+)
+
 # List of pattern definitions to automatically add verified users to a cohort
 # If value is [] this feature is disabled
 # Otherwise this setting is a list of

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -4,7 +4,7 @@
 # ==== core ====
 edx-gea==0.2.0
 fonzie==0.2.0
-fun-apps==5.11.0
+fun-apps==5.13.0
 
 # ==== xblocks ====
 configurable_lti_consumer-xblock==1.3.0

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -11,6 +11,7 @@ release.
 
 ### Changed
 
+- Upgrade `fun-apps` to 2.6.0+wb to synchronize course runs with Richie
 - Use Nginx Inc's unprivileged image instead of our custom image for OpenShift
 
 ## [eucalyptus.3-wb-1.10.1] - 2021-09-28

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [eucalyptus.3-wb-1.11.0] - 2022-01-27
+
 ### Changed
 
 - Upgrade `fun-apps` to 2.6.0+wb to synchronize course runs with Richie
@@ -278,7 +280,8 @@ release.
 - Set replicaSet and read_preference in mongodb connection
 - Add missing support for redis sentinel
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.10.1...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.11.0...HEAD
+[eucalyptus.3-wb-1.11.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.10.1...eucalyptus.3-wb-1.11.0
 [eucalyptus.3-wb-1.10.1]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.10.0...eucalyptus.3-wb-1.10.1
 [eucalyptus.3-wb-1.10.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.9.4...eucalyptus.3-wb-1.10.0
 [eucalyptus.3-wb-1.9.4]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.9.3...eucalyptus.3-wb-1.9.4

--- a/releases/eucalyptus/3/wb/config/cms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/cms/docker_run_production.py
@@ -832,6 +832,11 @@ MAX_ASSET_UPLOAD_FILE_SIZE_IN_MB = config(
     "MAX_ASSET_UPLOAD_FILE_SIZE_IN_MB", default=10, formatter=int
 )
 
+# Richie synchronization
+COURSE_HOOKS = config(
+    "COURSE_HOOKS", default=[], formatter=json.loads
+)
+
 # Force Edx to use `libcast_xblock` as default video player
 # in the studio (big green button) and if any xblock is called `video`
 XBLOCK_SELECT_FUNCTION = prefer_fun_video

--- a/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
+++ b/releases/eucalyptus/3/wb/config/lms/docker_run_production.py
@@ -1413,6 +1413,11 @@ PAGINATION_SETTINGS = {
 
 NUMBER_DAYS_TOO_LATE = 31
 
+# Richie synchronization
+COURSE_HOOKS = config(
+    "COURSE_HOOKS", default=[], formatter=json.loads
+)
+
 # Force Edx to use `libcast_xblock` as default video player
 # in the studio (big green button) and if any xblock is called `video`
 XBLOCK_SELECT_FUNCTION = prefer_fun_video

--- a/releases/eucalyptus/3/wb/requirements.txt
+++ b/releases/eucalyptus/3/wb/requirements.txt
@@ -4,7 +4,7 @@
 # ==== core ====
 configurable-lti-consumer-xblock==1.3.0
 edx-gea==0.2.0
-fun-apps==2.5.0+wb
+fun-apps==2.6.0+wb
 libcast-xblock==0.6.1
 password-container-xblock==0.3.0
 xblock-proctor-exam==1.0.0


### PR DESCRIPTION
## Purpose

We released a new version of [fun-apps](https://github.com/openfun/fun-apps) for dogwood and eucalyptus.

For eucalytus, it adds the course runs synchronization web hook that allows keeping Richie's catalog up-to-date.

For dogwood, it adds enrollment count to the course runs synchronization, updated upon each enrollment. It also adds an API endpoint for grades.

## Proposal

- [x] Bump fun-apps to v5.13.0 for `dogwood.3-fun`
- [x] Bump fun-apps to v2.6.0-wb for `eucalyptus.3-wb`
