### PR TITLE
Deps/upgrade fonzie to 0.4.0

### DIFF
--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,13 @@ release.
 
 ## [Unreleased]
 
+### Changed
+
+- Upgraded
+  [fonzie](https://github.com/openfun/fonzie)
+  to
+  [`v0.4.0`](https://github.com/openfun/fonzie/releases/tag/v0.4.0)
+
 ## [dogwood.3-fun-2.6.2] - 2022-05-31
 
 ### Fixed

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-2.7.0] - 2022-07-28
+
 ### Changed
 
 - Upgraded
@@ -478,7 +480,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.6.2...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.7.0...HEAD
+[dogwood.3-fun-2.7.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.6.2...dogwood.3-fun-2.7.0
 [dogwood.3-fun-2.6.2]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.6.1...dogwood.3-fun-2.6.2
 [dogwood.3-fun-2.6.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.6.0...dogwood.3-fun-2.6.1
 [dogwood.3-fun-2.6.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.5.0...dogwood.3-fun-2.6.0

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -3,7 +3,7 @@
 
 # ==== core ====
 edx-gea==0.2.0
-fonzie==0.3.0
+fonzie==0.4.0
 fun-apps==5.13.1
 
 # ==== xblocks ====


### PR DESCRIPTION
## Purpose

Upgrade `dogwood.3.fun` to fonzie v0.4.0 and prepare the release of `dogwood.3.fun` 2.7.0.
