### PR TITLE
🐛(eucalyptus/3/wb) avoid build error when running npm install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,11 +158,13 @@ jobs:
   #
   # Note that the job name should match the EDX_RELEASE value
 
-  # Run jobs for the dogwood.3-fun release
-  dogwood.3-fun:
+  # No changes detected for dogwood.3-fun
+  # Run jobs for the eucalyptus.3-bare release
+  eucalyptus.3-bare:
     <<: [*defaults, *build_steps]
-  # No changes detected for eucalyptus.3-bare
-  # No changes detected for eucalyptus.3-wb
+  # Run jobs for the eucalyptus.3-wb release
+  eucalyptus.3-wb:
+    <<: [*defaults, *build_steps]
   # No changes detected for hawthorn.1-bare
   # No changes detected for hawthorn.1-oee
   # No changes detected for ironwood.2-bare
@@ -257,15 +259,21 @@ workflows:
 
       # Build jobs
 
-      # Run jobs for the dogwood.3-fun release
-      - dogwood.3-fun:
+      # No changes detected so no job to run for dogwood.3-fun
+      # Run jobs for the eucalyptus.3-bare release
+      - eucalyptus.3-bare:
           requires:
             - check-configuration
           filters:
             tags:
               ignore: /.*/
-      # No changes detected so no job to run for eucalyptus.3-bare
-      # No changes detected so no job to run for eucalyptus.3-wb
+      # Run jobs for the eucalyptus.3-wb release
+      - eucalyptus.3-wb:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
       # No changes detected so no job to run for hawthorn.1-bare
       # No changes detected so no job to run for hawthorn.1-oee
       # No changes detected so no job to run for ironwood.2-bare

--- a/releases/eucalyptus/3/bare/CHANGELOG.md
+++ b/releases/eucalyptus/3/bare/CHANGELOG.md
@@ -13,6 +13,10 @@ release.
 
 - Use Nginx Inc's unprivileged image instead of our custom image for OpenShift
 
+### Fixed
+
+- Avoid build error when running npm install on `edx-ui-toolkit` due to github command
+
 ## [eucalyptus.3-1.2.1] - 2021-08-28
 
 ### Fixed

--- a/releases/eucalyptus/3/bare/Dockerfile
+++ b/releases/eucalyptus/3/bare/Dockerfile
@@ -150,7 +150,7 @@ RUN npm install
 # Force the reinstallation of edx-ui-toolkit's dependencies inside its
 # node_modules because someone is poking files from there when updating assets.
 RUN cd node_modules/edx-ui-toolkit && \
-      npm install
+    npm install backbone.paginator
 
 # Update assets skipping collectstatic (it should be done during deployment)
 RUN NO_PREREQ_INSTALL=1 \

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Avoid build error when running npm install on `edx-ui-toolkit` due to github command
+
 ## [eucalyptus.3-wb-1.12.1] - 2022-04-14
 
 ### Fixed

--- a/releases/eucalyptus/3/wb/Dockerfile
+++ b/releases/eucalyptus/3/wb/Dockerfile
@@ -152,7 +152,7 @@ RUN npm install
 # Force the reinstallation of edx-ui-toolkit's dependencies inside its
 # node_modules because someone is poking files from there when updating assets.
 RUN cd node_modules/edx-ui-toolkit && \
-      npm install
+    npm install backbone.paginator
 
 # Update assets skipping collectstatic (it should be done during deployment)
 RUN NO_PREREQ_INSTALL=1 \


### PR DESCRIPTION
## Purpose

When running npm install on `edx-ui-toolkit`, npm tries to run a command:
`/bin/usr/git ls-remote -h -t git://github.com/bessdsv/bower-installer.git`

It seems that github does not accept this syntax anymore because it still works with `ssh://git@github.com`.

## Proposal

Since it's not trivial to control the git commands that npm issues, we can avoid this problem by installing only the specific packet we need.

