### PR TITLE
Deps/fun apps 5.15.0

### DIFF
--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,11 @@ release.
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade fun-apps to version 5.15.0 to add mailing_list routes to
+  un.subscribe users from a course's mailing list
+
 ### Fixed
 
 - Use new FUN logo in menu

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-2.9.0] - 2023-07-07
+
 ### Changed
 
 - Upgrade fun-apps to version 5.15.0 to add mailing_list routes to
@@ -502,7 +504,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.8.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.9.0...HEAD
+[dogwood.3-fun-2.9.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.8.0...dogwood.3-fun-2.9.0
 [dogwood.3-fun-2.8.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.7.1...dogwood.3-fun-2.8.0
 [dogwood.3-fun-2.7.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.7.0...dogwood.3-fun-2.7.1
 [dogwood.3-fun-2.7.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.6.2...dogwood.3-fun-2.7.0

--- a/releases/dogwood/3/fun/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/lms/docker_run_production.py
@@ -1218,6 +1218,7 @@ INSTALLED_APPS += (
     "funsite",
     "haystack",
     "masquerade",
+    "mailing_list",
     "newsfeed",
     "password_container",
     "payment_api",
@@ -1335,6 +1336,7 @@ MAKO_TEMPLATES["main"] = [
     FUN_BASE_ROOT / "course_dashboard/templates",
     FUN_BASE_ROOT / "newsfeed/templates",
     FUN_BASE_ROOT / "fun_certificates/templates",
+    FUN_BASE_ROOT / "mailing_list/templates",
 ] + MAKO_TEMPLATES["main"]
 
 # JS static override

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -4,7 +4,7 @@
 # ==== core ====
 edx-gea==0.2.0
 fonzie==0.4.0
-fun-apps==5.14.0
+fun-apps==5.15.0
 
 # ==== xblocks ====
 configurable_lti_consumer-xblock==1.4.1


### PR DESCRIPTION
## Purpose

Upgrade fun-apps to version 5.15.0 then Bump to dogwood.3-fun-2.9.0

### Changed

- Upgrade fun-apps to version 5.15.0 to add mailing_list routes to un.subscribe users from a course's mailing list

### Fixed

- Use new FUN logo in menu
- Pin urlib3 to v1 to ensure Python 2 compatibility
