### PR TITLE
⬆️(dogwood.3-fun) bump fun-apps to version 5.20.0

### DIFF
--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-2.15.0] - 2024-05-13
+
 ## Changed
 
 - Upgrade fun-apps to v5.20.0
@@ -561,7 +563,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.14.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.15.0...HEAD
+[dogwood.3-fun-2.15.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.14.0...dogwood.3-fun-2.15.0
 [dogwood.3-fun-2.14.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.13.0...dogwood.3-fun-2.14.0
 [dogwood.3-fun-2.13.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.12.0...dogwood.3-fun-2.13.0
 [dogwood.3-fun-2.12.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.11.0...dogwood.3-fun-2.12.0

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+## Changed
+
+- Upgrade fun-apps to v5.20.0
+
 ## [dogwood.3-fun-2.14.0] - 2024-04-17
 
 ## Changed

--- a/releases/dogwood/3/fun/Dockerfile
+++ b/releases/dogwood/3/fun/Dockerfile
@@ -179,6 +179,7 @@ RUN pip install -r requirements/edx/pre.txt
 # Splinter is a sub-dependency. The version match pattern is >=0.5.0
 # but the version 0.17.0 dropped the support for Python 2.7 we install manually the
 # latest compatible version to prevent the installation of 0.17.0.
+COPY pip.conf /etc/pip.conf
 RUN pip install \
     pip==9.0.3 \
     urllib3==1 \

--- a/releases/dogwood/3/fun/pip.conf
+++ b/releases/dogwood/3/fun/pip.conf
@@ -1,0 +1,4 @@
+[global]
+trusted-host = pypi.python.org
+               pypi.org
+               files.pythonhosted.org

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -4,7 +4,7 @@
 # ==== core ====
 edx-gea==0.2.0
 fonzie==0.7.0
-fun-apps==5.19.0
+fun-apps==5.20.0
 
 # ==== xblocks ====
 configurable_lti_consumer-xblock==1.4.1


### PR DESCRIPTION
## Purpose

Bump fun-apps to version 5.20.0
then release minor version of Dogwood.3-fun

