### PR TITLE
Install ipython xblock and Release eucalyptus.3-wb-1.13.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,11 +158,11 @@ jobs:
   #
   # Note that the job name should match the EDX_RELEASE value
 
-  # Run jobs for the dogwood.3-fun release
-  dogwood.3-fun:
-    <<: [*defaults, *build_steps]
+  # No changes detected for dogwood.3-fun
   # No changes detected for eucalyptus.3-bare
-  # No changes detected for eucalyptus.3-wb
+  # Run jobs for the eucalyptus.3-wb release
+  eucalyptus.3-wb:
+    <<: [*defaults, *build_steps]
   # No changes detected for hawthorn.1-bare
   # No changes detected for hawthorn.1-oee
   # No changes detected for ironwood.2-bare
@@ -257,15 +257,15 @@ workflows:
 
       # Build jobs
 
-      # Run jobs for the dogwood.3-fun release
-      - dogwood.3-fun:
+      # No changes detected so no job to run for dogwood.3-fun
+      # No changes detected so no job to run for eucalyptus.3-bare
+      # Run jobs for the eucalyptus.3-wb release
+      - eucalyptus.3-wb:
           requires:
             - check-configuration
           filters:
             tags:
               ignore: /.*/
-      # No changes detected so no job to run for eucalyptus.3-bare
-      # No changes detected so no job to run for eucalyptus.3-wb
       # No changes detected so no job to run for hawthorn.1-bare
       # No changes detected so no job to run for hawthorn.1-oee
       # No changes detected so no job to run for ironwood.2-bare

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Added
+
+- Add Python dependency `ipython-xblock==0.2.0`
+
 ### Fixed
 
 - Fix Docker build by removing `nose-faulthandler` Python dependency

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [eucalyptus.3-wb-1.13.0] - 2023-05-17
+
 ### Added
 
 - Add Python dependency `ipython-xblock==0.2.0`
@@ -302,7 +304,8 @@ release.
 - Set replicaSet and read_preference in mongodb connection
 - Add missing support for redis sentinel
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.12.1...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.13.0...HEAD
+[eucalyptus.3-wb-1.13.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.12.1...eucalyptus.3-wb-1.13.0
 [eucalyptus.3-wb-1.12.1]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.12.0...eucalyptus.3-wb-1.12.1
 [eucalyptus.3-wb-1.12.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.11.0...eucalyptus.3-wb-1.12.0
 [eucalyptus.3-wb-1.11.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.10.1...eucalyptus.3-wb-1.11.0

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -11,6 +11,7 @@ release.
 
 ### Fixed
 
+- Fix Docker build by removing `nose-faulthandler` Python dependency
 - Avoid build error when running npm install on `edx-ui-toolkit` due to github command
 
 ## [eucalyptus.3-wb-1.12.1] - 2022-04-14

--- a/releases/eucalyptus/3/wb/Dockerfile
+++ b/releases/eucalyptus/3/wb/Dockerfile
@@ -123,6 +123,13 @@ RUN python get-pip.py
 
 WORKDIR /edx/app/edxapp/edx-platform
 
+# Patches
+COPY patches/* /tmp/
+
+# Patches pre-install
+# Remove faulthandler dependency that is no more available and is useful only for running tests
+RUN patch -p1 < /tmp/edx-platform_eucalyptus.3-remove_faulthandler.patch
+
 # Install python dependencies
 #
 # Note that we force some pinned release installations before installing github

--- a/releases/eucalyptus/3/wb/patches/edx-platform_eucalyptus.3-remove_faulthandler.patch
+++ b/releases/eucalyptus/3/wb/patches/edx-platform_eucalyptus.3-remove_faulthandler.patch
@@ -1,0 +1,12 @@
+diff --git a/requirements/edx/base.txt b/requirements/edx/base.txt
+index 9bc8908d72..5b374a18e2 100644
+--- a/requirements/edx/base.txt
++++ b/requirements/edx/base.txt
+@@ -169,7 +169,6 @@ selenium==2.53.1
+ splinter==0.5.4
+ testtools==0.9.34
+ testfixtures==4.5.0
+-nose-faulthandler==0.1
+ 
+ # Used for Segment analytics
+ analytics-python==1.1.0

--- a/releases/eucalyptus/3/wb/requirements.txt
+++ b/releases/eucalyptus/3/wb/requirements.txt
@@ -5,6 +5,7 @@
 configurable-lti-consumer-xblock==1.4.1
 edx-gea==0.2.0
 fun-apps==2.6.0+wb
+ipython-xblock==0.2.0
 libcast-xblock==0.6.1
 password-container-xblock==0.3.0
 xblock-proctor-exam==1.0.0


### PR DESCRIPTION
## Purpose

We need this xblock to run Jupyter. It is already installed in the `dogwood/3/fun image`.

## Proposal

Added Python dependency: `ipython-xblock==0.2.0`

the build was broken because the `faulthandler` packet is not available anymore for Python 2. Since this packet is only useful to run the tests, we think we can skip its installation in the production image, so I added a patch for this.
