### PR TITLE
🚑️(dogwood.3-fun) enforce to install voluptuous<0.13.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,9 +160,7 @@ jobs:
   dogwood.3-fun:
     <<: [*defaults, *build_steps]
   # No changes detected for eucalyptus.3-bare
-  # Run jobs for the eucalyptus.3-wb release
-  eucalyptus.3-wb:
-    <<: [*defaults, *build_steps]
+  # No changes detected for eucalyptus.3-wb
   # No changes detected for hawthorn.1-bare
   # No changes detected for hawthorn.1-oee
   # No changes detected for ironwood.2-bare
@@ -264,13 +262,7 @@ workflows:
             tags:
               ignore: /.*/
       # No changes detected so no job to run for eucalyptus.3-bare
-      # Run jobs for the eucalyptus.3-wb release
-      - eucalyptus.3-wb:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
+      # No changes detected so no job to run for eucalyptus.3-wb
       # No changes detected so no job to run for hawthorn.1-bare
       # No changes detected so no job to run for hawthorn.1-oee
       # No changes detected so no job to run for ironwood.2-bare

--- a/releases/dogwood/3/fun/Dockerfile
+++ b/releases/dogwood/3/fun/Dockerfile
@@ -160,9 +160,13 @@ RUN python get-pip.py
 RUN pip install -r requirements/edx/pre.txt
 # We need specific versions of pip and setuptools to handle the different
 # ways to declare Python dependencies in OpenEdX 😅
+# Voluptuous is a sub-dependency. The version match pattern is >=0.10.5,<1.0.0
+# but the version 0.13.0 is incompatible with this version of OpenEdX so we install
+# manually the latest compatible version to prevent the installation of 0.13.0
 RUN pip install \
     pip==9.0.3 \
-    setuptools==44.1.1
+    setuptools==44.1.1 \
+    voluptuous==0.12.2
 
 RUN pip install --src /usr/local/src -r requirements/edx/github.txt
 # Uninstall django==1.4.22 which gets installed because of django-wiki.


### PR DESCRIPTION
## Purpose

voluptuous 0.13.0 is not compatible with python 2.7 so we was not able to build dogwood.3-fun image.
As a workaround, we enforce installation of a lower version (0.12.2)


## Proposal

- [x] Enforce installation of voluptuous 0.12.2
