### PR TITLE
📌(dogwood/3/fun) pin urlib3 to ensure python 2 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,11 +158,11 @@ jobs:
   #
   # Note that the job name should match the EDX_RELEASE value
 
-  # No changes detected for dogwood.3-fun
-  # No changes detected for eucalyptus.3-bare
-  # Run jobs for the eucalyptus.3-wb release
-  eucalyptus.3-wb:
+  # Run jobs for the dogwood.3-fun release
+  dogwood.3-fun:
     <<: [*defaults, *build_steps]
+  # No changes detected for eucalyptus.3-bare
+  # No changes detected for eucalyptus.3-wb
   # No changes detected for hawthorn.1-bare
   # No changes detected for hawthorn.1-oee
   # No changes detected for ironwood.2-bare
@@ -257,15 +257,15 @@ workflows:
 
       # Build jobs
 
-      # No changes detected so no job to run for dogwood.3-fun
-      # No changes detected so no job to run for eucalyptus.3-bare
-      # Run jobs for the eucalyptus.3-wb release
-      - eucalyptus.3-wb:
+      # Run jobs for the dogwood.3-fun release
+      - dogwood.3-fun:
           requires:
             - check-configuration
           filters:
             tags:
               ignore: /.*/
+      # No changes detected so no job to run for eucalyptus.3-bare
+      # No changes detected so no job to run for eucalyptus.3-wb
       # No changes detected so no job to run for hawthorn.1-bare
       # No changes detected so no job to run for hawthorn.1-oee
       # No changes detected so no job to run for ironwood.2-bare

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Pin urlib3 to v1 to ensure Python 2 compatibility
+
 ## [dogwood.3-fun-2.8.0] - 2023-04-17
 
 ### Changed

--- a/releases/dogwood/3/fun/Dockerfile
+++ b/releases/dogwood/3/fun/Dockerfile
@@ -175,6 +175,7 @@ RUN pip install -r requirements/edx/pre.txt
 # latest compatible version to prevent the installation of 0.17.0.
 RUN pip install \
     pip==9.0.3 \
+    urllib3==1 \
     setuptools==44.1.1 \
     splinter==0.16.0 \
     voluptuous==0.12.2


### PR DESCRIPTION

## Purpose

A new version of urlib3 came out which breaks compatibility with Python2. 

## Proposal

Pin `urlib3` dependency to its version 1.