### PR TITLE
Configure dogwood with fun-apps 5.17.0 and oauth2 middleware

### DIFF
--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,9 +9,17 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-2.11.0] - 2024-01-16
+
+### Added
+
+- Middleware fun.middleware.Oauth2Step
+- Settings OAUTH_EXPIRE_CODE_DELTA and OAUTH_DELETE_EXPIRED
+
 ### Changed
 
 - Upgrade fonzie to v0.5.0
+- Upgrade to fun-apps 5.17.0
 
 ## [dogwood.3-fun-2.10.0] - 2023-10-10
 
@@ -526,7 +534,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.10.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.11.0...HEAD
+[dogwood.3-fun-2.11.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.10.0...dogwood.3-fun-2.11.0
 [dogwood.3-fun-2.10.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.9.1...dogwood.3-fun-2.10.0
 [dogwood.3-fun-2.9.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.9.0...dogwood.3-fun-2.9.1
 [dogwood.3-fun-2.9.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.8.0...dogwood.3-fun-2.9.0

--- a/releases/dogwood/3/fun/config/lms/docker_run_production.py
+++ b/releases/dogwood/3/fun/config/lms/docker_run_production.py
@@ -24,6 +24,7 @@ import os
 from path import Path as path
 import pkgutil
 import platform
+from datetime import timedelta
 
 from django.utils.translation import ugettext_lazy
 from django.conf import global_settings
@@ -965,6 +966,12 @@ if FEATURES.get("ENABLE_OAUTH2_PROVIDER"):
     OAUTH_ENFORCE_CLIENT_SECURE = config(
         "OAUTH_ENFORCE_CLIENT_SECURE", default=True, formatter=bool
     )
+    OAUTH_EXPIRE_CODE_DELTA = config(
+        "OAUTH_EXPIRE_CODE_DELTA", default=timedelta(days=365)
+    )
+    OAUTH_DELETE_EXPIRED = config(
+        "OAUTH_DELETE_EXPIRED", default=False,
+    )
 
 ##### ADVANCED_SECURITY_CONFIG #####
 ADVANCED_SECURITY_CONFIG = config(
@@ -1339,9 +1346,6 @@ MAKO_TEMPLATES["main"] = [
     FUN_BASE_ROOT / "mailing_list/templates",
 ] + MAKO_TEMPLATES["main"]
 
-# JS static override
-DEFAULT_TEMPLATE_ENGINE["DIRS"].append(FUN_BASE_ROOT / "funsite/templates/lms")
-
 FUN_SMALL_LOGO_RELATIVE_PATH = "funsite/images/logos/fun-fr.svg"
 FUN_BIG_LOGO_RELATIVE_PATH = "funsite/images/logos/funmoocfp.png"
 FAVICON_PATH = "fun/images/favicon.ico"
@@ -1457,6 +1461,7 @@ FUN_DEFAULT_VIDEO_PLAYER = "libcast_xblock"
 
 MIDDLEWARE_CLASSES += (
     "fun.middleware.LegalAcceptance",
+    "fun.middleware.Oauth2Step",
     "backoffice.middleware.PathLimitedMasqueradeMiddleware",
 )
 

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -4,7 +4,7 @@
 # ==== core ====
 edx-gea==0.2.0
 fonzie==0.5.0
-fun-apps==5.16.0
+fun-apps==5.17.0
 
 # ==== xblocks ====
 configurable_lti_consumer-xblock==1.4.1


### PR DESCRIPTION
## Purpose

In the fun-apps 5.17.0 we added a new middleware to fix a bug in the Oauth2 process. We must add it in the dogwood MIDDLEWARE_CLASSES settings.


## Proposal

- [x] add oauth2 middleware in the settings
- [x] bump to version 2.11.0
