### PR TITLE
Dogwood.3 fun/upgrade fonzie 0.7.0 fun apps 5.18.0

### DIFF
--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -12,6 +12,7 @@ release.
 ## Changed
 
 - Upgrade fonzie to v0.7.0
+- Upgrade fun-apps to v5.18.0
 
 ## [dogwood.3-fun-2.12.0] - 2024-03-14
 

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+## Changed
+
+- Upgrade fonzie to v0.7.0
+
 ## [dogwood.3-fun-2.12.0] - 2024-03-14
 
 ### Changed

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-2.13.0] - 2024-04-04
+
 ## Changed
 
 - Upgrade fonzie to v0.7.0
@@ -549,7 +551,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.12.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.13.0...HEAD
+[dogwood.3-fun-2.13.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.12.0...dogwood.3-fun-2.13.0
 [dogwood.3-fun-2.12.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.11.0...dogwood.3-fun-2.12.0
 [dogwood.3-fun-2.11.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.10.0...dogwood.3-fun-2.11.0
 [dogwood.3-fun-2.10.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.9.1...dogwood.3-fun-2.10.0

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -3,7 +3,7 @@
 
 # ==== core ====
 edx-gea==0.2.0
-fonzie==0.6.0
+fonzie==0.7.0
 fun-apps==5.17.0
 
 # ==== xblocks ====

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -4,7 +4,7 @@
 # ==== core ====
 edx-gea==0.2.0
 fonzie==0.7.0
-fun-apps==5.17.0
+fun-apps==5.18.0
 
 # ==== xblocks ====
 configurable_lti_consumer-xblock==1.4.1


### PR DESCRIPTION
## Purpose

Upgrade dogwood.3-fun to fonzie v0.7.0.
Upgrade dogwood.3-fun to fun-apps v5.18.0.
Then release dogwood.3-fun 2.13.0

## [dogwood.3-fun-2.13.0] - 2024-04-04

## Changed

- Upgrade fonzie to v0.7.0
- Upgrade fun-apps to v5.18.0
