### PR TITLE
🔨(backend) migration docker compose

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,9 +33,9 @@ build_steps: &build_steps
         name: Check if changes are targeting the current release
         command: bin/ci checkpoint
 
-    # Install a recent docker-compose release
+    # Install a recent docker compose release
     - run:
-        name: Upgrade docker-compose
+        name: Upgrade docker compose
         command: |
           curl -L "https://github.com/docker/compose/releases/download/1.25.1/docker-compose-$(uname -s)-$(uname -m)" -o ~/docker-compose
           chmod +x ~/docker-compose
@@ -178,9 +178,9 @@ jobs:
           name: Login to DockerHub
           command: echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
 
-      # Install a recent docker-compose release
+      # Install a recent docker compose release
       - run:
-          name: Upgrade docker-compose
+          name: Upgrade docker compose
           command: |
             curl -L "https://github.com/docker/compose/releases/download/1.25.1/docker-compose-$(uname -s)-$(uname -m)" -o ~/docker-compose
             chmod +x ~/docker-compose

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,13 +33,6 @@ build_steps: &build_steps
         name: Check if changes are targeting the current release
         command: bin/ci checkpoint
 
-    # Install a recent docker compose release
-    - run:
-        name: Upgrade docker compose
-        command: |
-          curl -L "https://github.com/docker/compose/releases/download/1.25.1/docker-compose-$(uname -s)-$(uname -m)" -o ~/docker-compose
-          chmod +x ~/docker-compose
-          sudo mv ~/docker-compose /usr/local/bin/docker-compose
 
     # Production image build
     - run:
@@ -158,9 +151,7 @@ jobs:
   #
   # Note that the job name should match the EDX_RELEASE value
 
-  # Run jobs for the dogwood.3-fun release
-  dogwood.3-fun:
-    <<: [*defaults, *build_steps]
+  # No changes detected for dogwood.3-fun
   # No changes detected for eucalyptus.3-wb
   # No changes detected for hawthorn.1-oee
   # No changes detected for ironwood.2-oee
@@ -177,14 +168,6 @@ jobs:
       - run:
           name: Login to DockerHub
           command: echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
-
-      # Install a recent docker compose release
-      - run:
-          name: Upgrade docker compose
-          command: |
-            curl -L "https://github.com/docker/compose/releases/download/1.25.1/docker-compose-$(uname -s)-$(uname -m)" -o ~/docker-compose
-            chmod +x ~/docker-compose
-            sudo mv ~/docker-compose /usr/local/bin/docker-compose
 
       # Thanks to docker layer caching, rebuilding the image should be blazing
       # fast!
@@ -253,13 +236,7 @@ workflows:
 
       # Build jobs
 
-      # Run jobs for the dogwood.3-fun release
-      - dogwood.3-fun:
-          requires:
-            - check-configuration
-          filters:
-            tags:
-              ignore: /.*/
+      # No changes detected so no job to run for dogwood.3-fun
       # No changes detected so no job to run for eucalyptus.3-wb
       # No changes detected so no job to run for hawthorn.1-oee
       # No changes detected so no job to run for ironwood.2-oee

--- a/.circleci/src/config.tpl
+++ b/.circleci/src/config.tpl
@@ -29,9 +29,9 @@ build_steps: &build_steps
         name: Check if changes are targeting the current release
         command: bin/ci checkpoint
 
-    # Install a recent docker-compose release
+    # Install a recent docker compose release
     - run:
-        name: Upgrade docker-compose
+        name: Upgrade docker compose
         command: |
           curl -L "https://github.com/docker/compose/releases/download/1.25.1/docker-compose-$(uname -s)-$(uname -m)" -o ~/docker-compose
           chmod +x ~/docker-compose
@@ -168,9 +168,9 @@ jobs:
           name: Login to DockerHub
           command: echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
 
-      # Install a recent docker-compose release
+      # Install a recent docker compose release
       - run:
-          name: Upgrade docker-compose
+          name: Upgrade docker compose
           command: |
             curl -L "https://github.com/docker/compose/releases/download/1.25.1/docker-compose-$(uname -s)-$(uname -m)" -o ~/docker-compose
             chmod +x ~/docker-compose

--- a/.circleci/src/config.tpl
+++ b/.circleci/src/config.tpl
@@ -29,13 +29,6 @@ build_steps: &build_steps
         name: Check if changes are targeting the current release
         command: bin/ci checkpoint
 
-    # Install a recent docker compose release
-    - run:
-        name: Upgrade docker compose
-        command: |
-          curl -L "https://github.com/docker/compose/releases/download/1.25.1/docker-compose-$(uname -s)-$(uname -m)" -o ~/docker-compose
-          chmod +x ~/docker-compose
-          sudo mv ~/docker-compose /usr/local/bin/docker-compose
 
     # Production image build
     - run:
@@ -167,14 +160,6 @@ jobs:
       - run:
           name: Login to DockerHub
           command: echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
-
-      # Install a recent docker compose release
-      - run:
-          name: Upgrade docker compose
-          command: |
-            curl -L "https://github.com/docker/compose/releases/download/1.25.1/docker-compose-$(uname -s)-$(uname -m)" -o ~/docker-compose
-            chmod +x ~/docker-compose
-            sudo mv ~/docker-compose /usr/local/bin/docker-compose
 
       # Thanks to docker layer caching, rebuilding the image should be blazing
       # fast!

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ COMPOSE          = \
   DOCKER_GID=$(DOCKER_GID) \
   FLAVORED_EDX_RELEASE_PATH="$(FLAVORED_EDX_RELEASE_PATH)" \
   EDXAPP_IMAGE_TAG=$(EDXAPP_IMAGE_TAG) \
-  docker-compose
+  docker compose
 COMPOSE_SSL      = NGINX_CONF=ssl $(COMPOSE)
 COMPOSE_RUN      = $(COMPOSE) run --rm -e HOME="/tmp"
 COMPOSE_EXEC     = $(COMPOSE) exec
@@ -217,7 +217,7 @@ dev: \
   check-activate \
   create-symlinks
 dev:  ## start the cms and lms services (development image and servers)
-	# starts lms-dev as well via docker-compose dependency
+	# starts lms-dev as well via docker compose dependency
 	$(COMPOSE) up -d cms-dev
 	@echo "Wait for services to be up..."
 	$(WAIT_DB)

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ laptop:
 $ docker -v
   Docker version 17.12.0-ce, build c97c6d6
 
-$ docker-compose --version
-  docker-compose version 1.17.1, build 6d101fb
+$ docker compose --version
+  docker compose version 1.17.1, build 6d101fb
 ```
 
 ⚠️ `Docker Compose` version 1.19 is not supported because of a bug (see

--- a/README.md
+++ b/README.md
@@ -85,15 +85,11 @@ laptop:
 
 ```bash
 $ docker -v
-  Docker version 17.12.0-ce, build c97c6d6
+  Docker version 26.0.0, build 2ae903e
 
-$ docker compose --version
-  docker compose version 1.17.1, build 6d101fb
+$ docker compose version
+  docker compose version v2.24.5
 ```
-
-⚠️ `Docker Compose` version 1.19 is not supported because of a bug (see
-https://github.com/docker/compose/issues/5686). Please downgrade to 1.18 or
-upgrade to a higher version.
 
 ## Getting started
 

--- a/bin/compose
+++ b/bin/compose
@@ -10,4 +10,4 @@ export DOCKER_GID
 export EDXAPP_IMAGE_TAG
 export FLAVORED_EDX_RELEASE_PATH
 
-docker-compose "${@}"
+docker compose "${@}"

--- a/bin/watch
+++ b/bin/watch
@@ -2,7 +2,7 @@
 
 THEME="${1:-red-theme}"
 
-docker-compose run --rm --no-deps lms-dev \
+docker compose run --rm --no-deps lms-dev \
     paver watch_assets \
         --settings=fun.docker_build_development \
         --theme-dirs=/edx/app/edxapp/edx-platform/themes \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-# OpenEdx docker-compose stack used for development/test purpose
+# OpenEdx docker compose stack used for development/test purpose
 #
 #
 #
@@ -6,7 +6,6 @@
 # and DOCKER_GID variables with relevant values (i.e. matching the current
 # system user ids). If you use the project's Makefile or the bin/compose
 # wrapper, those variable definitions have already been handled on your behalf.
-version: "3.5"
 
 services:
   mysql:
@@ -137,7 +136,7 @@ services:
       #- ./src/edx-ora2/openassessment:/usr/local/lib/python2.7/dist-packages/openassessment
     networks:
       - default
-      - outside
+      - lms_outside
     depends_on:
       - lms
     user: ${DOCKER_UID}:${DOCKER_GID}
@@ -177,7 +176,7 @@ services:
       default:
         aliases:
           - nginx
-      outside:
+      lms_outside:
         aliases:
           - edx
     volumes:
@@ -191,6 +190,6 @@ services:
     image: jwilder/dockerize
 
 networks:
-  outside:
+  lms_outside:
     driver: bridge
-    name: ${EDX_NETWORK:-edx_outside}
+    name: "${EDX_NETWORK:-edx-lms-outside}"

--- a/env.d/redis
+++ b/env.d/redis
@@ -1,4 +1,4 @@
 # Add Redis service environment variables in this file
 # 
 # PLEASE DO NOT REMOVE THIS FILE
-# It is required for docker-compose environment description
+# It is required for docker compose environment description


### PR DESCRIPTION
docker-compose command doesn't work anymore.
we need to switch to docker compose

```sh
git grep -rl docker-compose . | xargs sed -i 's/docker-compose/docker compose/g'
git grep -rl "docker compose file" . | xargs sed -i 's/docker compose file/docker-compose file/g'
git grep -rl "../docker compose.yml" . | xargs sed -i 's/docker compose.yml/docker-compose.yml/g'
git grep -rl "/docker compose" . | xargs sed -i 's/\/docker compose/\/docker-compose/g'
```

migration: 
```sh
$ docker-compose down
$ make boostrap
```

