### PR TITLE
Fix datetime parse for year earlier than 1900 and release a fix

### DIFF
--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-2.7.1] - 2022-09-19
+
 ### Fixed
 
 - Fix bug when year is less than 1900
@@ -484,7 +486,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.7.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.7.1...HEAD
+[dogwood.3-fun-2.7.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.7.0...dogwood.3-fun-2.7.1
 [dogwood.3-fun-2.7.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.6.2...dogwood.3-fun-2.7.0
 [dogwood.3-fun-2.6.2]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.6.1...dogwood.3-fun-2.6.2
 [dogwood.3-fun-2.6.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.6.0...dogwood.3-fun-2.6.1

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix bug when year is less than 1900
+
 ## [dogwood.3-fun-2.7.0] - 2022-07-28
 
 ### Changed

--- a/releases/dogwood/3/fun/Dockerfile
+++ b/releases/dogwood/3/fun/Dockerfile
@@ -145,6 +145,13 @@ RUN apt-get update && \
 
 WORKDIR /edx/app/edxapp/edx-platform
 
+# Patches
+COPY patches/* /tmp/
+
+# Patches pre-install
+# Patch strftime to fix bug when year is less than 1900
+RUN patch -p1 < /tmp/edx-platform_dogwood.3-fun_strftime-1900.patch
+
 # Install Javascript requirements
 RUN npm install
 

--- a/releases/dogwood/3/fun/patches/edx-platform_dogwood.3-fun_strftime-1900.patch
+++ b/releases/dogwood/3/fun/patches/edx-platform_dogwood.3-fun_strftime-1900.patch
@@ -1,0 +1,16 @@
+diff --git a/common/lib/xmodule/xmodule/fields.py b/common/lib/xmodule/xmodule/fields.py
+index a3c6aa19d7..2b73d5b63f 100644
+--- a/common/lib/xmodule/xmodule/fields.py
++++ b/common/lib/xmodule/xmodule/fields.py
+@@ -73,6 +73,10 @@ class Date(JSONField):
+             return time.strftime('%Y-%m-%dT%H:%M:%SZ', value)
+         elif isinstance(value, datetime.datetime):
+             if value.tzinfo is None or value.utcoffset().total_seconds() == 0:
++                if value.year < 1900:
++                    # strftime doesn't work for pre-1900 dates, so use
++                    # isoformat instead
++                    return value.isoformat()
+                 # isoformat adds +00:00 rather than Z
+                 return value.strftime('%Y-%m-%dT%H:%M:%SZ')
+             else:
+


### PR DESCRIPTION
## Purpose

When users key in a datetime earlier than 1900, the whole course is broken with a 500 error and nothing can be done to fix it via the UI.

## Proposal

This is due to a bug in Python 2 datetime.strftime and the fact that OpenEdX does not validate the dates submitted by users.

It was fixed in Eucalyptus so I propose to port the same fix to dogwood.
