### PR TITLE
Dogwood.fun.3 upgrade fun apps to v5.16.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,15 +161,9 @@ jobs:
   # Run jobs for the dogwood.3-fun release
   dogwood.3-fun:
     <<: [*defaults, *build_steps]
-  # Run jobs for the eucalyptus.3-wb release
-  eucalyptus.3-wb:
-    <<: [*defaults, *build_steps]
-  # Run jobs for the hawthorn.1-oee release
-  hawthorn.1-oee:
-    <<: [*defaults, *build_steps]
-  # Run jobs for the ironwood.2-oee release
-  ironwood.2-oee:
-    <<: [*defaults, *build_steps]
+  # No changes detected for eucalyptus.3-wb
+  # No changes detected for hawthorn.1-oee
+  # No changes detected for ironwood.2-oee
 
   # Hub job
   hub:
@@ -266,27 +260,9 @@ workflows:
           filters:
             tags:
               ignore: /.*/
-      # Run jobs for the eucalyptus.3-wb release
-      - eucalyptus.3-wb:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
-      # Run jobs for the hawthorn.1-oee release
-      - hawthorn.1-oee:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
-      # Run jobs for the ironwood.2-oee release
-      - ironwood.2-oee:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
+      # No changes detected so no job to run for eucalyptus.3-wb
+      # No changes detected so no job to run for hawthorn.1-oee
+      # No changes detected so no job to run for ironwood.2-oee
 
       # We are pushing to Docker only images that are the result of a tag respecting the pattern:
       #    **{branch-name}-x.y.z**

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,11 @@ release.
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade fun-apps to version 5.16.0 to add a title to the course run
+  synchronization webhook data
+
 ## [dogwood.3-fun-2.9.1] - 2023-07-07
 
 ### Fixed

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -14,6 +14,10 @@ release.
 - Upgrade fun-apps to version 5.16.0 to add a title to the course run
   synchronization webhook data
 
+### Fixed
+
+- Remove dependency to missing Python package `moto` only used in tests
+
 ## [dogwood.3-fun-2.9.1] - 2023-07-07
 
 ### Fixed

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-2.10.0] - 2023-10-10
+
 ### Changed
 
 - Upgrade fun-apps to version 5.16.0 to add a title to the course run
@@ -520,7 +522,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.9.1...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.10.0...HEAD
+[dogwood.3-fun-2.10.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.9.1...dogwood.3-fun-2.10.0
 [dogwood.3-fun-2.9.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.9.0...dogwood.3-fun-2.9.1
 [dogwood.3-fun-2.9.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.8.0...dogwood.3-fun-2.9.0
 [dogwood.3-fun-2.8.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.7.1...dogwood.3-fun-2.8.0

--- a/releases/dogwood/3/fun/Dockerfile
+++ b/releases/dogwood/3/fun/Dockerfile
@@ -153,6 +153,8 @@ COPY patches/* /tmp/
 # Patches pre-install
 # Patch strftime to fix bug when year is less than 1900
 RUN patch -p1 < /tmp/edx-platform_dogwood.3-fun_strftime-1900.patch
+# Patch to fix installation of Python modules
+RUN patch -p1 < /tmp/edx-platform_dogwood.3-fun_moto.patch
 
 # Install Javascript requirements
 RUN npm install

--- a/releases/dogwood/3/fun/patches/edx-platform_dogwood.3-fun_moto.patch
+++ b/releases/dogwood/3/fun/patches/edx-platform_dogwood.3-fun_moto.patch
@@ -1,0 +1,14 @@
+diff --git a/requirements/edx/base.txt b/requirements/edx/base.txt
+index 19c655d79e..457d719e30 100644
+--- a/requirements/edx/base.txt
++++ b/requirements/edx/base.txt
+@@ -140,7 +140,7 @@ flaky==2.4.0
+ freezegun==0.1.11
+ mock-django==0.6.9
+ mock==1.0.1
+-moto==0.3.1
++#moto==0.3.1 version not available anymore but we don't need to run the tests anyway
+ nose==1.3.7
+ nose-exclude
+ nose-ignore-docstring
+

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -4,7 +4,7 @@
 # ==== core ====
 edx-gea==0.2.0
 fonzie==0.4.0
-fun-apps==5.15.1
+fun-apps==5.16.0
 
 # ==== xblocks ====
 configurable_lti_consumer-xblock==1.4.1


### PR DESCRIPTION
### Changed

- Upgrade fun-apps to version 5.16.0 to add a title to the course run synchronization webhook data

### Fixed

- Remove dependency to missing Python package `moto` only used in tests

