### PR TITLE
⬆️(dogwood.3-fun) bump fun-apps to version 5.19.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,9 @@ jobs:
   #
   # Note that the job name should match the EDX_RELEASE value
 
-  # No changes detected for dogwood.3-fun
+  # Run jobs for the dogwood.3-fun release
+  dogwood.3-fun:
+    <<: [*defaults, *build_steps]
   # No changes detected for eucalyptus.3-wb
   # No changes detected for hawthorn.1-oee
   # No changes detected for ironwood.2-oee
@@ -236,7 +238,13 @@ workflows:
 
       # Build jobs
 
-      # No changes detected so no job to run for dogwood.3-fun
+      # Run jobs for the dogwood.3-fun release
+      - dogwood.3-fun:
+          requires:
+            - check-configuration
+          filters:
+            tags:
+              ignore: /.*/
       # No changes detected so no job to run for eucalyptus.3-wb
       # No changes detected so no job to run for hawthorn.1-oee
       # No changes detected so no job to run for ironwood.2-oee

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ version: 2
 # Templates
 defaults: &defaults
   machine:
-    image: ubuntu-2004:202111-02
+    image: default
   resource_class: large
   working_directory: ~/fun
 

--- a/.circleci/src/config.tpl
+++ b/.circleci/src/config.tpl
@@ -5,7 +5,7 @@ version: 2
 # Templates
 defaults: &defaults
   machine:
-    image: ubuntu-2004:202111-02
+    image: default
   resource_class: large
   working_directory: ~/fun
 

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-2.14.0] - 2024-04-17
+
 ## Changed
 
 - Upgrade fun-apps to v5.19.0
@@ -555,7 +557,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.13.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.14.0...HEAD
+[dogwood.3-fun-2.14.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.13.0...dogwood.3-fun-2.14.0
 [dogwood.3-fun-2.13.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.12.0...dogwood.3-fun-2.13.0
 [dogwood.3-fun-2.12.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.11.0...dogwood.3-fun-2.12.0
 [dogwood.3-fun-2.11.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.10.0...dogwood.3-fun-2.11.0

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+## Changed
+
+- Upgrade fun-apps to v5.19.0
+
 ## [dogwood.3-fun-2.13.0] - 2024-04-04
 
 ## Changed

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -4,7 +4,7 @@
 # ==== core ====
 edx-gea==0.2.0
 fonzie==0.7.0
-fun-apps==5.18.0
+fun-apps==5.19.0
 
 # ==== xblocks ====
 configurable_lti_consumer-xblock==1.4.1


### PR DESCRIPTION
Purpose

Bump fun-apps to version 5.19.0
then release minor version of Dogwood.3-fun


