### PR TITLE
🔖(dogwood.3-fun) bump to version 2.5.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,9 +156,7 @@ jobs:
   #
   # Note that the job name should match the EDX_RELEASE value
 
-  # Run jobs for the dogwood.3-fun release
-  dogwood.3-fun:
-    <<: [*defaults, *build_steps]
+  # No changes detected for dogwood.3-fun
   # No changes detected for eucalyptus.3-bare
   # No changes detected for eucalyptus.3-wb
   # No changes detected for hawthorn.1-bare
@@ -254,13 +252,7 @@ workflows:
 
       # Build jobs
 
-      # Run jobs for the dogwood.3-fun release
-      - dogwood.3-fun:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
+      # No changes detected so no job to run for dogwood.3-fun
       # No changes detected so no job to run for eucalyptus.3-bare
       # No changes detected so no job to run for eucalyptus.3-wb
       # No changes detected so no job to run for hawthorn.1-bare

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-2.5.0] - 2022-04-12
+
 ### Added
 
 - Install fonzie 0.3.0 next to fun-apps
@@ -450,7 +452,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.4.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.5.0...HEAD
+[dogwood.3-fun-2.5.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.4.2...dogwood.3-fun-2.5.0
 [dogwood.3-fun-2.4.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.3.2...dogwood.3-fun-2.4.0
 [dogwood.3-fun-2.3.2]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.3.1...dogwood.3-fun-2.3.2
 [dogwood.3-fun-2.3.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.3.0...dogwood.3-fun-2.3.1


### PR DESCRIPTION
## Purpose

### Release dogwood.3-fun 2.5.0

### Added

- Install fonzie 0.3.0 next to fun-apps
