### PR TITLE
⬆️(dogwood.3-fun) bump fun-apps to version 5.21.0

### DIFF
--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-2.16.0] - 2025-01-13
+
 ## Changed
 
 - Upgrade fun-apps to v5.21.0
@@ -567,7 +569,8 @@ release.
 
 - First experimental release of OpenEdx `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.15.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.16.0...HEAD
+[dogwood.3-fun-2.16.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.15.0...dogwood.3-fun-2.16.0
 [dogwood.3-fun-2.15.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.14.0...dogwood.3-fun-2.15.0
 [dogwood.3-fun-2.14.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.13.0...dogwood.3-fun-2.14.0
 [dogwood.3-fun-2.13.0]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-2.12.0...dogwood.3-fun-2.13.0

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+## Changed
+
+- Upgrade fun-apps to v5.21.0
+
 ## [dogwood.3-fun-2.15.0] - 2024-05-13
 
 ## Changed

--- a/releases/dogwood/3/fun/requirements.txt
+++ b/releases/dogwood/3/fun/requirements.txt
@@ -4,7 +4,7 @@
 # ==== core ====
 edx-gea==0.2.0
 fonzie==0.7.0
-fun-apps==5.20.0
+fun-apps==5.21.0
 
 # ==== xblocks ====
 configurable_lti_consumer-xblock==1.4.1


### PR DESCRIPTION
## Purpose

Bump fun-apps to version 5.21.0 then release minor version of Dogwood.3-fun
