### PR TITLE
Upgrade configurable_lti_consumer-xblock to version 1.4.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,17 +160,11 @@ jobs:
   dogwood.3-fun:
     <<: [*defaults, *build_steps]
   # No changes detected for eucalyptus.3-bare
-  # Run jobs for the eucalyptus.3-wb release
-  eucalyptus.3-wb:
-    <<: [*defaults, *build_steps]
+  # No changes detected for eucalyptus.3-wb
   # No changes detected for hawthorn.1-bare
-  # Run jobs for the hawthorn.1-oee release
-  hawthorn.1-oee:
-    <<: [*defaults, *build_steps]
+  # No changes detected for hawthorn.1-oee
   # No changes detected for ironwood.2-bare
-  # Run jobs for the ironwood.2-oee release
-  ironwood.2-oee:
-    <<: [*defaults, *build_steps]
+  # No changes detected for ironwood.2-oee
   # No changes detected for master.0-bare
 
   # Hub job
@@ -268,29 +262,11 @@ workflows:
             tags:
               ignore: /.*/
       # No changes detected so no job to run for eucalyptus.3-bare
-      # Run jobs for the eucalyptus.3-wb release
-      - eucalyptus.3-wb:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
+      # No changes detected so no job to run for eucalyptus.3-wb
       # No changes detected so no job to run for hawthorn.1-bare
-      # Run jobs for the hawthorn.1-oee release
-      - hawthorn.1-oee:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
+      # No changes detected so no job to run for hawthorn.1-oee
       # No changes detected so no job to run for ironwood.2-bare
-      # Run jobs for the ironwood.2-oee release
-      - ironwood.2-oee:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
+      # No changes detected so no job to run for ironwood.2-oee
       # No changes detected so no job to run for master.0-bare
 
       # We are pushing to Docker only images that are the result of a tag respecting the pattern:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,9 @@ jobs:
   hawthorn.1-oee:
     <<: [*defaults, *build_steps]
   # No changes detected for ironwood.2-bare
-  # No changes detected for ironwood.2-oee
+  # Run jobs for the ironwood.2-oee release
+  ironwood.2-oee:
+    <<: [*defaults, *build_steps]
   # No changes detected for master.0-bare
 
   # Hub job
@@ -282,7 +284,13 @@ workflows:
             tags:
               ignore: /.*/
       # No changes detected so no job to run for ironwood.2-bare
-      # No changes detected so no job to run for ironwood.2-oee
+      # Run jobs for the ironwood.2-oee release
+      - ironwood.2-oee:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
       # No changes detected so no job to run for master.0-bare
 
       # We are pushing to Docker only images that are the result of a tag respecting the pattern:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,9 @@ jobs:
   dogwood.3-fun:
     <<: [*defaults, *build_steps]
   # No changes detected for eucalyptus.3-bare
-  # No changes detected for eucalyptus.3-wb
+  # Run jobs for the eucalyptus.3-wb release
+  eucalyptus.3-wb:
+    <<: [*defaults, *build_steps]
   # No changes detected for hawthorn.1-bare
   # No changes detected for hawthorn.1-oee
   # No changes detected for ironwood.2-bare
@@ -262,7 +264,13 @@ workflows:
             tags:
               ignore: /.*/
       # No changes detected so no job to run for eucalyptus.3-bare
-      # No changes detected so no job to run for eucalyptus.3-wb
+      # Run jobs for the eucalyptus.3-wb release
+      - eucalyptus.3-wb:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
       # No changes detected so no job to run for hawthorn.1-bare
       # No changes detected so no job to run for hawthorn.1-oee
       # No changes detected so no job to run for ironwood.2-bare

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,9 @@ jobs:
   eucalyptus.3-wb:
     <<: [*defaults, *build_steps]
   # No changes detected for hawthorn.1-bare
-  # No changes detected for hawthorn.1-oee
+  # Run jobs for the hawthorn.1-oee release
+  hawthorn.1-oee:
+    <<: [*defaults, *build_steps]
   # No changes detected for ironwood.2-bare
   # No changes detected for ironwood.2-oee
   # No changes detected for master.0-bare
@@ -272,7 +274,13 @@ workflows:
             tags:
               ignore: /.*/
       # No changes detected so no job to run for hawthorn.1-bare
-      # No changes detected so no job to run for hawthorn.1-oee
+      # Run jobs for the hawthorn.1-oee release
+      - hawthorn.1-oee:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
       # No changes detected so no job to run for ironwood.2-bare
       # No changes detected so no job to run for ironwood.2-oee
       # No changes detected so no job to run for master.0-bare

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,11 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Upgrade configurable_lti_consumer-xblock to version 1.4.1
+  to allow screen sharing
+
 ## [dogwood.3-fun-2.6.0] - 2022-04-13
 
 ### Changed

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-2.6.1] - 2022-04-14
+
 ### Fixed
 
 - Upgrade configurable_lti_consumer-xblock to version 1.4.1
@@ -463,7 +465,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.6.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.6.1...HEAD
+[dogwood.3-fun-2.6.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.6.0...dogwood.3-fun-2.6.1
 [dogwood.3-fun-2.6.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.5.0...dogwood.3-fun-2.6.0
 [dogwood.3-fun-2.5.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.4.0...dogwood.3-fun-2.5.0
 [dogwood.3-fun-2.4.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.3.2...dogwood.3-fun-2.4.0

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -7,7 +7,7 @@ fonzie==0.3.0
 fun-apps==5.13.0
 
 # ==== xblocks ====
-configurable_lti_consumer-xblock==1.4.0
+configurable_lti_consumer-xblock==1.4.1
 glowbl-xblock==0.2.1
 ipython-xblock==0.2.0
 libcast-xblock==0.5.0

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,11 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Upgrade configurable_lti_consumer-xblock to version 1.4.1
+  to allow screen sharing
+
 ## [eucalyptus.3-wb-1.12.0] - 2022-04-13
 
 ### Changed

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [eucalyptus.3-wb-1.12.1] - 2022-04-14
+
 ### Fixed
 
 - Upgrade configurable_lti_consumer-xblock to version 1.4.1
@@ -291,7 +293,8 @@ release.
 - Set replicaSet and read_preference in mongodb connection
 - Add missing support for redis sentinel
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.12.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.12.1...HEAD
+[eucalyptus.3-wb-1.12.1]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.12.0...eucalyptus.3-wb-1.12.1
 [eucalyptus.3-wb-1.12.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.11.0...eucalyptus.3-wb-1.12.0
 [eucalyptus.3-wb-1.11.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.10.1...eucalyptus.3-wb-1.11.0
 [eucalyptus.3-wb-1.10.1]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.10.0...eucalyptus.3-wb-1.10.1

--- a/releases/eucalyptus/3/wb/requirements.txt
+++ b/releases/eucalyptus/3/wb/requirements.txt
@@ -2,7 +2,7 @@
 --extra-index-url https://pypi.fury.io/openfun/
 
 # ==== core ====
-configurable-lti-consumer-xblock==1.4.0
+configurable-lti-consumer-xblock==1.4.1
 edx-gea==0.2.0
 fun-apps==2.6.0+wb
 libcast-xblock==0.6.1

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -9,6 +9,11 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Upgrade configurable_lti_consumer-xblock to version 1.4.1
+  to allow screen sharing
+
 ## [hawthorn.1-oee-3.4.0] - 2022-04-13
 
 ### Changed

--- a/releases/hawthorn/1/oee/CHANGELOG.md
+++ b/releases/hawthorn/1/oee/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [hawthorn.1-oee-3.4.1] - 2022-04-13
+
 ### Fixed
 
 - Upgrade configurable_lti_consumer-xblock to version 1.4.1
@@ -341,7 +343,8 @@ First release of OpenEdx extended.
 
 - Add a configurable LTI consumer xblock
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.4.0..HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.4.1..HEAD
+[hawthorn.1-oee-3.4.1]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.4.0...hawthorn.1-oee-3.4.1
 [hawthorn.1-oee-3.4.0]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.3.5...hawthorn.1-oee-3.4.0
 [hawthorn.1-oee-3.3.5]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.3.4...hawthorn.1-oee-3.3.5
 [hawthorn.1-oee-3.3.4]: https://github.com/openfun/openedx-docker/compare/hawthorn.1-oee-3.3.3...hawthorn.1-oee-3.3.4

--- a/releases/hawthorn/1/oee/requirements.txt
+++ b/releases/hawthorn/1/oee/requirements.txt
@@ -4,7 +4,7 @@
 fonzie==0.2.1
 
 # ==== xblocks ====
-configurable_lti_consumer-xblock==1.4.0
+configurable_lti_consumer-xblock==1.4.1
 
 # pin ora2 to a version that works with the filesystem
 git+https://github.com/edx/edx-ora2.git@2.2.7#egg=ora2==2.2.7

--- a/releases/ironwood/2/oee/CHANGELOG.md
+++ b/releases/ironwood/2/oee/CHANGELOG.md
@@ -9,6 +9,11 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Upgrade configurable_lti_consumer-xblock to version 1.4.1
+  to allow screen sharing
+
 ## [ironwood.2-oee-1.1.0] - 2022-04-13
 
 ### Changed

--- a/releases/ironwood/2/oee/CHANGELOG.md
+++ b/releases/ironwood/2/oee/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [ironwood.2-oee-1.1.1] - 2022-04-14
+
 ### Fixed
 
 - Upgrade configurable_lti_consumer-xblock to version 1.4.1
@@ -57,7 +59,8 @@ release.
 
 - First release of an `ironwood.2-oee` Docker image.
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/ironwood.2-oee-1.1.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/ironwood.2-oee-1.1.1...HEAD
+[ironwood.2-oee-1.1.1]: https://github.com/openfun/openedx-docker/compare/ironwood.2-oee-1.1.0...ironwood.2-oee-1.1.1
 [ironwood.2-oee-1.1.0]: https://github.com/openfun/openedx-docker/compare/ironwood.2-oee-1.0.5...ironwood.2-oee-1.1.0
 [ironwood.2-oee-1.0.5]: https://github.com/openfun/openedx-docker/compare/ironwood.2-oee-1.0.4...ironwood.2-oee-1.0.5
 [ironwood.2-oee-1.0.4]: https://github.com/openfun/openedx-docker/compare/ironwood.2-oee-1.0.3...ironwood.2-oee-1.0.4

--- a/releases/ironwood/2/oee/requirements.txt
+++ b/releases/ironwood/2/oee/requirements.txt
@@ -4,7 +4,7 @@
 fonzie==0.2.1
 
 # ==== xblocks ====
-configurable_lti_consumer-xblock==1.4.0
+configurable_lti_consumer-xblock==1.4.1
 
 # pin ora2 to a version that works with the filesystem
 git+https://github.com/edx/edx-ora2.git@2.2.7#egg=ora2==2.2.7


### PR DESCRIPTION
## Purpose

Upgrade configurable_lti_consumer-xblock to version 1.4.1 on all OpenEDX releases


## Proposal

- [x] Upgrade configurable_lti_consumer-xblock to version 1.4.1 on all OpenEDX releases
