### PR TITLE
⬆️(dogwood.3-fun) bump fonzie to 0.6.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,12 +162,8 @@ jobs:
   dogwood.3-fun:
     <<: [*defaults, *build_steps]
   # No changes detected for eucalyptus.3-wb
-  # Run jobs for the hawthorn.1-oee release
-  hawthorn.1-oee:
-    <<: [*defaults, *build_steps]
-  # Run jobs for the ironwood.2-oee release
-  ironwood.2-oee:
-    <<: [*defaults, *build_steps]
+  # No changes detected for hawthorn.1-oee
+  # No changes detected for ironwood.2-oee
 
   # Hub job
   hub:
@@ -265,20 +261,8 @@ workflows:
             tags:
               ignore: /.*/
       # No changes detected so no job to run for eucalyptus.3-wb
-      # Run jobs for the hawthorn.1-oee release
-      - hawthorn.1-oee:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
-      # Run jobs for the ironwood.2-oee release
-      - ironwood.2-oee:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
+      # No changes detected so no job to run for hawthorn.1-oee
+      # No changes detected so no job to run for ironwood.2-oee
 
       # We are pushing to Docker only images that are the result of a tag respecting the pattern:
       #    **{branch-name}-x.y.z**

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade fonzie to v0.6.0
+
 ### Fixed
 
 - Fix build by updating Xblock package repository url

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-2.12.0] - 2024-03-14
+
 ### Changed
 
 - Upgrade fonzie to v0.6.0
@@ -542,7 +544,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.11.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.12.0...HEAD
+[dogwood.3-fun-2.12.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.11.0...dogwood.3-fun-2.12.0
 [dogwood.3-fun-2.11.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.10.0...dogwood.3-fun-2.11.0
 [dogwood.3-fun-2.10.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.9.1...dogwood.3-fun-2.10.0
 [dogwood.3-fun-2.9.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.9.0...dogwood.3-fun-2.9.1

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -3,7 +3,7 @@
 
 # ==== core ====
 edx-gea==0.2.0
-fonzie==0.5.0
+fonzie==0.6.0
 fun-apps==5.17.0
 
 # ==== xblocks ====


### PR DESCRIPTION
## Purpose

Upgrade dogwood.3-fun to fonzie v0.6.0.
Then release dogwood.3-fun 2.12.0

### [dogwood.3-fun-2.12.0] - 2024-03-14

#### Changed

- Upgrade fonzie to v0.6.0

#### Fixed

- Fix build by updating Xblock package repository url
