### PR TITLE
upgrade configurable_lti_consumer-xblock to 1.4.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,9 @@ jobs:
   hawthorn.1-oee:
     <<: [*defaults, *build_steps]
   # No changes detected for ironwood.2-bare
-  # No changes detected for ironwood.2-oee
+  # Run jobs for the ironwood.2-oee release
+  ironwood.2-oee:
+    <<: [*defaults, *build_steps]
   # No changes detected for master.0-bare
 
   # Hub job
@@ -282,7 +284,13 @@ workflows:
             tags:
               ignore: /.*/
       # No changes detected so no job to run for ironwood.2-bare
-      # No changes detected so no job to run for ironwood.2-oee
+      # Run jobs for the ironwood.2-oee release
+      - ironwood.2-oee:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
       # No changes detected so no job to run for master.0-bare
 
       # We are pushing to Docker only images that are the result of a tag respecting the pattern:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,9 @@ jobs:
   dogwood.3-fun:
     <<: [*defaults, *build_steps]
   # No changes detected for eucalyptus.3-bare
-  # No changes detected for eucalyptus.3-wb
+  # Run jobs for the eucalyptus.3-wb release
+  eucalyptus.3-wb:
+    <<: [*defaults, *build_steps]
   # No changes detected for hawthorn.1-bare
   # No changes detected for hawthorn.1-oee
   # No changes detected for ironwood.2-bare
@@ -262,7 +264,13 @@ workflows:
             tags:
               ignore: /.*/
       # No changes detected so no job to run for eucalyptus.3-bare
-      # No changes detected so no job to run for eucalyptus.3-wb
+      # Run jobs for the eucalyptus.3-wb release
+      - eucalyptus.3-wb:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
       # No changes detected so no job to run for hawthorn.1-bare
       # No changes detected so no job to run for hawthorn.1-oee
       # No changes detected so no job to run for ironwood.2-bare

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,9 @@ jobs:
   eucalyptus.3-wb:
     <<: [*defaults, *build_steps]
   # No changes detected for hawthorn.1-bare
-  # No changes detected for hawthorn.1-oee
+  # Run jobs for the hawthorn.1-oee release
+  hawthorn.1-oee:
+    <<: [*defaults, *build_steps]
   # No changes detected for ironwood.2-bare
   # No changes detected for ironwood.2-oee
   # No changes detected for master.0-bare
@@ -272,7 +274,13 @@ workflows:
             tags:
               ignore: /.*/
       # No changes detected so no job to run for hawthorn.1-bare
-      # No changes detected so no job to run for hawthorn.1-oee
+      # Run jobs for the hawthorn.1-oee release
+      - hawthorn.1-oee:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
       # No changes detected so no job to run for ironwood.2-bare
       # No changes detected so no job to run for ironwood.2-oee
       # No changes detected so no job to run for master.0-bare

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-2.6.0] - 2022-04-13
+
 ### Changed
 
 - Upgrade configurable_lti_consumer-xblock to version 1.4.0
@@ -456,7 +458,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.5.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.6.0...HEAD
+[dogwood.3-fun-2.6.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.5.0...dogwood.3-fun-2.6.0
 [dogwood.3-fun-2.5.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.4.0...dogwood.3-fun-2.5.0
 [dogwood.3-fun-2.4.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.3.2...dogwood.3-fun-2.4.0
 [dogwood.3-fun-2.3.2]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.3.1...dogwood.3-fun-2.3.2

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade configurable_lti_consumer-xblock to version 1.4.0
+
 ## [dogwood.3-fun-2.5.0] - 2022-04-12
 
 ### Added

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -7,7 +7,7 @@ fonzie==0.3.0
 fun-apps==5.13.0
 
 # ==== xblocks ====
-configurable_lti_consumer-xblock==1.3.0
+configurable_lti_consumer-xblock==1.4.0
 glowbl-xblock==0.2.1
 ipython-xblock==0.2.0
 libcast-xblock==0.5.0

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade configurable_lti_consumer-xblock to version 1.4.0
+
 ## [eucalyptus.3-wb-1.11.0] - 2022-01-27
 
 ### Changed

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [eucalyptus.3-wb-1.12.0] - 2022-04-13
+
 ### Changed
 
 - Upgrade configurable_lti_consumer-xblock to version 1.4.0
@@ -284,7 +286,8 @@ release.
 - Set replicaSet and read_preference in mongodb connection
 - Add missing support for redis sentinel
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.11.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.12.0...HEAD
+[eucalyptus.3-wb-1.12.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.11.0...eucalyptus.3-wb-1.12.0
 [eucalyptus.3-wb-1.11.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.10.1...eucalyptus.3-wb-1.11.0
 [eucalyptus.3-wb-1.10.1]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.10.0...eucalyptus.3-wb-1.10.1
 [eucalyptus.3-wb-1.10.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.9.4...eucalyptus.3-wb-1.10.0

--- a/releases/eucalyptus/3/wb/requirements.txt
+++ b/releases/eucalyptus/3/wb/requirements.txt
@@ -2,7 +2,7 @@
 --extra-index-url https://pypi.fury.io/openfun/
 
 # ==== core ====
-configurable-lti-consumer-xblock==1.3.0
+configurable-lti-consumer-xblock==1.4.0
 edx-gea==0.2.0
 fun-apps==2.6.0+wb
 libcast-xblock==0.6.1

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -12,6 +12,7 @@ release.
 ### Changed
 
 - Use Nginx Inc's unprivileged image instead of our custom image for OpenShift
+- Upgrade configurable_lti_consumer-xblock to version 1.4.0
 
 ## [hawthorn.1-oee-3.3.5] - 2021-09-28
 

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [hawthorn.1-oee-3.4.0] - 2022-04-13
+
 ### Changed
 
 - Use Nginx Inc's unprivileged image instead of our custom image for OpenShift
@@ -334,7 +336,8 @@ First release of OpenEdx extended.
 
 - Add a configurable LTI consumer xblock
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.3.5..HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.4.0..HEAD
+[hawthorn.1-oee-3.4.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.3.5...hawthorn.1-oee-3.4.0
 [hawthorn.1-oee-3.3.5]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.3.4...hawthorn.1-oee-3.3.5
 [hawthorn.1-oee-3.3.4]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.3.3...hawthorn.1-oee-3.3.4
 [hawthorn.1-oee-3.3.3]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.3.2...hawthorn.1-oee-3.3.3

--- a/releases/hawthorn/1/oee/requirements.txt
+++ b/releases/hawthorn/1/oee/requirements.txt
@@ -4,7 +4,7 @@
 fonzie==0.2.1
 
 # ==== xblocks ====
-configurable_lti_consumer-xblock==1.2.3
+configurable_lti_consumer-xblock==1.4.0
 
 # pin ora2 to a version that works with the filesystem
 git+https://github.com/edx/edx-ora2.git@2.2.7#egg=ora2==2.2.7

--- a/releases/ironwood/2/oee/CHANGELOG.md
+++ b/releases/ironwood/2/oee/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [ironwood.2-oee-1.1.0] - 2022-04-13
+
 ### Changed
 
 - Use Nginx Inc's unprivileged image instead of our custom image for OpenShift
@@ -50,7 +52,8 @@ release.
 
 - First release of an `ironwood.2-oee` Docker image.
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/ironwood.2-oee-1.0.5...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/ironwood.2-oee-1.1.0...HEAD
+[ironwood.2-oee-1.1.0]: https://github.com/openfun/openedx-docker/compare/ironwood.2-oee-1.0.5...ironwood.2-oee-1.1.0
 [ironwood.2-oee-1.0.5]: https://github.com/openfun/openedx-docker/compare/ironwood.2-oee-1.0.4...ironwood.2-oee-1.0.5
 [ironwood.2-oee-1.0.4]: https://github.com/openfun/openedx-docker/compare/ironwood.2-oee-1.0.3...ironwood.2-oee-1.0.4
 [ironwood.2-oee-1.0.3]: https://github.com/openfun/openedx-docker/compare/ironwood.2-oee-1.0.2...ironwood.2-oee-1.0.3

--- a/releases/ironwood/2/oee/CHANGELOG.md
+++ b/releases/ironwood/2/oee/CHANGELOG.md
@@ -12,6 +12,7 @@ release.
 ### Changed
 
 - Use Nginx Inc's unprivileged image instead of our custom image for OpenShift
+- Upgrade configurable_lti_consumer-xblock to version 1.4.0
 
 ## [ironwood.2-oee-1.0.5] - 2021-09-28
 

--- a/releases/ironwood/2/oee/requirements.txt
+++ b/releases/ironwood/2/oee/requirements.txt
@@ -4,7 +4,7 @@
 fonzie==0.2.1
 
 # ==== xblocks ====
-configurable_lti_consumer-xblock==1.2.3
+configurable_lti_consumer-xblock==1.4.0
 
 # pin ora2 to a version that works with the filesystem
 git+https://github.com/edx/edx-ora2.git@2.2.7#egg=ora2==2.2.7


### PR DESCRIPTION
## Purpose

A new release 1.4.0 of configurable_lti_consumer-xblock is available and must be installed on all OpenEDX version

## Proposal

Description...

- [x] upgrade configurable_lti_consumer-xblock to 1.4.0 on all OpenEDX versions
- [x] bump dogwood.3-fun to version 2.6.0
- [x] bump eucalyptus/3/wb to version 1.12.0
- [x] bump hawtorn/1/oee to version 3.4.0
- [x] bump irownwood/2/oee to version 1.1.0
