### PR TITLE
🚑️(dogwood.3-fun) enforce to install splinter<0.17.0

### DIFF
--- a/releases/dogwood/3/fun/Dockerfile
+++ b/releases/dogwood/3/fun/Dockerfile
@@ -163,9 +163,13 @@ RUN pip install -r requirements/edx/pre.txt
 # Voluptuous is a sub-dependency. The version match pattern is >=0.10.5,<1.0.0
 # but the version 0.13.0 is incompatible with this version of OpenEdX so we install
 # manually the latest compatible version to prevent the installation of 0.13.0
+# Splinter is a sub-dependency. The version match pattern is >=0.5.0
+# but the version 0.17.0 dropped the support for Python 2.7 we install manually the
+# latest compatible version to prevent the installation of 0.17.0.
 RUN pip install \
     pip==9.0.3 \
     setuptools==44.1.1 \
+    splinter==0.16.0 \
     voluptuous==0.12.2
 
 RUN pip install --src /usr/local/src -r requirements/edx/github.txt


### PR DESCRIPTION
## Purpose

Splinter 0.17.0 is not compatible with python 2.7 so we was not able to build dogwood.3-fun image. As a workaround, we enforce installation of a lower version (0.16.0)


## Proposal

- [x] Force to install splinter 0.16.0
