### PR TITLE
🐛(dogwood.3-fun) fix build following git dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,8 +162,12 @@ jobs:
   dogwood.3-fun:
     <<: [*defaults, *build_steps]
   # No changes detected for eucalyptus.3-wb
-  # No changes detected for hawthorn.1-oee
-  # No changes detected for ironwood.2-oee
+  # Run jobs for the hawthorn.1-oee release
+  hawthorn.1-oee:
+    <<: [*defaults, *build_steps]
+  # Run jobs for the ironwood.2-oee release
+  ironwood.2-oee:
+    <<: [*defaults, *build_steps]
 
   # Hub job
   hub:
@@ -261,8 +265,20 @@ workflows:
             tags:
               ignore: /.*/
       # No changes detected so no job to run for eucalyptus.3-wb
-      # No changes detected so no job to run for hawthorn.1-oee
-      # No changes detected so no job to run for ironwood.2-oee
+      # Run jobs for the hawthorn.1-oee release
+      - hawthorn.1-oee:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
+      # Run jobs for the ironwood.2-oee release
+      - ironwood.2-oee:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
 
       # We are pushing to Docker only images that are the result of a tag respecting the pattern:
       #    **{branch-name}-x.y.z**

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 # Target OpenEdx release
 FLAVORED_EDX_RELEASE_PATH  = releases/$(shell echo ${EDX_RELEASE} | sed -E "s|\.|/|")/$(FLAVOR)
-EDX_ARCHIVE_URL           ?= https://github.com/edx/edx-platform/archive/open-release/$(EDX_RELEASE_REF).tar.gz
+EDX_ARCHIVE_URL           ?= https://github.com/openedx/edx-platform/archive/open-release/$(EDX_RELEASE_REF).tar.gz
 
 # Target OpenEdx demo course release
-EDX_DEMO_ARCHIVE_URL      ?= https://github.com/edx/edx-demo-course/archive/$(EDX_DEMO_RELEASE_REF).tar.gz
+EDX_DEMO_ARCHIVE_URL      ?= https://github.com/openedx/edx-demo-course/archive/$(EDX_DEMO_RELEASE_REF).tar.gz
 
 # Docker images
 EDXAPP_IMAGE_NAME         ?= edxapp

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix build by updating Xblock package repository url
+
 ## [dogwood.3-fun-2.11.0] - 2024-01-16
 
 ### Added

--- a/releases/dogwood/3/fun/Dockerfile
+++ b/releases/dogwood/3/fun/Dockerfile
@@ -155,6 +155,8 @@ COPY patches/* /tmp/
 RUN patch -p1 < /tmp/edx-platform_dogwood.3-fun_strftime-1900.patch
 # Patch to fix installation of Python modules
 RUN patch -p1 < /tmp/edx-platform_dogwood.3-fun_moto.patch
+# Patch to fix installation of XBlock package from github
+RUN patch -p1 < /tmp/edx-platform_dogwood.3-fun_XBlock.patch
 
 # Install Javascript requirements
 RUN npm install

--- a/releases/dogwood/3/fun/patches/edx-platform_dogwood.3-fun_XBlock.patch
+++ b/releases/dogwood/3/fun/patches/edx-platform_dogwood.3-fun_XBlock.patch
@@ -1,0 +1,12 @@
+diff --git a/requirements/edx/github.txt b/requirements/edx/github.txt
+--- a/requirements/edx/github.txt
++++ b/requirements/edx/github.txt
+@@ -71,7 +71,7 @@
+ git+https://github.com/edx/lettuce.git@0.2.20.002#egg=lettuce==0.2.20.002
+
+ # Our libraries:
+-git+https://github.com/edx/XBlock.git@xblock-0.4.5#egg=XBlock==0.4.5
++git+https://github.com/openedx/XBlock.git@xblock-0.4.5#egg=XBlock==0.4.5
+ -e git+https://github.com/edx/codejail.git@6b17c33a89bef0ac510926b1d7fea2748b73aadd#egg=codejail
+ -e git+https://github.com/edx/js-test-tool.git@v0.1.6#egg=js_test_tool
+ -e git+https://github.com/edx/event-tracking.git@0.2.1#egg=event-tracking==0.2.1

--- a/releases/hawthorn/1/oee/Dockerfile
+++ b/releases/hawthorn/1/oee/Dockerfile
@@ -126,6 +126,9 @@ COPY patches/* /tmp/
 # Patch requirements to install py2neo==3.1.2 from github as this version has been removed from pypi.org
 RUN patch -p1 < /tmp/edx-platform_hawthorn.1-oee_requirements-py2neo.patch
 
+# Patch to fix installation of Python modules
+RUN patch -p1 < /tmp/edx-platform_hawthorn.1-oee_moto.patch
+
 # Install python dependencies
 RUN pip install --src /usr/local/src -r requirements/edx/base.txt && \
     pip install -r requirements/edx/extend.txt

--- a/releases/hawthorn/1/oee/Dockerfile
+++ b/releases/hawthorn/1/oee/Dockerfile
@@ -45,7 +45,7 @@ RUN curl -sLo get-pip.py https://bootstrap.pypa.io/pip/2.7/get-pip.py
 # Download edxapp release
 # Get default EDX_RELEASE_REF value (defined on top)
 ARG EDX_RELEASE_REF
-RUN curl -sLo edxapp.tgz https://github.com/edx/edx-platform/archive/open-release/$EDX_RELEASE_REF.tar.gz && \
+RUN curl -sLo edxapp.tgz https://github.com/openedx/edx-platform/archive/open-release/$EDX_RELEASE_REF.tar.gz && \
     tar xzf edxapp.tgz
 
 

--- a/releases/hawthorn/1/oee/activate
+++ b/releases/hawthorn/1/oee/activate
@@ -2,3 +2,5 @@ export EDX_RELEASE="hawthorn.1"
 export FLAVOR="oee"
 export EDX_RELEASE_REF="hawthorn.1"
 export EDX_DEMO_RELEASE_REF="open-release/hawthorn.1"
+unset EDX_ARCHIVE_URL
+unset EDX_DEMO_ARCHIVE_URL

--- a/releases/hawthorn/1/oee/patches/edx-platform_hawthorn.1-oee_moto.patch
+++ b/releases/hawthorn/1/oee/patches/edx-platform_hawthorn.1-oee_moto.patch
@@ -1,0 +1,38 @@
+diff --git a/requirements/edx/testing.txt b/requirements/edx/testing.txt
+--- a/requirements/edx/testing.txt
++++ b/requirements/edx/testing.txt
+@@ -203,7 +203,7 @@
+ mock==1.0.1
+ mongoengine==0.10.0
+ more-itertools==4.2.0     # via pytest
+-moto==0.3.1
++# moto==0.3.1 version not available anymore but we don't need to run the tests anyway
+ mysql-python==1.2.5
+ needle==0.5.0             # via bok-choy
+ networkx==1.7
+
+diff --git a/requirements/edx/testing.in b/requirements/edx/testing.in
+--- a/requirements/edx/testing.in
++++ b/requirements/edx/testing.in
+@@ -26,7 +26,7 @@
+ freezegun                 # Allows tests to mock the output of assorted datetime module functions
+ httpretty                 # Library for mocking HTTP requests, used in many tests
+ isort                     # For checking and fixing the order of imports
+-moto==0.3.1               # Lets tests mock AWS access via the boto library
++# moto==0.3.1             # Version not available anymore but we don't need to run the tests anyway
+ nose                      # Former test runner, we're still using some utility functions from it
+ pa11ycrawler              # Python crawler (using Scrapy) that uses Pa11y to check accessibility of pages as it crawls
+ pycodestyle               # Checker for compliance with the Python style guide (PEP 8)
+
+diff --git a/requirements/edx/development.txt b/requirements/edx/development.txt
+--- a/requirements/edx/development.txt
++++ b/requirements/edx/development.txt
+@@ -212,7 +212,7 @@
+ modernize==0.6.1
+ mongoengine==0.10.0
+ more-itertools==4.2.0
+-moto==0.3.1
++# moto==0.3.1 version not available anymore but we don't need to run the tests anyway
+ mysql-python==1.2.5
+ needle==0.5.0
+ networkx==1.7

--- a/releases/hawthorn/1/oee/patches/edx-platform_hawthorn.1-oee_requirements-py2neo.patch
+++ b/releases/hawthorn/1/oee/patches/edx-platform_hawthorn.1-oee_requirements-py2neo.patch
@@ -7,8 +7,8 @@ index f90b796..b5a7d62 100644
  polib==1.1.0              # via edx-i18n-tools
  psutil==1.2.1
 -py2neo==3.1.2
-+# install py2neo==3.1.2 from github repository as 3.1.2 has been removed from pypi.org
-+git+https://github.com/technige/py2neo@py2neo-3.1.2#egg=py2neo==3.1.2
++# Old versions of py2neo have been moved into a package called py2neo-history
++py2neo-history==3.1.2
  pycontracts==1.7.1
  pycountry==1.20
  pycparser==2.18
@@ -22,8 +22,8 @@ index 4d69e60..c4662b0 100644
  polib==1.1.0
  psutil==1.2.1
 -py2neo==3.1.2
-+# install py2neo==3.1.2 from github repository as 3.1.2 has been removed from pypi.org
-+git+https://github.com/technige/py2neo@py2neo-3.1.2#egg=py2neo==3.1.2
++# Old versions of py2neo have been moved into a package called py2neo-history
++py2neo-history==3.1.2
  py==1.5.4
  pyasn1-modules==0.2.2
  pyasn1==0.4.3
@@ -38,8 +38,8 @@ index 23dd44a..44ed71e 100644
  polib==1.1.0
  psutil==1.2.1
 -py2neo==3.1.2
-+# install py2neo==3.1.2 from github repository as 3.1.2 has been removed from pypi.org
-+git+https://github.com/technige/py2neo@py2neo-3.1.2#egg=py2neo==3.1.2
++# Old versions of py2neo have been moved into a package called py2neo-history
++py2neo-history==3.1.2
  py==1.5.4                 # via pytest, tox
  pyasn1-modules==0.2.2     # via service-identity
  pyasn1==0.4.3             # via pyasn1-modules, service-identity

--- a/releases/ironwood/2/oee/Dockerfile
+++ b/releases/ironwood/2/oee/Dockerfile
@@ -126,6 +126,9 @@ COPY patches/* /tmp/
 # Patch requirements to install py2neo==3.1.2 from github as this version has been removed from pypi.org
 RUN patch -p1 < /tmp/edx-platform_ironwood.2-oee_requirements-py2neo.patch
 
+# Patch to fix installation of Python modules
+RUN patch -p1 < /tmp/edx-platform_ironwood.2-oee_moto.patch
+
 # Install python dependencies
 RUN pip install --src /usr/local/src -r requirements/edx/base.txt && \
     pip install -r requirements/edx/extend.txt

--- a/releases/ironwood/2/oee/Dockerfile
+++ b/releases/ironwood/2/oee/Dockerfile
@@ -45,7 +45,7 @@ RUN curl -sLo get-pip.py https://bootstrap.pypa.io/pip/2.7/get-pip.py
 # Download edxapp release
 # Get default EDX_RELEASE_REF value (defined on top)
 ARG EDX_RELEASE_REF
-RUN curl -sLo edxapp.tgz https://github.com/edx/edx-platform/archive/open-release/$EDX_RELEASE_REF.tar.gz && \
+RUN curl -sLo edxapp.tgz https://github.com/openedx/edx-platform/archive/open-release/$EDX_RELEASE_REF.tar.gz && \
     tar xzf edxapp.tgz
 
 

--- a/releases/ironwood/2/oee/activate
+++ b/releases/ironwood/2/oee/activate
@@ -2,3 +2,5 @@ export EDX_RELEASE="ironwood.2"
 export FLAVOR="oee"
 export EDX_RELEASE_REF="ironwood.2"
 export EDX_DEMO_RELEASE_REF="open-release/ironwood.2"
+unset EDX_ARCHIVE_URL
+unset EDX_DEMO_ARCHIVE_URL

--- a/releases/ironwood/2/oee/patches/edx-platform_ironwood.2-oee_moto.patch
+++ b/releases/ironwood/2/oee/patches/edx-platform_ironwood.2-oee_moto.patch
@@ -1,0 +1,38 @@
+diff --git a/requirements/edx/testing.txt b/requirements/edx/testing.txt
+--- a/requirements/edx/testing.txt
++++ b/requirements/edx/testing.txt
+@@ -205,7 +205,7 @@
+ mock==1.0.1
+ mongoengine==0.10.0
+ more-itertools==5.0.0     # via pytest
+-moto==0.3.1
++# moto==0.3.1 version not available anymore but we don't need to run the tests anyway
+ mysql-python==1.2.5
+ networkx==1.7
+ newrelic==4.10.0.112
+
+diff --git a/requirements/edx/testing.in b/requirements/edx/testing.in
+--- a/requirements/edx/testing.in
++++ b/requirements/edx/testing.in
+@@ -28,7 +28,7 @@
+ freezegun                 # Allows tests to mock the output of assorted datetime module functions
+ httpretty                 # Library for mocking HTTP requests, used in many tests
+ isort                     # For checking and fixing the order of imports
+-moto==0.3.1               # Lets tests mock AWS access via the boto library
++# moto==0.3.1             # Version not available anymore but we don't need to run the tests anyway
+ pa11ycrawler              # Python crawler (using Scrapy) that uses Pa11y to check accessibility of pages as it crawls
+ pycodestyle               # Checker for compliance with the Python style guide (PEP 8)
+ polib                     # Library for manipulating gettext translation files, used to test paver i18n commands
+
+diff --git a/requirements/edx/development.txt b/requirements/edx/development.txt
+--- a/requirements/edx/development.txt
++++ b/requirements/edx/development.txt
+@@ -213,7 +213,7 @@
+ modernize==0.6.1
+ mongoengine==0.10.0
+ more-itertools==5.0.0
+-moto==0.3.1
++# moto==0.3.1 version not available anymore but we don't need to run the tests anyway
+ mysql-python==1.2.5
+ networkx==1.7
+ newrelic==4.10.0.112

--- a/releases/ironwood/2/oee/patches/edx-platform_ironwood.2-oee_requirements-py2neo.patch
+++ b/releases/ironwood/2/oee/patches/edx-platform_ironwood.2-oee_requirements-py2neo.patch
@@ -7,8 +7,8 @@ index 8a5f114..338d8a5 100644
  polib==1.1.0              # via edx-i18n-tools
  psutil==1.2.1
 -py2neo==3.1.2
-+# install py2neo==3.1.2 from github repository as 3.1.2 has been removed from pypi.org
-+git+https://github.com/technige/py2neo@py2neo-3.1.2#egg=py2neo==3.1.2
++# Old versions of py2neo have been moved into a package called py2neo-history
++py2neo-history==3.1.2
  pycontracts==1.7.1
  pycountry==1.20
  pycparser==2.19
@@ -22,8 +22,8 @@ index 80ac873..cbb87b4 100644
  polib==1.1.0
  psutil==1.2.1
 -py2neo==3.1.2
-+# install py2neo==3.1.2 from github repository as 3.1.2 has been removed from pypi.org
-+git+https://github.com/technige/py2neo@py2neo-3.1.2#egg=py2neo==3.1.2
++# Old versions of py2neo have been moved into a package called py2neo-history
++py2neo-history==3.1.2
  py==1.7.0
  pyasn1-modules==0.2.3
  pyasn1==0.4.5
@@ -37,8 +37,8 @@ index 9d55925..0123ad4 100644
  polib==1.1.0
  psutil==1.2.1
 -py2neo==3.1.2
-+# install py2neo==3.1.2 from github repository as 3.1.2 has been removed from pypi.org
-+git+https://github.com/technige/py2neo@py2neo-3.1.2#egg=py2neo==3.1.2
++# Old versions of py2neo have been moved into a package called py2neo-history
++py2neo-history==3.1.2
  py==1.7.0                 # via pytest, tox
  pyasn1-modules==0.2.3     # via service-identity
  pyasn1==0.4.5             # via pyasn1-modules, service-identity


### PR DESCRIPTION
## Purpose

The build was broken as the dependency Xblock was installed through a
corrupted git repository url. Indeed, this repository has been moved in
another github organization (edx -> openedx) and the old repository url
does not redirect to the new one. So we create a patch to amend this url
 with the good one.

## Proposal

- [x] Fix `dogwood.3-fun` build
- [x] Fix configuration variable definition
