### PR TITLE
💄(dogwood/3/fun) use new FUN logo in menu

### DIFF
--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -11,6 +11,7 @@ release.
 
 ### Fixed
 
+- Use new FUN logo in menu
 - Pin urlib3 to v1 to ensure Python 2 compatibility
 
 ## [dogwood.3-fun-2.8.0] - 2023-04-17

--- a/releases/dogwood/3/fun/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/lms/docker_run_production.py
@@ -1340,7 +1340,7 @@ MAKO_TEMPLATES["main"] = [
 # JS static override
 DEFAULT_TEMPLATE_ENGINE["DIRS"].append(FUN_BASE_ROOT / "funsite/templates/lms")
 
-FUN_SMALL_LOGO_RELATIVE_PATH = "funsite/images/logos/funmooc173.png"
+FUN_SMALL_LOGO_RELATIVE_PATH = "funsite/images/logos/fun-fr.svg"
 FUN_BIG_LOGO_RELATIVE_PATH = "funsite/images/logos/funmoocfp.png"
 FAVICON_PATH = "fun/images/favicon.ico"
 


### PR DESCRIPTION
## Purpose

The new FUN logo was recently added in fun-apps but the setting pointing to it is overriden here so the new logo won't show on the site after deployment in production.

## Proposal

Point setting to the new FUN logo.
