### PR TITLE
Deps/bump fun apps 5.15.1

### DIFF
--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-2.9.1] - 2023-07-07
+
 ### Fixed
 
 - Upgrade fun-apps to version 5.15.1 to fix Manifest.in to include mailing_list
@@ -509,7 +511,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.9.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.9.1...HEAD
+[dogwood.3-fun-2.9.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.9.0...dogwood.3-fun-2.9.1
 [dogwood.3-fun-2.9.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.8.0...dogwood.3-fun-2.9.0
 [dogwood.3-fun-2.8.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.7.1...dogwood.3-fun-2.8.0
 [dogwood.3-fun-2.7.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.7.0...dogwood.3-fun-2.7.1

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,11 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Upgrade fun-apps to version 5.15.1 to fix Manifest.in to include mailing_list
+  html, po and mo files
+
 ## [dogwood.3-fun-2.9.0] - 2023-07-07
 
 ### Changed

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -4,7 +4,7 @@
 # ==== core ====
 edx-gea==0.2.0
 fonzie==0.4.0
-fun-apps==5.15.0
+fun-apps==5.15.1
 
 # ==== xblocks ====
 configurable_lti_consumer-xblock==1.4.1


### PR DESCRIPTION
## Purpose

Bump fun-apps to version 5.15.1 to fix the `mailing_list` app (missing template files in package published to pypi) then release dogwood.3-fun-2.9.1


### Fixed

- Upgrade fun-apps to version 5.15.1 to fix Manifest.in to include mailing_list
  html, po and mo files
